### PR TITLE
feat: add set_focus() tool for UI navigation (#77)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -60,6 +60,9 @@
 - ✅ `get_perspectives` - List custom perspectives
 - ✅ `switch_perspective` - Change active perspective
 
+**UI Navigation (1 tool):**
+- ✅ `set_focus` - Focus OmniFocus window on project or folder
+
 ### Test Coverage
 
 **333 passing tests** with 89% overall code coverage. See [../guides/TESTING.md](../guides/TESTING.md) for detailed breakdown.
@@ -372,7 +375,6 @@ Major consolidation to optimize for MCP tool calling efficiency.
 
 **Current open issues (as of November 2025):**
 - **Bug:** #78 - get_tasks() and get_projects() full_notes parameter not working (high priority)
-- **Enhancement:** #77 - Add UI navigation tools (set focus, manage tabs)
 - **Enhancement:** #50 - Performance optimization for slow operations (~10s for overdue tasks)
 - **Enhancement:** #51 - Refactor high-complexity functions (technical debt)
 - **Workflow:** #93 - Phase 7 comprehensive documentation updates (in progress)
@@ -406,16 +408,14 @@ These items need design discussion before implementation:
 
 **Decision needed before implementation.**
 
-**🤔 UI Navigation**
-- `show_project(project_id)` - Focus OmniFocus window on specific project
-- `show_task(task_id)` - Focus OmniFocus window on specific task
+**🤔 UI Navigation - Partially Implemented**
+- ✅ `set_focus(item_id, item_type="project"|"folder")` - Focus window on project or folder (IMPLEMENTED in v0.7.0)
+  - **AppleScript Limitation:** Tasks and tags cannot be focused (OmniFocus restriction)
+  - Only supports `item_type="project"` or `item_type="folder"`
+  - Raises clear error for unsupported types with explanation
+- ❌ Tab management - Not available via AppleScript (API doesn't expose tabs property)
 
-**Question:** Does UI navigation belong in an MCP server?
-- Precedent: `switch_perspective()` exists (UI control)
-- AppleScript verified: `set focus of front document window to item` works
-- Use case: "Jump to this item" after querying/searching
-
-**Decision needed before implementation.**
+**Resolution:** UI navigation is appropriate for MCP server (precedent: `switch_perspective()`). Implemented within AppleScript limitations. Future: May add task/tag navigation if OmniFocus exposes it.
 
 ### Future Research - Technical Blockers
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,7 +1,7 @@
 # OmniFocus MCP Server - API Reference
 
 **Current Version:** v0.6.6 (Release Process Infrastructure & Quality Checks)
-**Total MCP Tools:** 16 (reduced from 40+)
+**Total MCP Tools:** 17 (reduced from 40+)
 
 This document shows the complete API surface that Claude Desktop sees when connecting to the OmniFocus MCP server. Each tool is exposed via the Model Context Protocol and can be invoked by Claude.
 
@@ -22,21 +22,22 @@ This document shows the complete API surface that Claude Desktop sees when conne
 
 ## Table of Contents
 
-**Current API (v0.6.0 - 16 Core Functions):**
+**Current API (v0.7.0 - 17 Core Functions):**
 - [Projects](#projects) (5 functions) - `create`, `get`, `update`, `update_batch`, `delete`
 - [Tasks](#tasks) (6 functions) - `create`, `get`, `update`, `update_batch`, `delete`, `reorder`
 - [Folders](#folders) (2 functions) - `create`, `get`
 - [Tags](#tags) (1 function) - `get`
 - [Perspectives](#perspectives) (2 functions) - `get`, `switch`
+- [UI Navigation](#ui-navigation) (1 function) - `set_focus`
 
 **Deprecated Functions (Removed in v0.6.0):**
 - [Deprecated Functions](#deprecated-functions-removed-in-v060) - 26 functions consolidated into core API
 
 ---
 
-## Implementation Status (v0.6.0)
+## Implementation Status (v0.7.0)
 
-### ✅ Implemented Functions (16 Core Functions)
+### ✅ Implemented Functions (17 Core Functions)
 
 All "Enhanced proposed signature" sections in this document have been **FULLY IMPLEMENTED** as of v0.6.0.
 
@@ -65,6 +66,9 @@ All "Enhanced proposed signature" sections in this document have been **FULLY IM
 **Perspectives (2):**
 - ✅ `get_perspectives()` - Returns available perspectives
 - ✅ `switch_perspective()` - UI control function
+
+**UI Navigation (1):**
+- ✅ `set_focus()` - Focus OmniFocus window on project or folder
 
 ### ❌ Removed Functions (26 Deprecated)
 
@@ -929,6 +933,46 @@ Perspectives are custom views that filter and organize your tasks and projects.
 **Returns:** Success message confirming perspective switch
 
 **PROPOSED: KEEP** - This is UI control functionality that can't be achieved through data operations. Switching perspectives is a distinct action that changes the application view state.
+
+---
+
+## UI Navigation
+
+### `set_focus()`
+
+**Description:** Set focus on a specific item in the OmniFocus window.
+
+OmniFocus only supports setting focus on projects and folders via AppleScript. Attempting to focus on tasks or tags will raise a clear error message.
+
+**Parameters:**
+- `item_id: str` - The ID of the project or folder to focus on
+- `item_type: str` - Must be either "project" or "folder"
+
+**Returns:** Success message with item details
+
+**Limitations:**
+- ❌ Cannot focus on tasks (AppleScript limitation)
+- ❌ Cannot focus on tags (AppleScript limitation)
+- ✅ Only projects and folders are supported
+
+**Error Handling:**
+- Attempting to focus on task or tag will raise `ValueError` with explanation
+- Invalid `item_type` raises `ValueError` with valid options
+- Nonexistent item ID raises `Exception` with error details
+
+**Example:**
+```python
+# Focus on a project
+set_focus(item_id="abc123", item_type="project")
+
+# Focus on a folder
+set_focus(item_id="def456", item_type="folder")
+
+# This will raise an error (not supported)
+set_focus(item_id="task789", item_type="task")  # ValueError: OmniFocus only supports setting focus on projects and folders
+```
+
+**Use Case:** After querying for items, you can focus the OmniFocus window on a specific project or folder to allow the user to see it in context.
 
 ---
 

--- a/scripts/research_focus_commands.sh
+++ b/scripts/research_focus_commands.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# Research script to test OmniFocus focus commands
+# This script tests various AppleScript commands for setting focus on OmniFocus items
+
+echo "=== Testing OmniFocus Focus Commands ==="
+echo ""
+
+# Test 1: Get a sample task ID from the test database
+echo "Test 1: Getting a sample task ID..."
+TASK_ID=$(osascript <<'EOF'
+tell application "OmniFocus"
+    tell default document
+        set testTasks to flattened tasks whose name contains "Test"
+        if (count of testTasks) > 0 then
+            set firstTask to item 1 of testTasks
+            return id of firstTask
+        else
+            return "NO_TEST_TASK_FOUND"
+        end if
+    end tell
+end tell
+EOF
+)
+
+if [ "$TASK_ID" = "NO_TEST_TASK_FOUND" ]; then
+    echo "  ❌ No test tasks found. Please run scripts/setup_test_database.sh first."
+    exit 1
+fi
+
+echo "  ✅ Found test task ID: $TASK_ID"
+echo ""
+
+# Test 2: Try to set focus on the task
+echo "Test 2: Testing 'set focus' on task..."
+FOCUS_RESULT=$(osascript <<EOF
+tell application "OmniFocus"
+    tell default document
+        set targetTask to first flattened task whose id is "$TASK_ID"
+        tell front document window
+            set focus to targetTask
+            return "SUCCESS"
+        end tell
+    end tell
+end tell
+EOF
+)
+
+if [ $? -eq 0 ]; then
+    echo "  ✅ Focus command succeeded: $FOCUS_RESULT"
+else
+    echo "  ❌ Focus command failed"
+fi
+echo ""
+
+# Test 3: Get a sample project ID
+echo "Test 3: Getting a sample project ID..."
+PROJECT_ID=$(osascript <<'EOF'
+tell application "OmniFocus"
+    tell default document
+        set testProjects to flattened projects whose name contains "Test"
+        if (count of testProjects) > 0 then
+            set firstProject to item 1 of testProjects
+            return id of firstProject
+        else
+            return "NO_TEST_PROJECT_FOUND"
+        end if
+    end tell
+end tell
+EOF
+)
+
+if [ "$PROJECT_ID" = "NO_TEST_PROJECT_FOUND" ]; then
+    echo "  ⚠️  No test projects found"
+else
+    echo "  ✅ Found test project ID: $PROJECT_ID"
+
+    # Test 4: Try to set focus on the project
+    echo ""
+    echo "Test 4: Testing 'set focus' on project..."
+    FOCUS_PROJECT_RESULT=$(osascript <<EOF
+tell application "OmniFocus"
+    tell default document
+        set targetProject to first flattened project whose id is "$PROJECT_ID"
+        tell front document window
+            set focus to targetProject
+            return "SUCCESS"
+        end tell
+    end tell
+end tell
+EOF
+)
+
+    if [ $? -eq 0 ]; then
+        echo "  ✅ Focus on project succeeded: $FOCUS_PROJECT_RESULT"
+    else
+        echo "  ❌ Focus on project failed"
+    fi
+fi
+echo ""
+
+# Test 5: Check if tabs are supported
+echo "Test 5: Testing tab management support..."
+TAB_TEST=$(osascript <<'EOF' 2>&1
+tell application "OmniFocus"
+    tell default document
+        tell front document window
+            -- Try to access tabs property
+            try
+                set tabCount to count of tabs
+                return "TABS_SUPPORTED: " & tabCount
+            on error errMsg
+                return "TABS_NOT_SUPPORTED: " & errMsg
+            end try
+        end tell
+    end tell
+end tell
+EOF
+)
+
+echo "  Result: $TAB_TEST"
+echo ""
+
+# Test 6: Check if folders support focus
+echo "Test 6: Testing folder focus support..."
+FOLDER_ID=$(osascript <<'EOF'
+tell application "OmniFocus"
+    tell default document
+        if (count of folders) > 0 then
+            return id of item 1 of folders
+        else
+            return "NO_FOLDERS"
+        end if
+    end tell
+end tell
+EOF
+)
+
+if [ "$FOLDER_ID" != "NO_FOLDERS" ]; then
+    echo "  ✅ Found folder ID: $FOLDER_ID"
+    FOLDER_FOCUS=$(osascript <<EOF 2>&1
+tell application "OmniFocus"
+    tell default document
+        set targetFolder to first folder whose id is "$FOLDER_ID"
+        tell front document window
+            try
+                set focus to targetFolder
+                return "SUCCESS"
+            on error errMsg
+                return "FAILED: " & errMsg
+            end try
+        end tell
+    end tell
+end tell
+EOF
+)
+    echo "  Result: $FOLDER_FOCUS"
+else
+    echo "  ⚠️  No folders found to test"
+fi
+echo ""
+
+# Test 7: Check if tags support focus
+echo "Test 7: Testing tag focus support..."
+TAG_ID=$(osascript <<'EOF'
+tell application "OmniFocus"
+    tell default document
+        if (count of flattened tags) > 0 then
+            return id of item 1 of flattened tags
+        else
+            return "NO_TAGS"
+        end if
+    end tell
+end tell
+EOF
+)
+
+if [ "$TAG_ID" != "NO_TAGS" ]; then
+    echo "  ✅ Found tag ID: $TAG_ID"
+    TAG_FOCUS=$(osascript <<EOF 2>&1
+tell application "OmniFocus"
+    tell default document
+        set targetTag to first flattened tag whose id is "$TAG_ID"
+        tell front document window
+            try
+                set focus to targetTag
+                return "SUCCESS"
+            on error errMsg
+                return "FAILED: " & errMsg
+            end try
+        end tell
+    end tell
+end tell
+EOF
+)
+    echo "  Result: $TAG_FOCUS"
+else
+    echo "  ⚠️  No tags found to test"
+fi
+echo ""
+
+echo "=== Research Complete ==="
+echo ""
+echo "Summary:"
+echo "- Task focus: Tested"
+echo "- Project focus: Tested"
+echo "- Folder focus: Tested"
+echo "- Tag focus: Tested"
+echo "- Tab management: Tested"
+echo ""
+echo "Next steps:"
+echo "1. Review test results above"
+echo "2. Implement set_focus() function based on working commands"
+echo "3. Decide on tab management based on AppleScript support"

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3011,3 +3011,64 @@ class OmniFocusConnector:
             return result.strip()
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error switching perspective: {e.stderr}")
+
+    def set_focus(self, item_id: str, item_type: str) -> dict:
+        """Set focus on a specific item in the OmniFocus window.
+
+        OmniFocus only supports setting focus on projects and folders via AppleScript.
+        Attempting to focus on tasks or tags will raise a ValueError.
+
+        Args:
+            item_id: ID of the item to focus on
+            item_type: Type of item - must be "project" or "folder"
+
+        Returns:
+            dict with success status, item_id, and item_type
+
+        Raises:
+            ValueError: If item_type is not "project" or "folder"
+            Exception: If focus operation fails
+        """
+        # Validate item_type
+        valid_types = ["project", "folder"]
+        if item_type not in valid_types:
+            if item_type in ["task", "tag"]:
+                raise ValueError(
+                    f"OmniFocus only supports setting focus on projects and folders. "
+                    f"Cannot set focus on {item_type}s via AppleScript."
+                )
+            else:
+                raise ValueError(
+                    f"item_type must be one of {valid_types}, got: {item_type}"
+                )
+
+        # Escape quotes in item_id
+        item_id_escaped = item_id.replace('"', '\\"')
+
+        # Build AppleScript based on item type
+        if item_type == "project":
+            item_reference = f'first flattened project whose id is "{item_id_escaped}"'
+        else:  # folder
+            item_reference = f'first folder whose id is "{item_id_escaped}"'
+
+        script = f'''
+        tell application "OmniFocus"
+            tell default document
+                set targetItem to {item_reference}
+                tell front document window
+                    set focus to targetItem
+                    return "SUCCESS"
+                end tell
+            end tell
+        end tell
+        '''
+
+        try:
+            run_applescript(script)
+            return {
+                "success": True,
+                "item_id": item_id,
+                "item_type": item_type
+            }
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Error setting focus on {item_type}: {e.stderr}")

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -994,6 +994,33 @@ def switch_perspective(perspective_name: str) -> str:
         return f"Error switching perspective: {str(e)}"
 
 
+@mcp.tool()
+def set_focus(item_id: str, item_type: str) -> str:
+    """Set focus on a specific item in the OmniFocus window.
+
+    OmniFocus only supports setting focus on projects and folders via AppleScript.
+    Tasks and tags cannot be focused directly.
+
+    Args:
+        item_id: ID of the item to focus on
+        item_type: Type of item - must be "project" or "folder"
+
+    Returns:
+        Success message confirming focus change
+
+    Raises:
+        ValueError: If item_type is not "project" or "folder"
+    """
+    client = get_client()
+    try:
+        client.set_focus(item_id=item_id, item_type=item_type)
+        return f"Successfully set focus on {item_type}: {item_id}"
+    except ValueError as e:
+        return f"Invalid item type: {str(e)}"
+    except Exception as e:
+        return f"Error setting focus: {str(e)}"
+
+
 # ============================================================================
 # Server Entry Point
 # ============================================================================

--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -457,3 +457,82 @@ class TestUpdateProjectsE2E:
         assert "success" in result.lower() or "updated" in result.lower()
 
         print(f"\n✓ E2E update_projects single ID: {result}")
+
+
+# ============================================================================
+# E2E Tests for set_focus() (NEW API - v0.7.0)
+# ============================================================================
+
+class TestSetFocusE2E:
+    """E2E tests for set_focus() MCP tool with real OmniFocus.
+
+    Tests the full stack:
+    MCP tool → client.set_focus() → AppleScript → OmniFocus
+    """
+
+    def test_set_focus_on_project_e2e(self):
+        """E2E: Set focus on a project via MCP tool."""
+        from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+        import omnifocus_mcp.server_fastmcp as server
+
+        # Get a test project
+        client = OmniFocusConnector(enable_safety_checks=True)
+        projects = client.get_projects(query="Active Test Project")
+        assert len(projects) > 0, "Need at least one test project"
+
+        project_id = projects[0]['id']
+
+        # Call the MCP tool
+        set_focus = server.set_focus.fn
+        result = set_focus(item_id=project_id, item_type="project")
+
+        # Verify MCP tool returns human-readable response
+        assert isinstance(result, str)
+        assert "success" in result.lower()
+        assert "project" in result.lower()
+        assert project_id in result
+
+        print(f"\n✓ E2E set_focus on project: {result}")
+
+    def test_set_focus_on_folder_e2e(self):
+        """E2E: Set focus on a folder via MCP tool."""
+        from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+        import omnifocus_mcp.server_fastmcp as server
+
+        # Get a test folder
+        client = OmniFocusConnector(enable_safety_checks=True)
+        folders = client.get_folders()
+        assert len(folders) > 0, "Need at least one folder"
+
+        # Find the test root folder
+        test_folder = next((f for f in folders if f['name'] == "Test Root Folder"), None)
+        assert test_folder is not None, "Test Root Folder should exist"
+
+        folder_id = test_folder['id']
+
+        # Call the MCP tool
+        set_focus = server.set_focus.fn
+        result = set_focus(item_id=folder_id, item_type="folder")
+
+        # Verify MCP tool returns human-readable response
+        assert isinstance(result, str)
+        assert "success" in result.lower()
+        assert "folder" in result.lower()
+        assert folder_id in result
+
+        print(f"\n✓ E2E set_focus on folder: {result}")
+
+    def test_set_focus_invalid_type_e2e(self):
+        """E2E: Test error handling for invalid item type via MCP tool."""
+        import omnifocus_mcp.server_fastmcp as server
+
+        # Call the MCP tool with invalid type
+        set_focus = server.set_focus.fn
+        result = set_focus(item_id="any-id", item_type="task")
+
+        # Verify MCP tool returns error message
+        assert isinstance(result, str)
+        assert "invalid" in result.lower() or "error" in result.lower()
+        assert "task" in result.lower()
+
+        print(f"\n✓ E2E set_focus invalid type: {result}")

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -1945,3 +1945,73 @@ class TestAvailabilityFields:
 
         # Cleanup
         client.delete_projects(project_id)
+
+
+class TestUINavigation:
+    """Test UI navigation operations (set_focus)."""
+
+    @pytest.fixture(scope="class")
+    def client(self):
+        """Create a client for real OmniFocus testing."""
+        return OmniFocusConnector(enable_safety_checks=True)
+
+    def test_set_focus_on_project(self, client):
+        """Test setting focus on a project."""
+        # Find a test project
+        projects = client.get_projects(query="Active Test Project")
+        assert len(projects) > 0, "Need at least one test project"
+
+        project = projects[0]
+        project_id = project['id']
+
+        # Set focus on the project
+        result = client.set_focus(item_id=project_id, item_type="project")
+
+        assert result["success"] is True
+        assert result["item_id"] == project_id
+        assert result["item_type"] == "project"
+        print(f"\n✓ Set focus on project: {project['name']}")
+
+    def test_set_focus_on_folder(self, client):
+        """Test setting focus on a folder."""
+        # Get folders
+        folders = client.get_folders()
+        assert len(folders) > 0, "Need at least one folder"
+
+        # Find the test root folder
+        test_folder = next((f for f in folders if f['name'] == "Test Root Folder"), None)
+        assert test_folder is not None, "Test Root Folder should exist"
+
+        folder_id = test_folder['id']
+
+        # Set focus on the folder
+        result = client.set_focus(item_id=folder_id, item_type="folder")
+
+        assert result["success"] is True
+        assert result["item_id"] == folder_id
+        assert result["item_type"] == "folder"
+        print(f"\n✓ Set focus on folder: {test_folder['name']}")
+
+    def test_set_focus_invalid_item_type(self, client):
+        """Test that invalid item types raise errors."""
+        # Get a task
+        tasks = client.get_tasks()
+        assert len(tasks) > 0, "Need at least one task"
+
+        task_id = tasks[0]['id']
+
+        # Try to set focus on task (should fail)
+        with pytest.raises(ValueError) as exc_info:
+            client.set_focus(item_id=task_id, item_type="task")
+
+        assert "OmniFocus only supports setting focus on projects and folders" in str(exc_info.value)
+        print("\n✓ Correctly rejected focus on task")
+
+    def test_set_focus_nonexistent_project(self, client):
+        """Test error handling for nonexistent project."""
+        # Try to set focus on nonexistent project
+        with pytest.raises(Exception) as exc_info:
+            client.set_focus(item_id="nonexistent-id-12345", item_type="project")
+
+        assert "Error setting focus" in str(exc_info.value)
+        print("\n✓ Correctly handled nonexistent project")

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -844,3 +844,76 @@ class TestSwitchPerspective:
             with pytest.raises(Exception) as exc_info:
                 client.switch_perspective("Invalid")
             assert "Error switching perspective" in str(exc_info.value)
+
+
+class TestSetFocus:
+    """Tests for set_focus method."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a client instance for testing."""
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_set_focus_on_project_success(self, client):
+        """Test successfully setting focus on a project."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "SUCCESS"
+            result = client.set_focus(item_id="proj-123", item_type="project")
+            assert result == {"success": True, "item_id": "proj-123", "item_type": "project"}
+            mock_run.assert_called_once()
+            # Verify the AppleScript contains the correct ID and uses flattened projects
+            call_args = mock_run.call_args[0][0]
+            assert 'proj-123' in call_args
+            assert 'flattened project' in call_args
+            assert 'set focus to' in call_args
+
+    def test_set_focus_on_folder_success(self, client):
+        """Test successfully setting focus on a folder."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "SUCCESS"
+            result = client.set_focus(item_id="folder-456", item_type="folder")
+            assert result == {"success": True, "item_id": "folder-456", "item_type": "folder"}
+            mock_run.assert_called_once()
+            # Verify the AppleScript contains the correct ID and uses folder
+            call_args = mock_run.call_args[0][0]
+            assert 'folder-456' in call_args
+            assert 'folder whose id' in call_args
+            assert 'set focus to' in call_args
+
+    def test_set_focus_on_task_raises_error(self, client):
+        """Test that setting focus on a task raises a clear error."""
+        with pytest.raises(ValueError) as exc_info:
+            client.set_focus(item_id="task-789", item_type="task")
+        assert "OmniFocus only supports setting focus on projects and folders" in str(exc_info.value)
+        assert "task" in str(exc_info.value).lower()
+
+    def test_set_focus_on_tag_raises_error(self, client):
+        """Test that setting focus on a tag raises a clear error."""
+        with pytest.raises(ValueError) as exc_info:
+            client.set_focus(item_id="tag-999", item_type="tag")
+        assert "OmniFocus only supports setting focus on projects and folders" in str(exc_info.value)
+        assert "tag" in str(exc_info.value).lower()
+
+    def test_set_focus_invalid_item_type(self, client):
+        """Test that invalid item types raise an error."""
+        with pytest.raises(ValueError) as exc_info:
+            client.set_focus(item_id="item-123", item_type="invalid")
+        assert "item_type must be" in str(exc_info.value)
+
+    def test_set_focus_applescript_error(self, client):
+        """Test handling of AppleScript errors."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, 'osascript', stderr="item not found")
+            with pytest.raises(Exception) as exc_info:
+                client.set_focus(item_id="proj-nonexistent", item_type="project")
+            assert "Error setting focus" in str(exc_info.value)
+
+    def test_set_focus_with_special_characters_in_id(self, client):
+        """Test that IDs with special characters are properly escaped."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "SUCCESS"
+            # Test with ID containing characters that might need escaping
+            result = client.set_focus(item_id="proj-test'123", item_type="project")
+            assert result["success"] is True
+            # Verify the script was called (escaping happens inside the implementation)
+            mock_run.assert_called_once()


### PR DESCRIPTION
## Summary

Implements `set_focus()` tool to allow focusing the OmniFocus window on specific projects or folders after querying.

**Key findings from AppleScript research:**
- OmniFocus only supports focus on projects and folders via AppleScript
- Tasks and tags cannot be focused (AppleScript limitation documented)
- Tab management not available (tabs property doesn't exist in AppleScript API)

## Implementation Details

**New Function: `set_focus(item_id, item_type)`**
- Located in `omnifocus_connector.py:3015-3074`
- Only accepts `item_type="project"` or `item_type="folder"`
- Raises clear `ValueError` for unsupported types (task, tag)
- Returns structured dict: `{"success": True, "item_id": "...", "item_type": "..."}`

**MCP Tool Exposure:**
- Added to `server_fastmcp.py:997-1021`
- Clear error messages for invalid item types
- Friendly success messages for users

## Testing

**Unit Tests (7):**
- ✅ Project focus success
- ✅ Folder focus success  
- ✅ Task focus raises error
- ✅ Tag focus raises error
- ✅ Invalid item type validation
- ✅ AppleScript error handling
- ✅ Special characters in IDs

**Integration Tests (4):**
- ✅ Focus on real project
- ✅ Focus on real folder
- ✅ Invalid item type error
- ✅ Nonexistent item error

**E2E Tests (3):**
- ✅ Project focus via MCP tool
- ✅ Folder focus via MCP tool
- ✅ Invalid type via MCP tool

**All 476 tests passing** (includes existing + new tests)

## Documentation Updates

- **ROADMAP.md:** Added as 17th core function, moved from "Under Investigation" to implemented
- **API_REFERENCE.md:** Complete documentation with examples, limitations, and error handling
- **Research Script:** `scripts/research_focus_commands.sh` documents AppleScript testing

## Use Case

After querying for projects or folders, users can now focus the OmniFocus window to see items in context:

```
"Find all projects with overdue tasks, then focus on the first one"
→ get_projects(has_overdue_tasks=True)
→ set_focus(item_id=project_id, item_type="project")
```

## Resolves

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)