### PR TITLE
docs: add one-branch-per-issue workflow documentation (#87)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -362,28 +362,59 @@ See `docs/guides/CONTRIBUTING.md` for complete workflow including:
 
 ## Before Starting Work
 
-**Create a feature branch for any non-trivial work:**
+### One-Branch-Per-Issue Workflow
+
+**ALWAYS create a dedicated branch for each GitHub issue:**
 
 ```bash
-git checkout -b feature/description  # For new features
-git checkout -b fix/description      # For bug fixes
-git checkout -b docs/description     # For documentation
+# Branch naming convention: {type}/issue-{num}-{brief-description}
+git checkout -b feature/issue-87-one-branch-workflow  # For features/enhancements
+git checkout -b fix/issue-92-applescript-timeout      # For bug fixes
+git checkout -b docs/issue-93-update-roadmap          # For documentation
+
+# Examples of good branch names:
+git checkout -b feature/issue-77-ui-navigation-tools
+git checkout -b fix/issue-78-empty-folder-handling
+git checkout -b docs/issue-86-doc-quality-command
 ```
 
-**Only work directly on main for:**
-- Hotfixes that need immediate deployment
-- Trivial documentation typos (single-line README fixes, etc.)
-- Emergency rollbacks
+**Branch naming rules:**
+- **Type prefix:** `feature/`, `fix/`, or `docs/`
+- **Issue number:** Always include `issue-{num}` (enables tracking)
+- **Description:** Brief kebab-case description (3-5 words max)
+- **Examples:**
+  - ✅ `feature/issue-77-ui-navigation-tools`
+  - ✅ `fix/issue-78-folder-empty-check`
+  - ✅ `docs/issue-86-slash-command`
+  - ❌ `feature/add-navigation` (missing issue number)
+  - ❌ `issue-77` (missing type and description)
+  - ❌ `feature/issue-77-add-comprehensive-ui-navigation-tools-with-focus-and-tabs` (too long)
 
-**Why:** Feature branches allow you to:
-- Test changes in isolation before merging
-- Get feedback via PR before affecting main
-- Easily roll back if something goes wrong
-- Keep main branch stable and deployable
+**Branch lifecycle:**
+1. **Create** - One branch per issue, created from latest main
+2. **Work** - All commits for that issue go on that branch
+3. **Push** - Push branch to remote for backup and PR creation
+4. **PR** - Create pull request for code review
+5. **Merge** - Merge to main after approval and CI passes
+6. **Delete** - Delete branch after merge (GitHub does this automatically)
+
+**Only work directly on main for:**
+- **Hotfixes** that need immediate deployment (label with "hotfix" in commit message)
+- **Trivial typos** in README (single-line fixes, no functional changes)
+- **Emergency rollbacks** (reverting broken commits)
+
+**Why one-branch-per-issue?**
+- **Isolation** - Test changes independently before merging
+- **Tracking** - Easy to see which commits address which issue
+- **Review** - PR-based workflow enables code review
+- **Rollback** - Easy to revert if something goes wrong
+- **Stability** - Keep main branch always deployable
 
 **See:** Issue #37 (ai-process) for why this matters
 
-**Automated enforcement:** Claude Code hooks automatically prevent commits to main branch (see below).
+**Automated enforcement:**
+- Claude Code hooks prevent commits to main/master (see Claude Code Hooks section)
+- Git pre-commit hook provides backup enforcement during manual operations (#94)
 
 ---
 

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -33,14 +33,31 @@ This project uses GitHub Issues for tracking bugs, features, documentation gaps,
 
 ### Before Starting Work
 
-**Create a feature branch:**
+**Create a dedicated branch for each GitHub issue (one-branch-per-issue workflow):**
+
 ```bash
-git checkout -b feature/description  # New features
-git checkout -b fix/description      # Bug fixes
-git checkout -b docs/description     # Documentation
+# Branch naming convention: {type}/issue-{num}-{brief-description}
+git checkout -b feature/issue-87-one-branch-workflow  # Features/enhancements
+git checkout -b fix/issue-92-applescript-timeout      # Bug fixes
+git checkout -b docs/issue-93-update-roadmap          # Documentation
+
+# Good branch name examples:
+git checkout -b feature/issue-77-ui-navigation-tools
+git checkout -b fix/issue-78-empty-folder-handling
+git checkout -b docs/issue-86-doc-quality-command
 ```
 
+**Branch naming rules:**
+- **Type prefix:** `feature/`, `fix/`, or `docs/`
+- **Issue number:** Always include `issue-{num}` (required for tracking)
+- **Description:** Brief kebab-case description (3-5 words max)
+- **Good:** `feature/issue-77-ui-navigation-tools`
+- **Bad:** `feature/add-navigation` (missing issue number)
+- **Bad:** `issue-77` (missing type and description)
+
 **Only work on main for:** Hotfixes, trivial typo fixes, emergency rollbacks
+
+**Automated enforcement:** Claude Code hooks and git pre-commit hook prevent commits to main
 
 ### Picking Issues to Work On
 


### PR DESCRIPTION
## Summary

Documented the one-branch-per-issue workflow with clear branch naming conventions and lifecycle management.

## Changes

- **Updated `.claude/CLAUDE.md`** "Before Starting Work" section:
  - Branch naming convention: `{type}/issue-{num}-{brief-description}`
  - Examples of good and bad branch names
  - Complete branch lifecycle (create, work, PR, merge, delete)
  - Rationale for one-branch-per-issue approach
  
- **Updated `docs/guides/CONTRIBUTING.md`**:
  - Consistent branch naming rules across both docs
  - Referenced automated enforcement via hooks

## Branch Naming Rules

- **Type prefix:** `feature/`, `fix/`, or `docs/`
- **Issue number:** Always include `issue-{num}` (enables tracking)
- **Description:** Brief kebab-case description (3-5 words max)

**Good examples:**
- `feature/issue-77-ui-navigation-tools`
- `fix/issue-78-empty-folder-handling`
- `docs/issue-86-doc-quality-command`

**Bad examples:**
- `feature/add-navigation` (missing issue number)
- `issue-77` (missing type and description)

## Acceptance Criteria

- [x] Document branch naming convention in `.claude/CLAUDE.md`
- [x] Document branch naming convention in `docs/guides/CONTRIBUTING.md`
- [x] Include branch lifecycle (create, work, PR, merge, delete)
- [x] Include good and bad examples
- [x] Reference automated enforcement

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)