### PR TITLE
Fix: Extract major.minor dynamically from tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,18 @@ jobs:
         run: |
           TAG_NAME=${{ steps.version.outputs.tag }}
 
-          # Calculate next patch version
-          CURRENT_PATCH=$(echo "$TAG_NAME" | sed 's/v0\.\([0-9]*\)\.\([0-9]*\)/\2/')
-          NEXT_PATCH=$((CURRENT_PATCH + 1))
-          NEXT_VERSION="v0.6.$NEXT_PATCH"
+          # Extract major, minor, and patch from tag (e.g., v0.7.0 → 0, 7, 0)
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          # Calculate next patch version (e.g., v0.7.0 → v0.7.1)
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
+          echo "Current version: $TAG_NAME"
+          echo "Next version: $NEXT_VERSION"
 
           # Check if next milestone exists
           NEXT_EXISTS=$(gh api repos/${{ github.repository }}/milestones \


### PR DESCRIPTION
## Summary

Fixes #149

The release workflow was hardcoding `v0.6` when calculating the next milestone version, causing it to try creating `v0.6.X` milestones even when releasing `v0.7.0` or higher.

## Changes

- Extract major, minor, and patch components from current tag dynamically
- Calculate next version as `v{MAJOR}.{MINOR}.{PATCH+1}`
- Add debug output showing current and next version
- Add comments explaining version calculation logic

## Examples

| Current Tag | Old Behavior | New Behavior |
|-------------|--------------|--------------|
| v0.7.0      | v0.6.1 ❌    | v0.7.1 ✅    |
| v0.8.0      | v0.6.1 ❌    | v0.8.1 ✅    |
| v1.0.0      | v0.6.1 ❌    | v1.0.1 ✅    |
| v1.2.3      | v0.6.4 ❌    | v1.2.4 ✅    |

## Testing

Tested version calculation logic manually with multiple tag formats:
- v0.7.0 → v0.7.1 ✅
- v0.7.1 → v0.7.2 ✅
- v0.8.0 → v0.8.1 ✅
- v1.0.0 → v1.0.1 ✅
- v1.2.3 → v1.2.4 ✅

## Impact

- Fixes milestone creation for all future releases
- No breaking changes - only affects workflow automation
- Will be validated on next release (v0.7.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)