### PR TITLE
chore: add .hygiene-approved-*.txt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ config.json
 
 # Hygiene check results
 .hygiene-check-results-*.txt
+.hygiene-approved-*.txt


### PR DESCRIPTION
## Summary

Adds  pattern to .gitignore to prevent tracking temporary hygiene check approval files.

## Context

During v0.7.0 release cleanup, we discovered  file was not ignored. This file is created during the release process when hygiene checks are reviewed and approved, but should not be tracked in git.

## Changes

- Added  to .gitignore line 49
- Pattern  was already present on line 48

## Testing

- [x] .gitignore change only, no code changes
- [x] Verified pattern matches approval files from release process