### PR TITLE
feat: integrate check_documentation.sh into pre-tag hygiene checks (#124)

### DIFF
--- a/docs/reference/HYGIENE_CHECK_CRITERIA.md
+++ b/docs/reference/HYGIENE_CHECK_CRITERIA.md
@@ -173,6 +173,44 @@ This document defines the **automated check criteria** only. Interactive checks 
 
 ---
 
+### 8. Documentation Completeness
+
+**Script:** `scripts/check_documentation.sh`
+
+**Pass Criteria:**
+- ✅ `CHANGELOG.md` contains `## [X.Y.Z]` entry for this version
+- ✅ `.claude/CLAUDE.md` has "Current Version: vX.Y.Z" updated
+- ✅ `README.md` references version (warning only)
+- ✅ If CHANGELOG mentions "breaking", migration guide exists: `docs/migration/vX.Y.Z.md`
+- ✅ All key documentation files exist:
+  - `docs/guides/TESTING.md`
+  - `docs/guides/CONTRIBUTING.md`
+  - `docs/guides/INTEGRATION_TESTING.md`
+  - `docs/reference/ARCHITECTURE.md`
+  - `docs/reference/CODE_QUALITY.md`
+  - `docs/reference/APPLESCRIPT_GOTCHAS.md`
+  - `docs/project/ROADMAP.md`
+
+**Fail Criteria:**
+- ❌ CHANGELOG missing entry for this version
+- ❌ CLAUDE.md version not updated
+- ❌ Breaking changes in CHANGELOG but no migration guide
+- ❌ Any key documentation file missing
+
+**Exit Codes:**
+- `0` - All documentation checks passed
+- `1` - One or more checks failed
+
+**Status:** ✅ Implemented (integrated in v0.6.7, issue #124).
+
+**Why this matters:**
+- Prevents shipping breaking changes without migration guides
+- Ensures documentation stays synchronized with code
+- Catches accidentally deleted key docs before release
+- Maintains professional changelog discipline
+
+---
+
 ### 6. Test Coverage
 
 **Script:** `scripts/check_test_coverage.sh`
@@ -290,6 +328,7 @@ These checks are available via manual script execution for code quality insights
 | 5. Milestone Status | Automated | ✅ Working | 0=pass, 1=fail | Yes |
 | 6. Test Coverage | Automated | ✅ Working | 0=pass, 1=fail | Yes |
 | 7. ROADMAP.md Sync | Automated | ✅ Working | 0=pass, 1=fail | Yes |
+| 8. Documentation Completeness | Automated | ✅ Working | 0=pass, 1=fail | Yes |
 | Doc Quality | Interactive | ⏳ To implement | N/A | No |
 | Code Quality | Interactive | ✅ Available | N/A | No |
 | Directory Org | Interactive | ✅ Available | N/A | No |
@@ -299,6 +338,10 @@ These checks are available via manual script execution for code quality insights
 - Code Quality and Directory Organization removed from automated checks (available for manual runs)
 - ROADMAP.md Sync added as new automated check (#34)
 - Test Count Sync merged into Test Coverage check
+
+**Changes in v0.6.7:**
+- Documentation Completeness added as new automated check (#124)
+- Verifies CHANGELOG entries, version references, migration guides, key docs existence
 
 ---
 

--- a/scripts/git-hooks/pre-tag
+++ b/scripts/git-hooks/pre-tag
@@ -251,6 +251,18 @@ if [ "$IS_RC" = true ]; then
     fi
     echo "" >> "$RESULTS_FILE"
 
+    # Check 8: Documentation completeness
+    echo "8. Checking documentation completeness..." | tee -a "$RESULTS_FILE"
+    DOC_OUTPUT=$(./scripts/check_documentation.sh "$VERSION" 2>&1)
+    if [ $? -eq 0 ]; then
+        echo "   ✅ Documentation check passed" | tee -a "$RESULTS_FILE"
+    else
+        echo "   ❌ Documentation check failed" | tee -a "$RESULTS_FILE"
+        echo "$DOC_OUTPUT" >> "$RESULTS_FILE"
+        ((FAILED_CHECKS++))
+    fi
+    echo "" >> "$RESULTS_FILE"
+
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
 


### PR DESCRIPTION
## Summary

Adds documentation completeness verification as check #8 in the pre-tag hygiene workflow, preventing release of incomplete or inconsistent documentation.

**Changes:**

1. **Add documentation check to scripts/git-hooks/pre-tag**
   - Runs after ROADMAP.md sync check (check #7)
   - Verifies CHANGELOG entry exists for version
   - Verifies .claude/CLAUDE.md version updated
   - Checks for migration guide if breaking changes present
   - Validates all key documentation files exist
   - Failures block tag creation (counted as critical)

2. **Document check in HYGIENE_CHECK_CRITERIA.md**
   - Add check #8 section with pass/fail criteria
   - Update summary table (7 → 8 automated checks)
   - Add v0.6.7 changes section

**What this prevents:**
- Shipping breaking changes without migration guides
- Forgetting to update CHANGELOG.md (unprofessional)
- Version inconsistencies across documentation
- Accidentally deleting key docs before release

**Testing:**
- ✅ Manual test: `./scripts/check_documentation.sh v0.6.6` (passes)
- ✅ Script integration tested
- Smoke tests will be added when #92 merges

**Context:**

`check_documentation.sh` was discovered orphaned (0 references) during #118 directory cleanup. The script exists and provides useful checks but was never integrated into automation. This integration completes the documentation hygiene suite.

**Pre-tag check count:** 7 → 8 automated checks

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)