### PR TITLE
feat: add /release skill for automated release workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,6 +83,7 @@ CHANGELOG.md is only updated on release branches, never on feature branches.
 
 Load these skills when working in their domains:
 
+- **release** — Full release workflow: milestone check, version bump, changelog, validation, tagging, PR
 - **applescript-omnifocus** — OmniFocus AppleScript patterns, quirks, and workarounds
 - **api-design** — API consolidation philosophy, decision tree for new functions, anti-patterns
 - **performance-patterns** — Batch fetching, round-trip minimization, filter architecture

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: release
+description: Use when the user wants to release a new version, says "time to release", "let's release", "cut a release", "version bump", or similar. Orchestrates the full release workflow including milestone check, version bump, changelog generation, validation, tagging, and PR creation. Also invocable as /release.
+---
+
+# Release Workflow
+
+This skill orchestrates a complete release. Follow each phase in order. Stop and report if any phase fails.
+
+## Phase 1: Milestone Check
+
+Before creating a release branch, verify the milestone is ready.
+
+1. Determine the target milestone. Look at open milestones:
+   ```bash
+   gh api "repos/{owner}/{repo}/milestones?state=open&sort=due_on" --jq '.[] | "\(.number) \(.title) open:\(.open_issues) closed:\(.closed_issues)"'
+   ```
+
+2. If there are multiple open milestones, ask the user which one to release.
+
+3. If the target milestone has open issues, **stop and ask the user**:
+   - List the open issues: `gh api "repos/{owner}/{repo}/milestones/{number}/issues?state=open" --jq ...` (or use `gh issue list --milestone`)
+   - Present options:
+     a. Move open issues to the next milestone (specify or create it)
+     b. Pause to work on the open issues first
+     c. Close the issues if they're no longer relevant
+   - Do NOT proceed until all issues in the target milestone are closed or moved.
+
+4. Once the milestone is clean (0 open issues), proceed.
+
+## Phase 2: Version Number
+
+1. Read the current version from `pyproject.toml` (authoritative source).
+2. The milestone title tells you the target version (e.g., `v0.7.3` means version `0.7.3`).
+3. Validate it's a valid semver bump from the current version.
+4. Present the version to the user for confirmation: "Release version X.Y.Z? (current: A.B.C)"
+5. Wait for confirmation before proceeding.
+
+## Phase 3: Create Release Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b release/vX.Y.Z
+```
+
+## Phase 4: Bump Version
+
+Update version in ALL of these files (pyproject.toml is authoritative):
+
+1. **pyproject.toml** - `version = "X.Y.Z"`
+2. **CLAUDE.md** (.claude/CLAUDE.md) - `**Version:** vX.Y.Z` in the header line
+3. **README.md** - All references to the old version (check with grep for old version string)
+
+Use the Edit tool for each file. Be precise about what to change.
+
+## Phase 5: Generate CHANGELOG
+
+1. Get all commits since the last tag:
+   ```bash
+   git log $(git describe --tags --abbrev=0)..HEAD --oneline
+   ```
+
+2. Get merged PRs since the last tag:
+   ```bash
+   gh pr list --state merged --base main --search "merged:>YYYY-MM-DD" --json number,title,labels
+   ```
+   (Use the date of the last tag)
+
+3. Generate a CHANGELOG entry following the existing format in CHANGELOG.md:
+   - Use Keep a Changelog format: `## [X.Y.Z] - YYYY-MM-DD`
+   - Categorize changes: Added, Changed, Fixed, Removed
+   - Reference PR/issue numbers with (#N)
+   - Be concise but descriptive
+   - Include today's date
+
+4. Insert the new entry at the top of CHANGELOG.md (after the header, before the previous version).
+
+## Phase 6: Validation
+
+Run ALL validation checks. Stop on any failure.
+
+1. **Version sync check:**
+   ```bash
+   ./scripts/check_version_sync.sh
+   ```
+
+2. **Client-server parity:**
+   ```bash
+   ./scripts/check_client_server_parity.sh
+   ```
+
+3. **Complexity check:**
+   ```bash
+   ./scripts/check_complexity.sh
+   ```
+
+4. **Unit tests:**
+   ```bash
+   make test
+   ```
+
+If any check fails, fix the issue and re-run. Do not proceed with failures.
+
+## Phase 7: Commit, Tag, Push, and PR
+
+1. **Commit** the version bump and changelog:
+   ```bash
+   git add -A
+   git commit -m "release: vX.Y.Z"
+   ```
+
+2. **Create the tag** on the release branch:
+   ```bash
+   ./scripts/create_tag.sh vX.Y.Z
+   ```
+
+3. **Push** the branch and tag:
+   ```bash
+   git push -u origin release/vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+4. **Create the PR** to main:
+   ```bash
+   gh pr create --title "release: vX.Y.Z" --body "..."
+   ```
+   Use a merge commit (not squash) for release PRs — the individual commits are meaningful.
+
+5. Tell the user the PR is ready for review. Do NOT merge it automatically.
+
+## Phase 8: Close Milestone
+
+After the PR is created (not merged), close the milestone:
+
+```bash
+gh api -X PATCH "repos/{owner}/{repo}/milestones/{number}" -f state=closed
+```
+
+## Notes
+
+- CHANGELOG is only updated on release branches, never on feature branches.
+- The pre-tag hook validates that final release tags are on main and that CHANGELOG dates are set. Since we tag on the release branch and merge to main, the tag is created here before merging.
+- If `create_tag.sh` fails due to the pre-tag hook requiring main branch, create the tag after the PR is merged instead. Adjust the workflow accordingly and inform the user.
+- Integration tests (`make test-integration`, `make test-e2e`) require a real OmniFocus test database. Ask the user if they want to run them — they're optional for the release validation.

--- a/scripts/check_client_server_parity.sh
+++ b/scripts/check_client_server_parity.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Check that all public client functions have corresponding MCP tools
 
-CLIENT_FILE="src/omnifocus_mcp/omnifocus_client.py"
+CLIENT_FILE="src/omnifocus_mcp/omnifocus_connector.py"
 SERVER_FILE="src/omnifocus_mcp/server_fastmcp.py"
 
 echo "Checking client/server parity..."

--- a/scripts/git-hooks/pre-tag
+++ b/scripts/git-hooks/pre-tag
@@ -20,11 +20,10 @@ if [[ "$TAG_NAME" =~ -rc[0-9]+$ ]]; then
         exit 1
     fi
 else
-    # Final release tags must be on main
-    if [ "$CURRENT_BRANCH" != "main" ]; then
-        echo "Final release tags must be created on main branch."
+    # Final release tags must be on main or release/* branches
+    if [ "$CURRENT_BRANCH" != "main" ] && [[ ! "$CURRENT_BRANCH" =~ ^release/ ]]; then
+        echo "Final release tags must be created on main or release/* branches."
         echo "Current branch: $CURRENT_BRANCH"
-        echo "Merge release branch to main first."
         exit 1
     fi
 


### PR DESCRIPTION
## Summary
- New `/release` skill that orchestrates the full release workflow: milestone check, version bump, changelog generation, validation checks, tagging, and PR creation
- Fixes `check_client_server_parity.sh` which still referenced the old `omnifocus_client.py` filename (renamed to `omnifocus_connector.py` in v0.6.1)
- Updates `pre-tag` hook to allow final release tags on `release/*` branches (previously required `main`)

## Test plan
- [x] `check_client_server_parity.sh` passes with corrected file path
- [x] `check_version_sync.sh` passes
- [ ] Invoke `/release` on next version to validate the full workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)