### PR TITLE
Fix: Enhance documentation completeness check to catch all version references

### DIFF
--- a/scripts/check_documentation.sh
+++ b/scripts/check_documentation.sh
@@ -33,12 +33,35 @@ else
     ISSUES_FOUND=1
 fi
 
-# Check 3: README.md has version updated
-echo "3. Checking README.md version..."
-if grep -q "${VERSION#v}" README.md; then
-    echo "   ✅ README.md references $VERSION"
+# Check 3: README.md has version updated comprehensively
+echo "3. Checking README.md version references..."
+README_ISSUES=0
+
+# Check 3a: Installation example should reference current version
+if grep -q "git checkout ${VERSION}" README.md; then
+    echo "   ✅ Installation example references $VERSION"
 else
-    echo "   ⚠️  README.md may need version update"
+    echo "   ❌ Installation example should reference '$VERSION' (currently references old version)"
+    README_ISSUES=1
+fi
+
+# Check 3b: "Key Changes" section should mention current version
+if grep -q "Key Changes.*${VERSION}" README.md; then
+    echo "   ✅ 'Key Changes' section mentions $VERSION"
+else
+    echo "   ❌ 'Key Changes' section should include $VERSION"
+    README_ISSUES=1
+fi
+
+# Check 3c: API version header should reference current version
+if grep -q "v${VERSION#v} API" README.md; then
+    echo "   ✅ API version header mentions $VERSION"
+else
+    echo "   ⚠️  API version header may need update to $VERSION"
+fi
+
+if [ $README_ISSUES -gt 0 ]; then
+    ISSUES_FOUND=1
 fi
 
 # Check 4: Check for breaking changes requiring migration guide

--- a/tests/test_check_documentation.py
+++ b/tests/test_check_documentation.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for scripts/check_documentation.sh
+
+Tests the documentation completeness check script that runs during release hygiene checks.
+"""
+
+import subprocess
+import tempfile
+import shutil
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def temp_repo():
+    """Create a temporary directory with minimal files for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = Path(tmpdir)
+
+        # Create minimal directory structure
+        (repo_path / ".claude").mkdir()
+        (repo_path / "docs" / "guides").mkdir(parents=True)
+        (repo_path / "docs" / "reference").mkdir(parents=True)
+        (repo_path / "docs" / "project").mkdir(parents=True)
+
+        # Copy the check script
+        script_src = Path("scripts/check_documentation.sh")
+        script_dest = repo_path / "scripts" / "check_documentation.sh"
+        script_dest.parent.mkdir(parents=True)
+        shutil.copy(script_src, script_dest)
+        script_dest.chmod(0o755)
+
+        yield repo_path
+
+
+def run_check(repo_path, version):
+    """Run the documentation check script and return result."""
+    result = subprocess.run(
+        ["./scripts/check_documentation.sh", version],
+        cwd=repo_path,
+        capture_output=True,
+        text=True
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_check_requires_version_argument():
+    """Test that script requires version argument."""
+    result = subprocess.run(
+        ["./scripts/check_documentation.sh"],
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 1
+    assert "Usage:" in result.stdout
+
+
+def test_changelog_check_passes(temp_repo):
+    """Test CHANGELOG check passes when entry exists."""
+    # Create CHANGELOG with entry
+    changelog = temp_repo / "CHANGELOG.md"
+    changelog.write_text("""
+# Changelog
+
+## [0.7.0] - 2025-11-12
+- New feature
+
+## [0.6.7] - 2025-11-11
+- Old feature
+""")
+
+    # Create minimal other files to avoid failures
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+    (temp_repo / "README.md").write_text("""
+v0.7.0 API
+Key Changes in v0.7.0:
+git checkout v0.7.0
+""")
+
+    # Create key doc files
+    for doc in ["TESTING.md", "CONTRIBUTING.md", "INTEGRATION_TESTING.md"]:
+        (temp_repo / "docs" / "guides" / doc).touch()
+    for doc in ["ARCHITECTURE.md", "CODE_QUALITY.md", "APPLESCRIPT_GOTCHAS.md"]:
+        (temp_repo / "docs" / "reference" / doc).touch()
+    (temp_repo / "docs" / "project" / "ROADMAP.md").touch()
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 0
+    assert "✅ CHANGELOG.md has entry for v0.7.0" in stdout
+
+
+def test_changelog_check_fails(temp_repo):
+    """Test CHANGELOG check fails when entry missing."""
+    changelog = temp_repo / "CHANGELOG.md"
+    changelog.write_text("""
+# Changelog
+
+## [0.6.7] - 2025-11-11
+- Old feature
+""")
+
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.6.7")
+    (temp_repo / "README.md").write_text("v0.6.7 API")
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 1
+    assert "❌ CHANGELOG.md missing entry for v0.7.0" in stdout
+
+
+def test_readme_installation_example_check(temp_repo):
+    """Test README installation example must reference current version."""
+    (temp_repo / "CHANGELOG.md").write_text("## [0.7.0] - 2025-11-12")
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+
+    # README has wrong version in installation example
+    readme = temp_repo / "README.md"
+    readme.write_text("""
+v0.7.0 API
+
+Key Changes in v0.7.0:
+- New stuff
+
+git checkout v0.6.7  # Old version!
+""")
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 1
+    assert "❌ Installation example should reference 'v0.7.0'" in stdout
+
+
+def test_readme_key_changes_check(temp_repo):
+    """Test README 'Key Changes' section must mention current version."""
+    (temp_repo / "CHANGELOG.md").write_text("## [0.7.0] - 2025-11-12")
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+
+    # README has old version in Key Changes
+    readme = temp_repo / "README.md"
+    readme.write_text("""
+v0.7.0 API
+
+Key Changes in v0.6.7:
+- Old stuff
+
+git checkout v0.7.0
+""")
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 1
+    assert "❌ 'Key Changes' section should include v0.7.0" in stdout
+
+
+def test_readme_comprehensive_checks_pass(temp_repo):
+    """Test all README checks pass with correct content."""
+    (temp_repo / "CHANGELOG.md").write_text("## [0.7.0] - 2025-11-12")
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+
+    # README with all correct version references
+    readme = temp_repo / "README.md"
+    readme.write_text("""
+This is the v0.7.0 API documentation.
+
+Key Changes in v0.7.0:
+- New feature added
+
+Installation:
+git checkout v0.7.0
+""")
+
+    # Create key doc files
+    for doc in ["TESTING.md", "CONTRIBUTING.md", "INTEGRATION_TESTING.md"]:
+        (temp_repo / "docs" / "guides" / doc).touch()
+    for doc in ["ARCHITECTURE.md", "CODE_QUALITY.md", "APPLESCRIPT_GOTCHAS.md"]:
+        (temp_repo / "docs" / "reference" / doc).touch()
+    (temp_repo / "docs" / "project" / "ROADMAP.md").touch()
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 0
+    assert "✅ Installation example references v0.7.0" in stdout
+    assert "✅ 'Key Changes' section mentions v0.7.0" in stdout
+    assert "✅ API version header mentions v0.7.0" in stdout
+
+
+def test_breaking_changes_require_migration_guide(temp_repo):
+    """Test that breaking changes in CHANGELOG require migration guide."""
+    changelog = temp_repo / "CHANGELOG.md"
+    changelog.write_text("""
+## [0.7.0] - 2025-11-12
+
+### BREAKING CHANGES
+- API changed significantly
+
+## [0.6.7] - 2025-11-11
+""")
+
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+    (temp_repo / "README.md").write_text("v0.7.0 API\nKey Changes in v0.7.0:\ngit checkout v0.7.0")
+
+    # No migration guide exists
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 1
+    assert "⚠️  CHANGELOG mentions breaking changes" in stdout
+    assert "❌ Migration guide missing" in stdout
+
+
+def test_missing_key_documentation_files(temp_repo):
+    """Test that missing key documentation files are detected."""
+    (temp_repo / "CHANGELOG.md").write_text("## [0.7.0] - 2025-11-12")
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+    (temp_repo / "README.md").write_text("v0.7.0 API\nKey Changes in v0.7.0:\ngit checkout v0.7.0")
+
+    # Create only some doc files, not all
+    (temp_repo / "docs" / "guides" / "TESTING.md").touch()
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+    assert returncode == 1
+    assert "❌ Missing key documentation files:" in stdout
+    assert "docs/guides/CONTRIBUTING.md" in stdout
+
+
+def test_v070_rc1_scenario_would_have_failed(temp_repo):
+    """
+    Test that the enhanced script would have caught the v0.7.0-rc1 issue.
+
+    At v0.7.0-rc1, README had:
+    - Line 1: "v0.7.0 API" (correct)
+    - Key Changes: "v0.6.7" (wrong)
+    - Installation: "git checkout v0.6.7" (wrong)
+
+    The old script passed because it only checked if v0.7.0 appeared anywhere.
+    The enhanced script should fail.
+    """
+    (temp_repo / "CHANGELOG.md").write_text("## [0.7.0] - 2025-11-12")
+    (temp_repo / ".claude/CLAUDE.md").write_text("Current Version: v0.7.0")
+
+    # Simulate the problematic v0.7.0-rc1 README
+    readme = temp_repo / "README.md"
+    readme.write_text("""
+This server provides **17 comprehensive tools** for managing OmniFocus (v0.7.0 API):
+
+**Key Changes in v0.6.7:**
+- v0.6.7: Fixed unit test timeout issue
+
+Installation:
+git checkout v0.6.7  # Or latest version
+""")
+
+    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")
+
+    # Should fail because installation and key changes reference wrong version
+    assert returncode == 1
+    assert "❌ Installation example should reference 'v0.7.0'" in stdout
+    assert "❌ 'Key Changes' section should include v0.7.0" in stdout
+    # But API header should pass
+    assert "✅ API version header mentions v0.7.0" in stdout


### PR DESCRIPTION
## Summary

Fixes #148

Enhances the documentation completeness check to validate **all critical version references** in README.md, not just the presence of the version string anywhere. This prevents issues like v0.7.0-rc1 where README had `v0.7.0` in the header but `v0.6.7` in "Key Changes" and installation examples.

## Problem Solved

**The v0.7.0-rc1 Issue:**

At v0.7.0-rc1, README.md had:
- ✅ Line 1: "v0.7.0 API" (correct)
- ❌ Key Changes: "**Key Changes in v0.6.7:**" (wrong)
- ❌ Installation: "`git checkout v0.6.7`" (wrong)

**Old check behavior:**
```bash
if grep -q "${VERSION#v}" README.md; then
    echo "✅ README.md references $VERSION"
fi
```
Result: **Passed** ❌ (because v0.7.0 appeared on line 1)

**Enhanced check behavior:**
```bash
# Check installation example
if grep -q "git checkout ${VERSION}" README.md; then
    echo "✅ Installation example references $VERSION"
else
    echo "❌ Installation example should reference '$VERSION'"
    ISSUES_FOUND=1
fi

# Check Key Changes section  
if grep -q "Key Changes.*${VERSION}" README.md; then
    echo "✅ 'Key Changes' section mentions $VERSION"
else
    echo "❌ 'Key Changes' section should include $VERSION"
    ISSUES_FOUND=1
fi
```
Result: **Failed** ✅ (catches both issues)

## Changes

### Enhanced Checks in `scripts/check_documentation.sh`

**Check 3a: Installation Example**
- Validates: `git checkout vX.Y.Z`
- Fails if references wrong version

**Check 3b: "Key Changes" Section**
- Validates: `Key Changes in vX.Y.Z:`
- Fails if missing or references wrong version

**Check 3c: API Version Header**
- Validates: `vX.Y.Z API`
- Warning only (not critical)

### Comprehensive Test Coverage

Added 9 unit tests in `tests/test_check_documentation.py`:

1. `test_check_requires_version_argument` - Validates script usage
2. `test_changelog_check_passes` - CHANGELOG entry validation
3. `test_changelog_check_fails` - Missing CHANGELOG entry
4. `test_readme_installation_example_check` - Installation version check
5. `test_readme_key_changes_check` - Key Changes version check
6. `test_readme_comprehensive_checks_pass` - All README checks pass
7. `test_breaking_changes_require_migration_guide` - Migration guide check
8. `test_missing_key_documentation_files` - Key docs existence check
9. **`test_v070_rc1_scenario_would_have_failed`** - Regression test ⭐

## Test Results

### Regression Test (Most Important)

```python
def test_v070_rc1_scenario_would_have_failed(temp_repo):
    """
    Test that the enhanced script would have caught the v0.7.0-rc1 issue.
    """
    readme.write_text("""
This server provides **17 comprehensive tools** (v0.7.0 API):

**Key Changes in v0.6.7:**
- v0.6.7: Fixed unit test timeout issue

git checkout v0.6.7  # Or latest version
""")

    returncode, stdout, stderr = run_check(temp_repo, "v0.7.0")

    assert returncode == 1  # Should fail
    assert "❌ Installation example should reference 'v0.7.0'" in stdout
    assert "❌ 'Key Changes' section should include v0.7.0" in stdout
    assert "✅ API version header mentions v0.7.0" in stdout
```

**Result:** ✅ All tests pass

### Manual Testing

**Scenario 1: Current v0.7.0 (should pass)**
```bash
./scripts/check_documentation.sh v0.7.0
```
Result: ✅ All checks pass

**Scenario 2: Simulated v0.7.0-rc1 problem (should fail)**
```bash
# README with v0.6.7 references
./scripts/check_documentation.sh v0.7.0
```
Result: ❌ Fails with:
- Installation example should reference 'v0.7.0'
- Key Changes section should include v0.7.0

## Impact

✅ **Prevention:** Would have caught the v0.7.0-rc1 README issue  
✅ **Validation:** Ensures all critical version references are updated  
✅ **Automation:** Runs in pre-tag hook (check #6)  
✅ **Test Coverage:** 9 comprehensive unit tests

## Integration

The pre-tag hook already calls this script:
```bash
# Check 6: Documentation completeness (~2s)
DOC_OUTPUT=$(./scripts/check_documentation.sh "$VERSION" 2>&1)
```

No hook changes needed - enhancement is backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)