### PR TITLE
feat: add interactive quality check prompt for minor/major releases (#108)

### DIFF
--- a/scripts/git-hooks/pre-tag
+++ b/scripts/git-hooks/pre-tag
@@ -12,6 +12,25 @@ fi
 
 echo "🔍 Checking release hygiene for tag: $TAG_NAME"
 
+# Extract version numbers to determine release type
+if [[ "$TAG_NAME" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+    MAJOR="${BASH_REMATCH[1]}"
+    MINOR="${BASH_REMATCH[2]}"
+    PATCH="${BASH_REMATCH[3]}"
+
+    # Determine release type (patch/minor/major)
+    if [ "$PATCH" != "0" ]; then
+        RELEASE_TYPE="patch"
+    elif [ "$MINOR" != "0" ]; then
+        RELEASE_TYPE="minor"
+    else
+        RELEASE_TYPE="major"
+    fi
+else
+    # Couldn't parse version, default to patch
+    RELEASE_TYPE="patch"
+fi
+
 # Get current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
@@ -29,6 +48,47 @@ if [[ "$TAG_NAME" =~ -rc[0-9]+$ ]]; then
         echo "  git checkout -b release/${TAG_NAME%-rc*}"
         echo "  git tag $TAG_NAME"
         exit 1
+    fi
+
+    # ============================================
+    # For minor/major releases: Prompt for interactive quality checks
+    # ============================================
+    if [ "$RELEASE_TYPE" = "minor" ] || [ "$RELEASE_TYPE" = "major" ]; then
+        echo ""
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo "🔍 ${RELEASE_TYPE^} Release Detected: $TAG_NAME"
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        echo ""
+        echo "${RELEASE_TYPE^} releases require interactive quality checks."
+        echo ""
+        echo "Required before tagging:"
+        echo "  ✓ /doc-quality - Documentation quality assessment"
+        echo "  ✓ /code-quality - Code quality review"
+        echo "  ✓ /test-coverage - Test coverage analysis"
+        echo "  ✓ /directory-check - Directory organization check"
+        echo ""
+        echo "Have you run all four interactive quality checks? (y/n)"
+        read -r QUALITY_CHECKS_DONE
+
+        if [ "$QUALITY_CHECKS_DONE" != "y" ] && [ "$QUALITY_CHECKS_DONE" != "Y" ]; then
+            echo ""
+            echo "❌ Interactive quality checks required before ${RELEASE_TYPE} release."
+            echo ""
+            echo "Run these commands in Claude Code:"
+            echo "  /doc-quality"
+            echo "  /code-quality"
+            echo "  /test-coverage"
+            echo "  /directory-check"
+            echo ""
+            echo "Review the results, address critical issues, then retry:"
+            echo "  git tag $TAG_NAME"
+            echo ""
+            exit 1
+        fi
+
+        echo ""
+        echo "✅ Interactive quality checks confirmed"
+        echo ""
     fi
 else
     echo "🚀 Final release tag detected - verifying RC passed..."

--- a/tests/test_pre_tag_version_detection.sh
+++ b/tests/test_pre_tag_version_detection.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Test script for pre-tag hook version detection
+# Tests the version type detection logic without running full hook
+
+set -e
+
+echo "Testing version detection logic..."
+echo ""
+
+# Test function that mimics the hook's version detection
+test_version_detection() {
+    local TAG_NAME="$1"
+    local EXPECTED_TYPE="$2"
+
+    if [[ "$TAG_NAME" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        MAJOR="${BASH_REMATCH[1]}"
+        MINOR="${BASH_REMATCH[2]}"
+        PATCH="${BASH_REMATCH[3]}"
+
+        if [ "$PATCH" != "0" ]; then
+            RELEASE_TYPE="patch"
+        elif [ "$MINOR" != "0" ]; then
+            RELEASE_TYPE="minor"
+        else
+            RELEASE_TYPE="major"
+        fi
+    else
+        RELEASE_TYPE="patch"
+    fi
+
+    if [ "$RELEASE_TYPE" = "$EXPECTED_TYPE" ]; then
+        echo "✅ $TAG_NAME → $RELEASE_TYPE (expected: $EXPECTED_TYPE)"
+    else
+        echo "❌ $TAG_NAME → $RELEASE_TYPE (expected: $EXPECTED_TYPE)"
+        exit 1
+    fi
+}
+
+# Test cases
+echo "Testing patch releases (v0.6.x):"
+test_version_detection "v0.6.1" "patch"
+test_version_detection "v0.6.7" "patch"
+test_version_detection "v0.6.99" "patch"
+test_version_detection "v0.6.1-rc1" "patch"
+test_version_detection "v0.6.7-rc2" "patch"
+
+echo ""
+echo "Testing minor releases (v0.x.0):"
+test_version_detection "v0.7.0" "minor"
+test_version_detection "v0.8.0" "minor"
+test_version_detection "v0.99.0" "minor"
+test_version_detection "v0.7.0-rc1" "minor"
+test_version_detection "v0.8.0-rc2" "minor"
+
+echo ""
+echo "Testing major releases (vX.0.0):"
+test_version_detection "v1.0.0" "major"
+test_version_detection "v2.0.0" "major"
+test_version_detection "v1.0.0-rc1" "major"
+test_version_detection "v2.0.0-rc2" "major"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ All version detection tests passed!"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

Implements issue #108 - Pre-tag hook now detects release type and prompts for interactive quality check confirmation on minor/major releases.

## Changes

### Version Type Detection

Added logic to detect patch vs minor vs major releases:
- **Patch (v0.6.x):** PATCH != 0 → No prompt, automated checks only
- **Minor (v0.x.0):** MINOR != 0, PATCH = 0 → Interactive check prompt
- **Major (vX.0.0):** MINOR = 0, PATCH = 0 → Interactive check prompt

### Interactive Quality Check Prompt

For minor/major RC tags, hook now prompts:
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🔍 Minor Release Detected: v0.7.0-rc1
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Minor releases require interactive quality checks.

Required before tagging:
  ✓ /doc-quality - Documentation quality assessment
  ✓ /code-quality - Code quality review
  ✓ /test-coverage - Test coverage analysis
  ✓ /directory-check - Directory organization check

Have you run all four interactive quality checks? (y/n)
```

**If 'n':** Exits with clear instructions
**If 'y':** Continues with automated hygiene checks

### Test Coverage

Created `tests/test_pre_tag_version_detection.sh` with 14 test cases:
- ✅ Patch releases: v0.6.1, v0.6.7, v0.6.99, v0.6.1-rc1, v0.6.7-rc2
- ✅ Minor releases: v0.7.0, v0.8.0, v0.99.0, v0.7.0-rc1, v0.8.0-rc2
- ✅ Major releases: v1.0.0, v2.0.0, v1.0.0-rc1, v2.0.0-rc2

All tests pass.

## Behavior Examples

### Patch Release (v0.6.7-rc1)
```bash
git tag v0.6.7-rc1
# → No interactive prompt
# → Runs automated checks directly
```

### Minor Release (v0.7.0-rc1)
```bash
git tag v0.7.0-rc1
# → Prompts for quality check confirmation
# → Must answer 'y' to proceed
# → Then runs automated checks
```

### Major Release (v1.0.0-rc1)
```bash
git tag v1.0.0-rc1
# → Prompts for quality check confirmation
# → Must answer 'y' to proceed
# → Then runs automated checks
```

## Test Plan

- [x] Added version detection logic to pre-tag hook
- [x] Added interactive prompt for minor/major releases
- [x] Prompt only triggers for RC tags (not final tags)
- [x] Patch releases skip prompt (existing behavior preserved)
- [x] Created test script with 14 test cases
- [x] All tests pass
- [x] Bash syntax validated (`bash -n`)

## Related Issues

Closes #108

Part of v0.6.6 milestone - completing release process enforcement.

## Related Documentation

- [docs/reference/RELEASE_PROCESS.md](https://github.com/s-morgan-jeffries/omnifocus-mcp/blob/main/docs/reference/RELEASE_PROCESS.md) - Complete release process
- [docs/guides/CONTRIBUTING.md](https://github.com/s-morgan-jeffries/omnifocus-mcp/blob/main/docs/guides/CONTRIBUTING.md) - Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)