### PR TITLE
docs: add CI monitoring documentation for automatic post-push workflow (#36)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -383,6 +383,43 @@ See `docs/guides/CONTRIBUTING.md` for complete pre-commit workflow.
 
 ---
 
+## After Every Push
+
+**CI Monitoring is Automatic:**
+
+When you run `git push`, the PostToolUse(Bash) hook automatically:
+1. Detects the push command
+2. Waits 5 seconds for CI to start
+3. Fetches the latest GitHub Actions run ID
+4. Watches the run until completion (`gh run watch`)
+5. **Blocks Claude if CI fails** - You must fix failures before continuing
+6. Reports success if CI passes
+
+**You don't need to manually monitor CI** - the hook handles it automatically (#42).
+
+**If CI fails:**
+- Hook shows the run URL and blocks further actions
+- Fetch detailed logs: `gh run view <run-id> --log-failed`
+- Fix the failure
+- Push the fix (hook monitors again)
+- Continue when CI passes
+
+**Manual monitoring (if needed):**
+```bash
+# Get latest run
+gh run list --limit 1
+
+# Watch specific run
+gh run watch <run-id>
+
+# View failure logs
+gh run view <run-id> --log-failed
+```
+
+**Note:** This automated monitoring prevents the mistake in #36 (pushing and not monitoring CI).
+
+---
+
 ## Before Closing Issues
 
 **CRITICAL: Check acceptance criteria before claiming an issue is "done".**

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -671,6 +671,89 @@ fix: update DESTRUCTIVE_OPERATIONS set for new function names
 
 ---
 
+## Continuous Integration (CI Monitoring)
+
+### Automatic CI Monitoring
+
+**When you push code, CI monitoring is automatic** (#36, #42):
+
+1. **Post-bash hook activates** - Detects `git push` commands
+2. **Waits for GitHub Actions** - Gives CI ~5 seconds to start
+3. **Monitors run until completion** - Uses `gh run watch`
+4. **Blocks if CI fails** - You must fix before continuing
+5. **Reports success** - Confirms all checks passed
+
+**You don't need to manually monitor CI** - the Claude Code hook handles it automatically.
+
+### If CI Fails
+
+When the hook detects a CI failure:
+
+```
+❌ GitHub Actions CI failed after your push
+View failure details: https://github.com/.../actions/runs/...
+
+Fetch logs with: gh run view <run-id> --log-failed
+
+You must fix CI failures before continuing.
+```
+
+**Next steps:**
+1. Review the failure URL or fetch logs: `gh run view <run-id> --log-failed`
+2. Fix the issue locally
+3. Commit and push the fix
+4. Hook monitors again automatically
+5. Continue when CI passes
+
+### Manual CI Monitoring (if needed)
+
+If you need to manually check CI status:
+
+```bash
+# View recent runs
+gh run list --limit 5
+
+# Watch specific run
+gh run watch <run-id>
+
+# View failure details
+gh run view <run-id> --log-failed
+
+# View full logs
+gh run view <run-id> --log
+```
+
+### CI Checks
+
+GitHub Actions runs on every push and PR:
+- Unit tests (~2 min, ~333 tests)
+- Integration tests (~10-15 min, ~92 tests)
+- E2E tests (MCP stack)
+- Code quality checks
+- Complexity analysis
+
+**All checks must pass before merging to main.**
+
+### Troubleshooting
+
+**"No GitHub Actions run found":**
+- CI may not have triggered yet (wait a few seconds)
+- Check manually: `https://github.com/<repo>/actions`
+- Verify `.github/workflows/` files are present
+
+**"gh CLI not found":**
+- Install: `brew install gh`
+- Authenticate: `gh auth login`
+
+**Hook not running:**
+- Verify hook is installed: `ls -la .claude/settings.json`
+- Check hook script exists: `scripts/hooks/post_bash.sh`
+- Restart Claude Code session (hooks load at startup)
+
+**See:** `.claude/CLAUDE.md` "Claude Code Hooks" and "After Every Push" sections for details.
+
+---
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the automatic CI monitoring feature implemented in #42. This completes the documentation requirements from issue #36 (No proactive GitHub Actions monitoring after git push).

## Changes

### CLAUDE.md
- Added "After Every Push" section
- Documents automatic CI monitoring via PostToolUse(Bash) hook
- Explains what happens when `git push` is executed
- Lists manual monitoring commands for reference
- Notes that this prevents the mistake in #36

### CONTRIBUTING.md
- Added "Continuous Integration (CI Monitoring)" section
- Comprehensive guide to automatic CI monitoring
- Step-by-step workflow when CI fails
- Manual monitoring commands (if needed)
- CI checks overview
- Troubleshooting section

## Acceptance Criteria

From issue #36 prevention measures:

- ✅ Add "After Every Push" section to CLAUDE.md
- ✅ Add CI monitoring example to CONTRIBUTING.md
- ✅ Test pattern: Next push should automatically monitor (post-bash hook from #42 already implements this)
- ⏳ Monitor for 30 days to ensure habit is formed (hook has been active since #42, ongoing)

## Key Points

### Automatic Monitoring (Post-Bash Hook)
The post-bash hook (#42) automatically:
1. Detects `git push` commands
2. Waits for GitHub Actions to start
3. Watches run until completion
4. **Blocks Claude if CI fails**
5. Reports success if CI passes

### No Manual Action Required
Users don't need to remember to monitor CI - the hook does it automatically. This addresses the root cause of #36 (forgetting to monitor).

### Documentation Completes Prevention
- Immediate fix (hook #42): ✅ Implemented
- Documentation (#36): ✅ This PR

## Testing

Post-bash hook monitoring tested in #42. This PR adds documentation only.

## Related Issues

- Closes #36
- Related: #42 (post-bash hook implementation)
- Related: #72 (merged with failing tests - also addressed by CI monitoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>