### PR TITLE
perf: use native whose clauses for get_tasks pre-filtering (#191)

### DIFF
--- a/docs/reference/PERFORMANCE_PROFILING.md
+++ b/docs/reference/PERFORMANCE_PROFILING.md
@@ -131,20 +131,54 @@ OmniFocus evaluates `whose` natively — 20-30x faster than manual iteration wit
 
 ### Optimization strategy
 
-1. **Use `whose` clauses** to pre-filter tasks before the property extraction loop
-2. **Reduce properties extracted** — not all 26 are needed for every use case
+1. **Use `whose` clauses** to pre-filter tasks before the property extraction loop ✅ (implemented)
+2. **Reduce properties extracted** — not all 27 are needed for every use case (future work)
 3. **Pre-filter to small sets** — the per-task cost is fixed, so fewer tasks = proportionally faster
 4. `get_projects()` nested loops (task_health, last_activity) should use similar pre-filtering
 
 ### Filters that map to `whose` clauses
 
-| Filter | `whose` equivalent | Works? |
+| Filter | `whose` equivalent | Implemented? |
 |--------|-------------------|--------|
-| `flagged_only` | `whose flagged is true` | Yes (tested) |
-| `overdue` | `whose due date < (current date)` | Needs testing |
-| `next_only` | `whose next is true` | Needs testing |
-| `completed` | `whose completed is true/false` | Yes (tested) |
-| `query` | `whose name contains "X"` | Yes (tested, name only) |
-| `available_only` | Complex (dropped, blocked, deferred) | Needs testing |
+| `flagged_only` | `whose flagged is true` | ✅ Yes |
+| `overdue` | `whose due date < (current date)` | ✅ Yes |
+| `next_only` | `whose next is true` | ✅ Yes |
+| `completed` | `whose completed is false` | ✅ Yes (default) |
+| `dropped_only` | `whose dropped is true` | ✅ Yes |
+| `blocked_only` | `whose blocked is true` | ✅ Yes |
+| `query` | `whose name contains "X" or note contains "X"` | ✅ Yes |
+| `available_only` | Complex (dropped, blocked, deferred) | No (still times out) |
 | `inbox_only` | Already uses `inbox tasks` (fast path) | N/A |
 | `project_id` | Already uses scoped task source (fast path) | N/A |
+
+## Post-Optimization Benchmark (whose-clause implementation)
+
+Measured after implementing `whose` clause pre-filtering for get_tasks().
+Same test database: 32 projects, ~200 tasks, 10 tags, 4 folders.
+
+### get_tasks() before vs after
+
+| Operation | Before | After | Speedup |
+|-----------|--------|-------|---------|
+| `get_tasks(flagged_only)` | 18.9s | **6.3s** | **3.0x** |
+| `get_tasks(overdue)` | 16.6s | **3.6s** | **4.6x** |
+| `get_tasks(query='bench')` | 80.8s | **16.3s** | **5.0x** |
+| `get_tasks(next_only)` | 41.9s | **29.3s** | **1.4x** |
+| `get_tasks(inbox_only)` | 5.4s | 5.4s | — (already fast path) |
+| `get_tasks(project_id=X)` | 0.20s | 0.18s | — (already fast path) |
+| `get_tasks(available_only)` | >120s | >120s | — (still times out) |
+| `get_tasks()` (no filter) | >120s | >120s | — (still times out) |
+
+### Why speedups are less than the 20-30x from whose experiments
+
+The `whose` clause itself is fast (0.2s), but the remaining bottleneck is per-task property extraction.
+With 27 properties × ~17ms per property × N matching tasks:
+
+| Filter | Matching tasks | Expected time | Actual time |
+|--------|---------------|--------------|-------------|
+| overdue | 8 | 8 × 27 × 17ms = 3.7s | 3.6s ✓ |
+| flagged | 14 | 14 × 27 × 17ms = 6.4s | 6.3s ✓ |
+| query | 39 | 39 × 27 × 17ms = 17.9s | 16.3s ✓ |
+| next | 67 | 67 × 27 × 17ms = 30.7s | 29.3s ✓ |
+
+The optimization eliminates iteration over non-matching tasks. Further gains require reducing properties per task.

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1699,23 +1699,23 @@ class OmniFocusConnector:
 
         # Detect if selective filters are active (Phase 2: Conditional filter-first optimization)
         # Selective filters eliminate >80% of tasks and benefit from filter-first architecture
-        # Note: query is NOT included - Python-side filtering performs equivalently (see #172)
         selective_filters_active = (
             flagged_only or
             overdue or
             dropped_only or
             blocked_only or
             next_only or
+            query or
+            available_only or
             due_relative in ['today', 'tomorrow', 'this_week', 'next_week', 'overdue']
         )
 
-        # Build task source (inbox, project, specific task, parent's subtasks, or all tasks)
-        # NEW (Phase 3.1): task_id and parent_task_id parameters
+        # Build task source with native 'whose' pre-filtering where possible.
+        # OmniFocus evaluates 'whose' clauses natively (~20-30x faster than
+        # manual iteration with per-task property checks). See PERFORMANCE_PROFILING.md.
         if task_id:
-            # Most specific: filter to single task by ID
             task_source = f'(flattened tasks whose id is "{task_id}")'
         elif parent_task_id:
-            # Filter to subtasks of a specific parent task
             parent_filter = f'whose id is "{parent_task_id}"'
             task_source = f'tasks of (first flattened task {parent_filter})'
         elif inbox_only:
@@ -1724,38 +1724,74 @@ class OmniFocusConnector:
             project_filter = f'whose id is "{project_id}"'
             task_source = f'flattened tasks of (first flattened project {project_filter})'
         else:
-            task_source = 'flattened tasks'
+            # Build whose conditions for filters that OmniFocus can evaluate natively
+            whose_conditions = []
+            if not include_completed:
+                whose_conditions.append("completed is false")
+            if flagged_only:
+                whose_conditions.append("flagged is true")
+            if next_only:
+                whose_conditions.append("next is true")
+            if dropped_only:
+                whose_conditions.append("dropped is true")
+            if blocked_only:
+                whose_conditions.append("blocked is true")
+            if overdue:
+                whose_conditions.append("due date < (current date)")
+            if query:
+                query_escaped = self._escape_applescript_string(query)
+                whose_conditions.append(f'(name contains "{query_escaped}" or note contains "{query_escaped}")')
 
-        # Build completion filter
-        completion_check = "" if include_completed else """
+            if whose_conditions:
+                task_source = f'(flattened tasks whose {" and ".join(whose_conditions)})'
+            else:
+                task_source = 'flattened tasks'
+
+        # Build in-loop filter checks. These are skipped when 'whose' handles the filter
+        # natively (whose_active). Filters handled by whose: completed, flagged, next,
+        # dropped, blocked, overdue, query.
+        whose_active = len(whose_conditions) > 0 if not (task_id or parent_task_id or inbox_only or project_id) else False
+
+        # Completion filter — skip if whose already filters completed
+        completion_check = ""
+        if not include_completed and not whose_active:
+            completion_check = """
                         -- Skip completed tasks
                         if completed of t then
                             error "skip completed task"
                         end if"""
 
-        # Build flagged filter
-        flagged_check = "" if not flagged_only else """
+        # Flagged filter — skip if whose already filters flagged
+        flagged_check = ""
+        if flagged_only and not whose_active:
+            flagged_check = """
                         -- Skip non-flagged tasks
                         if not flagged of t then
                             error "skip non-flagged task"
                         end if"""
 
-        # Build dropped filter
-        dropped_check = "" if not dropped_only else """
+        # Dropped filter — skip if whose already filters dropped
+        dropped_check = ""
+        if dropped_only and not whose_active:
+            dropped_check = """
                         -- Skip non-dropped tasks
                         if not dropped of t then
                             error "skip non-dropped task"
                         end if"""
 
-        # Build blocked filter
-        blocked_check = "" if not blocked_only else """
+        # Blocked filter — skip if whose already filters blocked
+        blocked_check = ""
+        if blocked_only and not whose_active:
+            blocked_check = """
                         -- Skip non-blocked tasks
                         if not blocked of t then
                             error "skip non-blocked task"
                         end if"""
 
-        # Build next filter
-        next_check = "" if not next_only else """
+        # Next filter — skip if whose already filters next
+        next_check = ""
+        if next_only and not whose_active:
+            next_check = """
                         -- Skip non-next tasks
                         if not next of t then
                             error "skip non-next task"
@@ -1780,8 +1816,10 @@ class OmniFocusConnector:
                             end if
                         end try"""
 
-        # Build overdue filter
-        overdue_check = "" if not overdue else """
+        # Overdue filter — skip if whose already filters by due date
+        overdue_check = ""
+        if overdue and not whose_active:
+            overdue_check = """
                         -- Skip non-overdue tasks
                         try
                             set taskDueDate to due date of t
@@ -1958,10 +1996,9 @@ class OmniFocusConnector:
                         end if''')
             tag_check = "".join(tag_checks)
 
-        # Build query filter (AppleScript-side name/note matching)
-        # AppleScript's 'contains' is case-insensitive by default
+        # Query filter — skip if whose already filters by name/note contains
         query_check = ""
-        if query:
+        if query and not whose_active:
             query_escaped = self._escape_applescript_string(query)
             query_check = f"""
                         -- Skip tasks not matching query (AppleScript contains is case-insensitive)

--- a/tests/test_conditional_filter_optimization.py
+++ b/tests/test_conditional_filter_optimization.py
@@ -122,25 +122,21 @@ class TestFilterDetectionLogic:
             script = mock_run.call_args[0][0]
             self._check_filter_first_mode(script)
 
-    def test_query_not_selective(self, client):
-        """Test that query uses extract-then-filter mode.
-
-        Query filtering performs equivalently in Python vs AppleScript (see #172),
-        so we don't use filter-first architecture for query parameter.
-        """
+    def test_query_is_selective(self, client):
+        """Test that query triggers filter-first mode (uses whose clause)."""
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = '[]'
             client.get_tasks(query="test")
             script = mock_run.call_args[0][0]
-            self._check_extract_then_filter_mode(script)
+            self._check_filter_first_mode(script)
 
-    def test_available_only_not_selective(self, client):
-        """Test that available_only uses extract-then-filter mode (inclusive)."""
+    def test_available_only_is_selective(self, client):
+        """Test that available_only triggers filter-first mode."""
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = '[]'
             client.get_tasks(available_only=True)
             script = mock_run.call_args[0][0]
-            self._check_extract_then_filter_mode(script)
+            self._check_filter_first_mode(script)
 
     def test_include_completed_not_selective(self, client):
         """Test that include_completed uses extract-then-filter mode (inclusive)."""

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -304,9 +304,9 @@ class TestGetTasks:
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = sample_tasks_json
             client.get_tasks(flagged_only=True)
-            # Verify flagged filter is in script
+            # Verify flagged filter uses whose clause
             call_args = mock_run.call_args[0][0]
-            assert "skip non-flagged task" in call_args
+            assert "flagged is true" in call_args
 
     def test_get_tasks_empty(self, client):
         """Test handling of empty tasks list."""
@@ -391,11 +391,9 @@ class TestGetTasks:
             tasks = client.get_tasks(dropped_only=True)
             assert len(tasks) == 1
             assert tasks[0]['dropped'] is True
-            # Verify the filter is in the script
+            # Verify dropped filter uses whose clause
             call_args = mock_run.call_args[0][0]
-            assert "dropped of t" in call_args
-            # Should skip non-dropped tasks
-            assert "skip" in call_args.lower() or "error" in call_args.lower()
+            assert "dropped is true" in call_args
 
     def test_get_tasks_includes_blocked_field(self, client):
         """Test that get_tasks includes the blocked field in the AppleScript and response."""
@@ -452,11 +450,9 @@ class TestGetTasks:
             tasks = client.get_tasks(blocked_only=True)
             assert len(tasks) == 1
             assert tasks[0]['blocked'] is True
-            # Verify the filter is in the script
+            # Verify blocked filter uses whose clause
             call_args = mock_run.call_args[0][0]
-            assert "blocked of t" in call_args
-            # Should skip non-blocked tasks
-            assert "skip" in call_args.lower() or "error" in call_args.lower()
+            assert "blocked is true" in call_args
 
     def test_get_tasks_available_only(self, client):
         """Test getting only available tasks (not deferred or blocked)."""
@@ -554,6 +550,92 @@ class TestGetTasks:
             mock_run.return_value = tasks_json
             tasks = client.get_tasks(tag_filter=["urgent", "work"])
             assert len(tasks) == 1
+
+
+class TestWhoseClauseOptimization:
+    """Tests that get_tasks uses 'whose' clauses for pre-filtering instead of manual iteration."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    @pytest.fixture
+    def sample_tasks_json(self):
+        return json.dumps([{
+            "id": "task-001", "name": "Test Task", "note": "", "completed": False,
+            "flagged": True, "dropped": False, "blocked": False, "next": True,
+            "projectId": "proj-001", "projectName": "Test Project",
+            "dueDate": "", "deferDate": "", "creationDate": None,
+            "modificationDate": None, "completionDate": None, "droppedDate": None,
+            "tags": [], "estimatedMinutes": None, "isRecurring": False,
+            "recurrence": "", "repetitionMethod": "", "parentTaskId": "",
+            "subtaskCount": 0, "sequential": False, "position": 1,
+            "numberOfAvailableTasks": 0, "available": True
+        }])
+
+    def test_flagged_uses_whose_clause(self, client, sample_tasks_json):
+        """flagged_only should use 'whose' with 'flagged is true' in task source."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(flagged_only=True)
+            script = mock_run.call_args[0][0]
+            assert "whose" in script
+            assert "flagged is true" in script
+
+    def test_next_uses_whose_clause(self, client, sample_tasks_json):
+        """next_only should use 'whose' with 'next is true' in task source."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(next_only=True)
+            script = mock_run.call_args[0][0]
+            assert "whose" in script
+            assert "next is true" in script
+
+    def test_query_uses_whose_clause(self, client, sample_tasks_json):
+        """query should use 'whose ... name contains' in task source."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(query="bench")
+            script = mock_run.call_args[0][0]
+            assert 'name contains "bench"' in script
+            assert 'note contains "bench"' in script
+            assert "whose" in script
+
+    def test_no_filter_uses_whose_completed_false(self, client, sample_tasks_json):
+        """No explicit filter should still use whose to exclude completed tasks."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks()
+            script = mock_run.call_args[0][0]
+            assert "whose completed is false" in script
+
+    def test_project_id_not_affected(self, client, sample_tasks_json):
+        """project_id filter should still use its existing fast path."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(project_id="proj-001")
+            script = mock_run.call_args[0][0]
+            assert 'whose id is "proj-001"' in script
+
+    def test_flagged_whose_excludes_completed(self, client, sample_tasks_json):
+        """flagged_only should combine whose with completed filter."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(flagged_only=True)
+            script = mock_run.call_args[0][0]
+            # Should combine both conditions in whose clause
+            assert "completed is false" in script
+            assert "flagged is true" in script
+
+    def test_overdue_uses_whose_clause(self, client, sample_tasks_json):
+        """overdue should use 'whose' with due date comparison."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(overdue=True)
+            script = mock_run.call_args[0][0]
+            # Should use whose for due date filtering
+            assert "whose" in script.lower()
+            assert "due date" in script
 
 
 class TestUpdateTask:


### PR DESCRIPTION
## Summary

- Use OmniFocus native `whose` clauses to pre-filter tasks before the expensive per-property extraction loop
- Filters implemented: flagged, overdue, next, dropped, blocked, completed (default), and query
- Redundant in-loop filter checks skipped when `whose` is active (`whose_active` flag)
- Updated profiling docs with before/after benchmark comparison

## Benchmark Results

| Operation | Before | After | Speedup |
|-----------|--------|-------|---------|
| `get_tasks(flagged)` | 18.9s | **6.3s** | **3.0x** |
| `get_tasks(overdue)` | 16.6s | **3.6s** | **4.6x** |
| `get_tasks(query='bench')` | 80.8s | **16.3s** | **5.0x** |
| `get_tasks(next)` | 41.9s | **29.3s** | **1.4x** |

Speedup is proportional to selectivity — fewer matching tasks = less time in property extraction.

## Test plan

- [x] 419 unit tests pass (7 new whose-clause tests + updated existing assertions)
- [x] Integration tests: 103 passed, 5 failed (all pre-existing, verified by stashing changes)
- [x] Benchmarks: 25 passed, 2 skipped (unfiltered/available timeouts — pre-existing)
- [x] Filter architecture tests updated (query and available_only now correctly marked as selective)

🤖 Generated with [Claude Code](https://claude.com/claude-code)