### PR TITLE
perf: batch subtask counts, fix test DB scripts, add OF automation reference

### DIFF
--- a/docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md
+++ b/docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md
@@ -1,0 +1,102 @@
+# OmniFocus Automation Notes
+
+Reference notes from reviewing OmniFocus automation documentation and AppleScript scripting dictionary.
+Sources: omni-automation.com, AppleScript `properties of` introspection.
+
+## Key Discovery: Batch-Readable Counting Properties
+
+These properties work with `a reference to` batch reads (one Apple Event for all tasks):
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `number of tasks` | Integer | Direct subtask count — **replaces per-task `count of (tasks of t)` IPC** |
+| `number of available tasks` | Integer | Available subtask count (already used) |
+| `number of completed tasks` | Integer | Completed subtask count |
+| `effectively completed` | Boolean | True if task or any ancestor is completed |
+| `effectively dropped` | Boolean | True if task or any ancestor is dropped |
+| `in inbox` | Boolean | Whether task is in inbox |
+
+**Impact:** `number of tasks` eliminates the dominant remaining per-task IPC bottleneck in batch mode (~17ms per task × N tasks).
+
+## Task Properties (Complete List from AppleScript)
+
+Verified via `properties of first flattened task`:
+
+### Scalar Properties
+- `id`, `name`, `note`, `class`
+- `flagged`, `completed`, `dropped`, `blocked`, `next`, `sequential`
+- `in inbox`, `effectively completed`, `effectively dropped`
+- `completed by children`
+
+### Date Properties
+- `creation date`, `modification date`, `completion date`, `dropped date`
+- `due date`, `defer date`, `planned date`
+- `effective due date`, `effective defer date`, `effective planned date`, `effective completed date`
+- `next due date`, `next defer date`, `next planned date`
+- `should use floating time zone`
+
+### Counting Properties
+- `number of tasks` (direct subtasks)
+- `number of available tasks`
+- `number of completed tasks`
+
+### Relationship Properties
+- `containing project` (Project ref)
+- `parent task` (Task ref)
+- `container` (Task/Project/Document ref)
+- `containing document` (Document ref)
+- `primary tag` (Tag ref or missing value)
+
+### Other
+- `estimated minutes` (Number or missing value)
+- `repetition rule` (RepetitionRule or missing value)
+- `repetition` (deprecated alias)
+
+## Task Object (OmniAutomation/JavaScript)
+
+From omni-automation.com/omnifocus/task.html:
+
+### Hierarchy Properties (not in AppleScript)
+- `hasChildren` (Boolean, r/o) — "more efficiently than checking if children is empty"
+- `children` (Array of Task, r/o) — direct child tasks
+- `flattenedTasks` (TaskArray, r/o) — all tasks recursively
+- `flattenedChildren` (TaskArray, r/o) — alias
+
+### Task.Status Enum
+- Available, Blocked, Completed, Dropped, DueSoon, Next, Overdue
+- Accessed via `taskStatus` property
+
+### Methods (OmniAutomation only)
+- `apply(function)` — recursive task tree iteration
+- `markComplete(date)`, `markIncomplete()`, `drop(allOccurrences)`
+- Tag operations: `addTag`, `addTags`, `removeTag`, `removeTags`, `clearTags`
+- `Task.byIdentifier(id)` — direct lookup
+- `Task.byParsingTransportText(text)` — create from text
+
+## Project Properties
+
+### Counting (computed per-project in current implementation)
+- No native `remainingCount`, `availableCount`, `overdueCount`, `deferredCount` properties
+- These must be computed from task iteration (our current approach)
+- Could potentially use batch reads on `flattened tasks of proj` per project
+
+### Status
+- `status` — Active, Done, Dropped, OnHold
+- `taskStatus` — inherited task status
+- `nextTask` (r/o) — next completable task
+- `lastReviewDate`, `nextReviewDate`
+
+## OmniAutomation vs AppleScript
+
+- OmniAutomation (JavaScript) runs inside OmniFocus, eliminating IPC overhead
+- **BUT** cannot return results to external callers (documented limitation)
+- AppleScript via `osascript` is the only option for external MCP servers
+- `a reference to` batch reads are the best AppleScript optimization available
+
+## Future Investigation
+
+- `taskStatus` enum could simplify availability calculations (Available, Blocked, etc.)
+  but need to verify it matches our current logic
+- `effective*` date properties (effectiveDueDate, effectiveDeferDate) might simplify
+  inherited date calculations
+- `planned date` (v4.7+) is a new property we don't currently expose

--- a/docs/reference/PERFORMANCE_PROFILING.md
+++ b/docs/reference/PERFORMANCE_PROFILING.md
@@ -262,8 +262,49 @@ The experiments used a larger, dirtier database (381 tasks, accumulated from pri
 
 ### Remaining per-task IPC in batch mode
 
-Two operations still require per-task IPC within the batch loop:
-1. **Subtask count**: `count of (tasks of t)` — cannot be batch-read (~17ms per task)
-2. **Repetition details**: `recurrence of repRuleVal`, `repetition method of repRuleVal` — only for tasks with rules (most have none)
+One operation still requires per-task IPC within the batch loop:
+- **Repetition details**: `recurrence of repRuleVal`, `repetition method of repRuleVal` — only for tasks with rules (most have none)
 
-For 150 tasks: 150 × 17ms = ~2.6s subtask count overhead. This is the dominant remaining cost.
+**Subtask count resolved:** Discovered `number of tasks` is a batch-readable property on task objects. Replaced per-task `count of (tasks of t)` IPC with batch `number of tasks of ft` — zero per-task IPC cost.
+
+## Apples-to-Apples Benchmark (batch + subtask fix, comparable dataset)
+
+Measured on clean benchmark dataset matching original profiling conditions.
+Test database: 32 projects, 191 tasks (14 flagged, 8 overdue, 27 next, 10 inbox), 10 tags, 4 folders.
+
+### get_tasks() — full comparison
+
+| Operation | Original | + whose (PR #196) | + batch + subtask fix | Total speedup |
+|-----------|----------|-------------------|-----------------------|---------------|
+| `get_tasks(flagged_only)` | 18.9s | 6.3s | **0.82s** | **23x** |
+| `get_tasks(overdue)` | 16.6s | 3.6s | **0.60s** | **28x** |
+| `get_tasks(next_only)` | 41.9s | 29.3s | **1.10s** | **38x** |
+| `get_tasks(query='bench')` | 80.8s | 16.3s | **2.00s** | **40x** |
+| `get_tasks(available_only)` | >120s | >120s | **5.79s** | **>20x** |
+| `get_tasks()` (unfiltered) | >120s | >120s | **5.70s** | **>21x** |
+| `get_tasks(inbox_only)` | 5.4s | 5.4s | **4.20s** | 1.3x |
+
+### get_projects()
+
+| Operation | Time | Overhead vs baseline |
+|-----------|------|---------------------|
+| `get_projects()` | 8.79s | baseline |
+| `get_projects(+task_health)` | 22.26s | +153% |
+| `get_projects(+last_activity)` | 14.11s | +60% |
+| `get_projects(all options)` | 27.63s | +214% |
+
+### Other reads
+
+| Operation | Time | Items |
+|-----------|------|-------|
+| `get_folders()` | 0.60s | 4 |
+| `get_tags()` | 0.96s | 24 |
+| `get_perspectives()` | 0.21s | 24 |
+
+### Analysis
+
+1. **`get_tasks()` is now fast across all filters.** The subtask count batch read eliminated the last per-task IPC bottleneck. Even `available_only` (previously >120s timeout) completes in under 6s.
+
+2. **`get_projects()` is now the primary bottleneck.** The task_health and last_activity nested loops iterate all tasks per project with per-task property reads. These could benefit from the same `a reference to` batch optimization.
+
+3. **Remaining per-task IPC:** Only repetition rule details (`recurrence`, `repetition method`) require per-task reads, and only for tasks with recurrence rules (typically few).

--- a/scripts/cleanup_test_data.sh
+++ b/scripts/cleanup_test_data.sh
@@ -4,6 +4,7 @@
 # Removes projects, tasks, tags, and folders created by:
 #   - scripts/setup_benchmark_data.sh (prefix: "Bench ", "bench-")
 #   - scripts/setup_test_database.sh (prefix: "Test ", "test-")
+#   - scripts/local/setup_profiling_data.sh (prefix: "Profile ", "Profiling ")
 #   - integration tests (prefix: "__bench_", "__test_")
 #
 # Prerequisites:
@@ -46,16 +47,16 @@ tell application "OmniFocus"
             end try
         end repeat
 
-        -- Delete test/benchmark folders (cascades to contained projects/tasks)
-        set testFolders to every flattened folder whose name starts with "Bench " or name starts with "Test "
+        -- Delete test/benchmark/profiling folders (cascades to contained projects/tasks)
+        set testFolders to every flattened folder whose name starts with "Bench " or name starts with "Test " or name starts with "Profile " or name starts with "Profiling "
         set folderCount to count of testFolders
         repeat with f in testFolders
             delete f
         end repeat
         set deletedCount to deletedCount + folderCount
 
-        -- Delete standalone test/benchmark projects (not in folders)
-        set testProjects to every flattened project whose name starts with "Bench " or name starts with "Test " or name starts with "__bench_" or name starts with "Active Test" or name starts with "On Hold Test" or name starts with "Completed Test" or name starts with "Standalone " or name starts with "Subfolder "
+        -- Delete standalone test/benchmark/profiling projects (not in folders)
+        set testProjects to every flattened project whose name starts with "Bench " or name starts with "Test " or name starts with "Profile " or name starts with "__bench_" or name starts with "Active Test" or name starts with "On Hold Test" or name starts with "Completed Test" or name starts with "Standalone " or name starts with "Subfolder "
         set projCount to count of testProjects
         repeat with p in testProjects
             delete p
@@ -63,7 +64,7 @@ tell application "OmniFocus"
         set deletedCount to deletedCount + projCount
 
         -- Delete test inbox tasks
-        set testInbox to every inbox task whose name starts with "Bench " or name starts with "Test " or name starts with "Inbox Task" or name starts with "__bench_"
+        set testInbox to every inbox task whose name starts with "Bench " or name starts with "Test " or name starts with "Profile " or name starts with "Inbox Task" or name starts with "__bench_"
         set inboxCount to count of testInbox
         repeat with t in testInbox
             delete t

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -2178,6 +2178,7 @@ class OmniFocusConnector:
                 set estMins to estimated minutes of ft
                 set repRules to repetition rule of ft
                 set availCounts to number of available tasks of ft
+                set subtaskCounts to number of tasks of ft
 
                 -- Nested batch reads (project, parent, tags)
                 set projIds to id of (containing project of ft)
@@ -2186,9 +2187,6 @@ class OmniFocusConnector:
                 set tagNameLists to name of (tags of ft)
 
                 set taskCount to count of ids
-
-                -- Dereference task list once for subtask count (avoids re-evaluating whose per iteration)
-                set taskList to contents of ft
 
                 -- Build JSON from parallel lists (local loop, minimal IPC)
                 repeat with i from 1 to taskCount
@@ -2290,11 +2288,8 @@ class OmniFocusConnector:
                             end try
                         end if
 
-                        -- Subtask count (per-task — cannot batch 'count of tasks')
-                        set taskSubtaskCount to 0
-                        try
-                            set taskSubtaskCount to count of (tasks of (item i of taskList))
-                        end try
+                        -- Subtask count (batch-read)
+                        set taskSubtaskCount to item i of subtaskCounts
 
                         -- Availability (computed from batch-read data)
                         set numAvailableTasks to item i of availCounts

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -734,6 +734,17 @@ class TestBatchPropertyExtraction:
             assert "a reference to" in script
             assert "id of ft" in script
 
+    def test_batch_uses_batch_subtask_count(self, client, sample_tasks_json):
+        """Batch mode should batch-read subtask counts, not per-task IPC."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(flagged_only=True)
+            script = mock_run.call_args[0][0]
+            # Should batch-read subtask counts before the loop
+            assert "number of tasks of ft" in script
+            # Should NOT use per-task count of tasks
+            assert "count of (tasks of" not in script
+
 
 class TestUpdateTask:
     """Tests for update_task functionality."""


### PR DESCRIPTION
## Summary
- **Batch subtask counts**: Replace per-task `count of (tasks of ...)` IPC with batch `number of tasks of ft` read, eliminating ~17ms × N tasks overhead
- **Fix test DB cleanup** (#198): Add "Profile"/"Profiling" prefixes to `cleanup_test_data.sh` so profiling data gets cleaned properly
- **OmniFocus automation reference**: New `docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md` documenting batch-readable properties, task/project API surface, and OmniAutomation vs AppleScript comparison
- **Benchmark results**: Updated `PERFORMANCE_PROFILING.md` with apples-to-apples benchmarks on standardized ~200 task dataset

## Test plan
- [x] 428 unit tests pass (0 failures)
- [x] 103/108 integration tests pass (5 pre-existing failures)
- [x] New test `test_batch_uses_batch_subtask_count` verifies batch mode uses `number of tasks of ft` instead of per-task IPC

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)