### PR TITLE
docs: performance profiling results (#191)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,39 +54,26 @@ The API was consolidated from 40+ functions to 16 in October 2025. This is inten
 
 ## Performance Constraints
 
-**AppleScript round-trips are expensive.** Each `osascript` subprocess call takes 100-300ms minimum. Design for fewer calls with more data per call.
+**The bottleneck is per-property IPC cost.** Each AppleScript property read from OmniFocus costs ~17ms (inter-process communication). With 26 properties per task, iterating 381 tasks = ~168s. This single fact explains nearly all performance issues. See `docs/reference/PERFORMANCE_PROFILING.md` for full experiment data.
 
-Benchmarked baselines (32 projects, ~200 tasks, clean test DB):
+**`whose` clauses are 20-30x faster than manual iteration.** OmniFocus evaluates `whose` natively:
+- `flattened tasks whose flagged is true`: 0.22s
+- Manual loop checking `flagged of t`: 6.59s
+- Current `get_tasks(flagged)` (loop + 26 props): 18.9s
 
-| Operation | Time | Items | Notes |
-|-----------|------|-------|-------|
-| `get_tasks(project_id=X)` | 0.20s | varies | Scoped to one project — fast |
-| `get_tasks(inbox_only)` | 5.4s | 13 | |
-| `get_tasks(overdue)` | 16.6s | 8 | Full scan despite filter |
-| `get_tasks(flagged_only)` | 18.9s | 14 | Full scan despite filter |
-| `get_tasks(next_only)` | 41.9s | 67 | |
-| `get_tasks(query='...')` | 80.8s | 39 | Slowest filter path |
-| `get_tasks(available_only)` | >120s | — | Times out |
-| `get_projects()` | 18.7s | 71 | Baseline |
-| `get_projects(+task_health)` | 43.6s | 71 | +133% overhead |
-| `get_projects(+last_activity)` | 28.8s | 71 | +54% overhead |
-| `get_projects(+full_notes)` | 18.7s | 71 | +0% overhead |
-| `get_folders()` | 0.68s | 5 | |
-| `get_tags()` | 1.01s | 25 | |
-| `get_perspectives()` | 0.17s | 24 | |
-| All write ops | 0.63-0.67s | — | create/update/delete |
+**What is NOT a bottleneck:** Loop iteration itself (0.17s for 381 tasks), string concatenation (<100ms for 400 items), JSON building.
 
-**Critical finding:** All `get_tasks()` filters except `project_id` iterate `flattened tasks` (full table scan). The filter is applied per-task inside the loop but the scan itself is the bottleneck. `project_id` is 100x faster because it scopes to one project's task list.
+**Current baselines** (32 projects, ~381 tasks — see profiling doc for full table):
+- `get_tasks(project_id)`: 0.20s | `get_tasks(flagged)`: 18.9s | `get_tasks(query)`: 80.8s
+- `get_projects()`: 18.7s | `get_perspectives()`: 0.17s | Write ops: 0.63-0.67s
 
-- Default timeout: 60s, max: 300s (configurable)
+Default timeout: 60s, max: 300s (configurable).
 
-**Key optimization:** `_get_tasks_batch_for_filtering()` fetches all project tasks in one AppleScript call instead of N calls. This pattern should be used for any new filtering that crosses project boundaries.
+**Optimization path:** Use `whose` to pre-filter, then extract properties only from the small result set. Projected: `get_tasks(flagged)` from 18.9s to ~3.5s.
 
-**Conditional filter-first architecture:** `get_tasks()` detects whether selective filters (flagged, overdue, query, etc.) are active. If yes, it filters BEFORE extracting full properties. If no, it extracts first. This matters — wrong order can be 19x slower.
+**Project task health:** `get_projects(include_task_health=True)` returns per-project task counts in a single AppleScript call. +133% overhead due to nested per-project task loops.
 
-**Project task health:** `get_projects(include_task_health=True)` returns per-project task counts (remaining, available, overdue, deferred) in a single AppleScript call. Use this for project review workflows instead of N per-project `get_tasks()` calls.
-
-**Conditional data loading:** `get_projects()` supports `include_last_activity=True` for expensive per-project calculations. Without this flag, `lastActivityDate` returns null (saves ~260ms for 33 projects).
+**Conditional data loading:** `get_projects()` supports `include_last_activity=True` for expensive per-project calculations (+54% overhead).
 
 ## Database Safety
 

--- a/docs/reference/PERFORMANCE_PROFILING.md
+++ b/docs/reference/PERFORMANCE_PROFILING.md
@@ -1,0 +1,150 @@
+# Performance Profiling Results
+
+Profiled 2026-03-07 on a clean test database (32 projects, ~200 tasks, 10 tags, 4 folders).
+Actual task count at profiling time: 381 total, 376 active (accumulated from prior test runs).
+
+## Benchmark Results
+
+### get_tasks() by filter (3 iterations each, CV <1.5%)
+
+| Operation | Mean | Items Returned |
+|-----------|------|----------------|
+| `get_tasks(project_id=X)` | 0.20s | varies |
+| `get_tasks(inbox_only)` | 5.4s | 13 |
+| `get_tasks(overdue)` | 16.6s | 8 |
+| `get_tasks(flagged_only)` | 18.9s | 14 |
+| `get_tasks(next_only)` | 41.9s | 67 |
+| `get_tasks(query='bench')` | 80.8s | 39 |
+| `get_tasks(available_only)` | >120s | TIMEOUT |
+
+### get_projects() by options
+
+| Operation | Mean | Overhead vs baseline |
+|-----------|------|---------------------|
+| `get_projects()` | 18.7s | baseline |
+| `get_projects(+task_health)` | 43.6s | +133% |
+| `get_projects(+last_activity)` | 28.8s | +54% |
+| `get_projects(+full_notes)` | 18.7s | +0% (no-op) |
+| `get_projects(all options)` | 53.6s | +187% |
+
+### Other reads
+
+| Operation | Mean | Items |
+|-----------|------|-------|
+| `get_folders()` | 0.68s | 5 |
+| `get_tags()` | 1.01s | 25 |
+| `get_perspectives()` | 0.17s | 24 |
+
+### Write operations
+
+| Operation | Mean |
+|-----------|------|
+| `create_task` | 0.66s |
+| `update_task` | 0.65s |
+| `delete_tasks` | 0.64s |
+| `create_project` | 0.65s |
+| `update_project` | 0.67s |
+| `delete_projects` | 0.65s |
+
+## Root Cause Experiments
+
+### Experiment 1: `whose` clause vs manual iteration
+
+OmniFocus evaluates `whose` clauses natively, avoiding per-task AppleScript overhead.
+
+| Approach | Time | Speedup |
+|----------|------|---------|
+| `repeat with t in flattened tasks` + `if flagged of t` | 6.59s | 1x |
+| `flattened tasks whose flagged is true` | 0.22s | **30x** |
+| Manual loop + `name contains "bench"` | 6.54s | 1x |
+| `whose name contains "bench"` | 0.32s | **20x** |
+| `whose completed is false` (376/381 match) | 1.14s | — |
+| `whose flagged is true and completed is false` | 0.22s | **30x** |
+
+### Experiment 2: Per-task property read cost
+
+Each AppleScript property read from OmniFocus costs ~17ms due to inter-process communication.
+
+| Loop body (381 tasks) | Time | Per-task |
+|-----------------------|------|----------|
+| Empty loop | 0.17s | 0.4ms |
+| 1 property (`id`) | 6.53s | 17ms |
+| 4 properties | 25.69s | 67ms |
+| 8 properties | 51.81s | 136ms |
+| 8 properties + 2 dates | 63.85s | 168ms |
+| `id` + `number of available tasks` | 12.90s | 34ms |
+| `id` + `containing project` (3 reads) | 25.22s | 66ms |
+
+The cost is linear in properties: ~17ms per property read per task.
+
+### Experiment 3: String concatenation scaling
+
+String concatenation is NOT a bottleneck at this scale.
+
+| Items | Concat (`&`) | List + join |
+|-------|-------------|-------------|
+| 50 | 0.035s | 0.030s |
+| 100 | 0.033s | 0.030s |
+| 200 | 0.041s | 0.043s |
+| 400 | 0.066s | 0.036s |
+
+Both approaches are <100ms even at 400 items with ~300-char JSON per item.
+
+### Experiment 4: `whose` + property extraction
+
+| Approach | Time |
+|----------|------|
+| `whose flagged` + loop 8 props (14 tasks) | 2.06s |
+| `whose flagged` + loop 14 props (14 tasks) | 3.20s |
+| Manual loop 381 tasks + filter + 3 props | 7.53s |
+| Bulk `id of (whose flagged)` | ERROR (mixed inbox/project types) |
+| Current `get_tasks(flagged)` benchmark | 18.88s |
+
+Bulk property reads (`id of flaggedTasks`) fail when the result set mixes inbox tasks and project tasks — different AppleScript classes. Looping over a pre-filtered set works and is fast.
+
+## Conclusions
+
+### The bottleneck is per-property IPC cost
+
+Each property read from OmniFocus via AppleScript costs ~17ms. This is inter-process communication overhead between `osascript` and OmniFocus. The cost is:
+
+```
+total_time ≈ (num_tasks_iterated × num_properties_per_task × 17ms) + overhead
+```
+
+Current `get_tasks()` extracts 26 properties per task. For 381 tasks:
+`381 × 26 × 17ms = 168s` — which explains the >120s timeout.
+
+### What was NOT the bottleneck
+
+- **Loop iteration itself**: 0.17s for 381 tasks (negligible)
+- **String concatenation**: <100ms for 400 items (negligible)
+- **JSON building**: Trivial compared to property reads
+
+### `whose` clauses are the key optimization
+
+OmniFocus evaluates `whose` natively — 20-30x faster than manual iteration with property checks. Combined with extracting properties only from the filtered set:
+
+| Current | Optimized (projected) |
+|---------|----------------------|
+| 381 tasks × 26 props × 17ms = 168s | `whose` (0.2s) + 14 tasks × 14 props × 17ms = 3.5s |
+
+### Optimization strategy
+
+1. **Use `whose` clauses** to pre-filter tasks before the property extraction loop
+2. **Reduce properties extracted** — not all 26 are needed for every use case
+3. **Pre-filter to small sets** — the per-task cost is fixed, so fewer tasks = proportionally faster
+4. `get_projects()` nested loops (task_health, last_activity) should use similar pre-filtering
+
+### Filters that map to `whose` clauses
+
+| Filter | `whose` equivalent | Works? |
+|--------|-------------------|--------|
+| `flagged_only` | `whose flagged is true` | Yes (tested) |
+| `overdue` | `whose due date < (current date)` | Needs testing |
+| `next_only` | `whose next is true` | Needs testing |
+| `completed` | `whose completed is true/false` | Yes (tested) |
+| `query` | `whose name contains "X"` | Yes (tested, name only) |
+| `available_only` | Complex (dropped, blocked, deferred) | Needs testing |
+| `inbox_only` | Already uses `inbox tasks` (fast path) | N/A |
+| `project_id` | Already uses scoped task source (fast path) | N/A |


### PR DESCRIPTION
## Summary

- Add `docs/reference/PERFORMANCE_PROFILING.md` with full experiment methodology and results
- Update CLAUDE.md performance section with empirically-validated findings

### Key findings from AppleScript microbenchmarks

1. **Per-property IPC cost: ~17ms** — each property read from OmniFocus via AppleScript costs ~17ms due to inter-process communication. This is the root cause of all slowness.
2. **`whose` clauses: 20-30x faster** — OmniFocus evaluates these natively vs manual iteration
3. **String concatenation: NOT a bottleneck** — <100ms for 400 items, debunking the O(n²) hypothesis
4. **Projected optimization**: `get_tasks(flagged)` from 18.9s to ~3.5s using `whose` pre-filtering

## Test plan

- [x] Documentation only — no code changes
- [x] Profiling data matches experiment outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)