### PR TITLE
fix: AppleScript injection gaps, server error handling, dead code

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -743,7 +743,8 @@ class OmniFocusConnector:
         # Build project source (specific project or all projects)
         # NEW (Phase 3.2): project_id parameter
         if project_id:
-            project_source = f'(flattened projects whose id is "{project_id}")'
+            project_id_escaped = self._escape_applescript_string(project_id)
+            project_source = f'(flattened projects whose id is "{project_id_escaped}")'
         else:
             project_source = 'flattened projects'
 
@@ -1105,118 +1106,6 @@ class OmniFocusConnector:
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error creating project: {e.stderr}")
 
-    def _build_project_update_commands(
-        self,
-        sequential: Optional[bool] = None,
-        status: Optional[Union['ProjectStatus', str]] = None,
-        review_interval_weeks: Optional[int] = None,
-        last_reviewed: Optional[str] = None,
-        next_review_date: Optional[str] = None,
-        folder_path: Optional[str] = None,
-    ) -> tuple[list[str], list[str], list[str]]:
-        """Build AppleScript command fragments for project updates.
-
-        Shared by update_project() and update_projects() to avoid duplicating
-        the command-building logic. Excludes project_name and note
-        (single-project-only fields).
-
-        Returns:
-            tuple of (properties, separate_commands, updated_fields)
-        """
-        properties = []
-        separate_commands = []
-        updated_fields = []
-
-        if sequential is not None:
-            properties.append(f'sequential:{str(sequential).lower()}')
-            updated_fields.append("sequential")
-
-        # Validate and normalize status
-        if status is not None:
-            if isinstance(status, ProjectStatus):
-                status_str = status.value
-            elif isinstance(status, str):
-                valid_statuses = ["active", "on_hold", "done", "dropped"]
-                if status.lower() not in valid_statuses:
-                    raise ValueError(f"Invalid status: {status}. Must be one of: {', '.join(valid_statuses)}")
-                status_str = status.lower()
-            else:
-                raise ValueError(f"status must be ProjectStatus enum or string, got {type(status)}")
-
-            if status_str == "done":
-                separate_commands.append("mark complete theProject")
-            else:
-                status_map = {
-                    "active": "active",
-                    "on_hold": "on hold",
-                    "dropped": "dropped"
-                }
-                of_status = status_map[status_str]
-                separate_commands.append(f'set status of theProject to {of_status}')
-            updated_fields.append("status")
-
-        if review_interval_weeks is not None:
-            separate_commands.append(
-                f'set review interval of theProject to {{unit:week, steps:{review_interval_weeks}, fixed:true}}'
-            )
-            updated_fields.append("review_interval_weeks")
-
-        if last_reviewed is not None:
-            if last_reviewed.lower() == "now" or last_reviewed == "":
-                separate_commands.append('set last review date of theProject to (current date)')
-            else:
-                separate_commands.append(f'set last review date of theProject to date "{last_reviewed}"')
-            updated_fields.append("last_reviewed")
-
-        if next_review_date is not None:
-            separate_commands.append(f'set next review date of theProject to date "{next_review_date}"')
-            updated_fields.append("next_review_date")
-
-        if folder_path is not None:
-            folder_parts = [part.strip() for part in folder_path.split('>')]
-            if len(folder_parts) == 1:
-                folder_escaped = self._escape_applescript_string(folder_parts[0])
-                separate_commands.append(f'''
-                    set targetFolder to first folder whose name is "{folder_escaped}"
-                    move theProject to end of projects of targetFolder''')
-            else:
-                folder_names_list = ', '.join(f'"{self._escape_applescript_string(p)}"' for p in folder_parts)
-                separate_commands.append(f'''
-                    set folderNames to {{{folder_names_list}}}
-                    set targetFolder to missing value
-                    repeat with i from 1 to count of folderNames
-                        set folderName to item i of folderNames
-                        if i is 1 then
-                            repeat with f in folders
-                                if name of f is folderName then
-                                    set targetFolder to f
-                                    exit repeat
-                                end if
-                            end repeat
-                        else
-                            if targetFolder is not missing value then
-                                set found to false
-                                repeat with f in folders of targetFolder
-                                    if name of f is folderName then
-                                        set targetFolder to f
-                                        set found to true
-                                        exit repeat
-                                    end if
-                                end repeat
-                                if not found then
-                                    error "Folder path not found: {folder_path}"
-                                end if
-                            end if
-                        end if
-                    end repeat
-                    if targetFolder is missing value then
-                        error "Folder path not found: {folder_path}"
-                    end if
-                    move theProject to end of projects of targetFolder''')
-            updated_fields.append("folder_path")
-
-        return properties, separate_commands, updated_fields
-
     def update_project(
         self,
         project_id: str,
@@ -1518,6 +1407,11 @@ class OmniFocusConnector:
                 "updated_ids": list[str],  # IDs of successfully updated projects
                 "failures": [{"project_id": str, "error": str}, ...]  # Failed updates with errors
             }
+
+        Note:
+            ``updated_ids`` is approximate on partial failure — it lists
+            the first N IDs from the input, not necessarily the ones that
+            succeeded.
 
         Raises:
             ValueError: If project_name or note parameters are provided, or no fields to update
@@ -2085,14 +1979,17 @@ class OmniFocusConnector:
         # OmniFocus evaluates 'whose' clauses natively (~20-30x faster than
         # manual iteration with per-task property checks). See PERFORMANCE_PROFILING.md.
         if task_id:
-            task_source = f'(flattened tasks whose id is "{task_id}")'
+            task_id_escaped = self._escape_applescript_string(task_id)
+            task_source = f'(flattened tasks whose id is "{task_id_escaped}")'
         elif parent_task_id:
-            parent_filter = f'whose id is "{parent_task_id}"'
+            parent_id_escaped = self._escape_applescript_string(parent_task_id)
+            parent_filter = f'whose id is "{parent_id_escaped}"'
             task_source = f'tasks of (first flattened task {parent_filter})'
         elif inbox_only:
             task_source = 'inbox tasks'
         elif project_id:
-            project_filter = f'whose id is "{project_id}"'
+            project_id_escaped = self._escape_applescript_string(project_id)
+            project_filter = f'whose id is "{project_id_escaped}"'
             task_source = f'flattened tasks of (first flattened project {project_filter})'
         else:
             # Build whose conditions for filters that OmniFocus can evaluate natively
@@ -2352,7 +2249,7 @@ class OmniFocusConnector:
             # Build AppleScript to check for all required tags (AND logic)
             tag_checks = []
             for tag_name in tag_filter:
-                tag_escaped = tag_name.replace('"', '\\"')
+                tag_escaped = self._escape_applescript_string(tag_name)
                 tag_checks.append(f'''
                         -- Check for tag: {tag_escaped}
                         set hasTag to false
@@ -2502,7 +2399,7 @@ class OmniFocusConnector:
         if tag_filter and len(tag_filter) > 0 and tag_filter_mode == "and":
             tag_checks_batch = []
             for tag_name in tag_filter:
-                tag_escaped = tag_name.replace('"', '\\"')
+                tag_escaped = self._escape_applescript_string(tag_name)
                 tag_checks_batch.append(f'''
                         set hasTag to false
                         set taskTagNames to contents of (item i of tagNameLists)
@@ -3057,170 +2954,6 @@ class OmniFocusConnector:
             raise Exception(f"Error parsing OmniFocus task output: {e}")
 
 
-    def _build_date_command(self, date_value: str, property_name: str) -> str:
-        """Build an AppleScript command to set or clear a date property.
-
-        Args:
-            date_value: ISO 8601 date string, or "" to clear.
-            property_name: AppleScript property name (e.g., "due date", "defer date").
-
-        Returns:
-            AppleScript command string.
-        """
-        if date_value == "":
-            return f"set {property_name} of theTask to missing value"
-        as_date = self._iso_to_applescript_date(date_value)
-        return f'set {property_name} of theTask to date "{as_date}"'
-
-    def _build_tag_commands(
-        self,
-        tags: Optional[list[str]],
-        add_tags: Optional[list[str]],
-        remove_tags: Optional[list[str]],
-    ) -> tuple[list[str], list[str]]:
-        """Build AppleScript commands for tag operations.
-
-        Args:
-            tags: Full replacement tag list, or None.
-            add_tags: Tags to add incrementally, or None.
-            remove_tags: Tags to remove, or None.
-
-        Returns:
-            tuple of (commands, updated_fields).
-        """
-        commands = []
-        updated_fields = []
-
-        if tags is not None:
-            if len(tags) > 0:
-                tag_adds = []
-                for tag in tags:
-                    tag_escaped = self._escape_applescript_string(tag)
-                    tag_adds.append(f'''
-                        set tagObj to first flattened tag whose name is "{tag_escaped}"
-                        copy tagObj to end of newTags''')
-                tag_adds_str = "\n                    ".join(tag_adds)
-                commands.append(f'''
-                    set newTags to {{}}
-                    {tag_adds_str}
-                    set tags of theTask to newTags''')
-            else:
-                commands.append("set tags of theTask to {}")
-            updated_fields.append("tags")
-
-        if add_tags is not None:
-            for tag in add_tags:
-                tag_escaped = self._escape_applescript_string(tag)
-                commands.append(f'''
-                    set tagObj to first flattened tag whose name is "{tag_escaped}"
-                    add tagObj to tags of theTask''')
-            updated_fields.append("add_tags")
-
-        if remove_tags is not None:
-            for tag in remove_tags:
-                tag_escaped = self._escape_applescript_string(tag)
-                commands.append(f'''
-                    set tagObj to first flattened tag whose name is "{tag_escaped}"
-                    remove tagObj from tags of theTask''')
-            updated_fields.append("remove_tags")
-
-        return commands, updated_fields
-
-    def _build_task_update_commands(
-        self,
-        flagged: Optional[bool] = None,
-        status: Optional[Union['TaskStatus', str]] = None,
-        completed: Optional[bool] = None,
-        project_id: Optional[str] = None,
-        parent_task_id: Optional[str] = None,
-        tags: Optional[list[str]] = None,
-        add_tags: Optional[list[str]] = None,
-        remove_tags: Optional[list[str]] = None,
-        due_date: Optional[str] = None,
-        defer_date: Optional[str] = None,
-        estimated_minutes: Optional[int] = None,
-    ) -> tuple[list[str], list[str], list[str]]:
-        """Build AppleScript command fragments for task updates.
-
-        Shared by update_task() and update_tasks() to avoid duplicating
-        the command-building logic. Excludes task_name, note, and recurrence
-        (single-task-only fields).
-
-        Args:
-            All fields from update_tasks() batch signature.
-
-        Returns:
-            tuple of (properties, separate_commands, updated_fields):
-                - properties: list of "key:value" for set properties of theTask
-                - separate_commands: list of AppleScript command strings
-                - updated_fields: list of field names that were set
-        """
-        properties = []
-        separate_commands = []
-        updated_fields = []
-
-        # Validate and normalize status
-        if status is not None:
-            if isinstance(status, str):
-                status = TaskStatus(status)
-
-        if flagged is not None:
-            properties.append(f'flagged:{str(flagged).lower()}')
-            updated_fields.append("flagged")
-
-        if due_date is not None:
-            separate_commands.append(self._build_date_command(due_date, "due date"))
-            updated_fields.append("due_date")
-
-        if defer_date is not None:
-            separate_commands.append(self._build_date_command(defer_date, "defer date"))
-            updated_fields.append("defer_date")
-
-        if estimated_minutes is not None:
-            separate_commands.append(f'set estimated minutes of theTask to {estimated_minutes}')
-            updated_fields.append("estimated_minutes")
-
-        # Handle completion (use "mark complete" for recurring task safety)
-        if completed is not None:
-            if completed:
-                separate_commands.append("mark complete theTask")
-            else:
-                separate_commands.append("set completed of theTask to false")
-            updated_fields.append("completed")
-
-        # Handle status (use "mark dropped" command)
-        if status is not None:
-            if status == TaskStatus.DROPPED:
-                separate_commands.append("mark dropped theTask")
-            elif status == TaskStatus.ACTIVE:
-                separate_commands.append("set dropped of theTask to false")
-            updated_fields.append("status")
-
-        # Handle hierarchy changes
-        if project_id is not None:
-            project_id_escaped = self._escape_applescript_string(project_id)
-            separate_commands.append(f'''
-                    set theProject to first flattened project whose id is "{project_id_escaped}"
-                    move theTask to end of tasks of theProject''')
-            updated_fields.append("project_id")
-
-        if parent_task_id is not None:
-            parent_id_escaped = self._escape_applescript_string(parent_task_id)
-            separate_commands.append(f'''
-                    set theParent to first flattened task whose id is "{parent_id_escaped}"
-                    if id of theTask is id of theParent then
-                        error "Cannot set task as its own parent"
-                    end if
-                    move theTask to end of tasks of theParent''')
-            updated_fields.append("parent_task_id")
-
-        # Handle tags
-        tag_commands, tag_fields = self._build_tag_commands(tags, add_tags, remove_tags)
-        separate_commands.extend(tag_commands)
-        updated_fields.extend(tag_fields)
-
-        return properties, separate_commands, updated_fields
-
     def update_task(
         self,
         task_id: str,
@@ -3608,6 +3341,11 @@ class OmniFocusConnector:
                 "failures": list[dict] with "task_id" and "error"
             }
 
+        Note:
+            ``updated_ids`` is approximate on partial failure — it lists
+            the first N IDs from the input, not necessarily the ones that
+            succeeded.
+
         Raises:
             ValueError: If validation fails (task_name/note provided, conflicting params, etc.)
 
@@ -3949,7 +3687,7 @@ class OmniFocusConnector:
             raise ValueError("task_ids cannot be empty")
 
         # Build AppleScript list of task IDs
-        ids_list = ", ".join([f'"{task_id}"' for task_id in ids_list_input])
+        ids_list = ", ".join([f'"{self._escape_applescript_string(task_id)}"' for task_id in ids_list_input])
 
         script = f'''
         tell application "OmniFocus"
@@ -4030,7 +3768,7 @@ class OmniFocusConnector:
             raise ValueError("project_ids cannot be empty")
 
         # Build AppleScript list of project IDs
-        ids_list = ", ".join([f'"{project_id}"' for project_id in ids_list_data])
+        ids_list = ", ".join([f'"{self._escape_applescript_string(project_id)}"' for project_id in ids_list_data])
 
         script = f'''
         tell application "OmniFocus"
@@ -4179,7 +3917,7 @@ class OmniFocusConnector:
                 tell application "OmniFocus"
                     tell front document
                         try
-                            set parentFolder to first folder whose name is "{parts[0]}"
+                            set parentFolder to first folder whose name is "{self._escape_applescript_string(parts[0])}"
                             set newFolder to make new folder at end of folders of parentFolder with properties {{name:"{name_escaped}"}}
                             return id of newFolder
                         on error errMsg
@@ -4190,9 +3928,9 @@ class OmniFocusConnector:
                 '''
             else:
                 # Nested parent path
-                folder_navigation = f'first folder whose name is "{parts[0]}"'
+                folder_navigation = f'first folder whose name is "{self._escape_applescript_string(parts[0])}"'
                 for part in parts[1:]:
-                    folder_navigation = f'first folder of ({folder_navigation}) whose name is "{part}"'
+                    folder_navigation = f'first folder of ({folder_navigation}) whose name is "{self._escape_applescript_string(part)}"'
 
                 script = f'''
                 tell application "OmniFocus"
@@ -4252,8 +3990,8 @@ class OmniFocusConnector:
         tell application "OmniFocus"
             tell front document
                 try
-                    set theTask to first flattened task whose id is "{task_id}"
-                    set refTask to first flattened task whose id is "{reference_task_id}"
+                    set theTask to first flattened task whose id is "{self._escape_applescript_string(task_id)}"
+                    set refTask to first flattened task whose id is "{self._escape_applescript_string(reference_task_id)}"
 
                     -- Move task to before/after reference task
                     move theTask to {position} refTask

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -139,6 +139,10 @@ def _format_project(proj: dict, truncate_notes: bool = True) -> str:
         else:
             result += "Health: Stuck\n"
 
+    # Last activity (when include_last_activity=True)
+    if proj.get('lastActivityDate'):
+        result += f"Last Activity: {proj['lastActivityDate']}\n"
+
     return result
 
 
@@ -172,14 +176,17 @@ def get_projects(
         Formatted text with project list (one per line with ID, name, folder, status, and note preview)
     """
     client = get_client()
-    projects = client.get_projects(
-        project_id=project_id,
-        include_full_notes=include_full_notes,
-        on_hold_only=on_hold_only,
-        query=query,
-        include_task_health=include_task_health,
-        include_last_activity=include_last_activity,
-    )
+    try:
+        projects = client.get_projects(
+            project_id=project_id,
+            include_full_notes=include_full_notes,
+            on_hold_only=on_hold_only,
+            query=query,
+            include_task_health=include_task_health,
+            include_last_activity=include_last_activity,
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     if not projects:
         if query:
@@ -219,13 +226,16 @@ def create_project(
         Success message with project ID and configuration details
     """
     client = get_client()
-    project_id = client.create_project(
-        name=name,
-        note=note,
-        folder_path=folder_path,
-        sequential=sequential,
-        review_interval_weeks=review_interval_weeks
-    )
+    try:
+        project_id = client.create_project(
+            name=name,
+            note=note,
+            folder_path=folder_path,
+            sequential=sequential,
+            review_interval_weeks=review_interval_weeks
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     result = f"Successfully created project '{name}'"
     result += f"\nProject ID: {project_id}"
@@ -294,16 +304,19 @@ def update_project(
                 return f"Error: Invalid sequential value '{sequential}'. Must be 'true' or 'false'."
 
     client = get_client()
-    result = client.update_project(
-        project_id=project_id,
-        project_name=project_name,
-        folder_path=folder_path,
-        note=note,
-        sequential=sequential_bool,
-        status=status,
-        review_interval_weeks=review_interval_weeks,
-        last_reviewed=last_reviewed
-    )
+    try:
+        result = client.update_project(
+            project_id=project_id,
+            project_name=project_name,
+            folder_path=folder_path,
+            note=note,
+            sequential=sequential_bool,
+            status=status,
+            review_interval_weeks=review_interval_weeks,
+            last_reviewed=last_reviewed
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     # Handle dict return from client
     if result["success"]:
@@ -456,22 +469,25 @@ def get_tasks(
         Formatted text with task list including ID, name, project, due date, tags, and completion status
     """
     client = get_client()
-    tasks = client.get_tasks(
-        task_id=task_id,
-        parent_task_id=parent_task_id,
-        include_full_notes=include_full_notes,
-        project_id=project_id,
-        flagged_only=flagged_only,
-        include_completed=include_completed,
-        available_only=available_only,
-        overdue=overdue,
-        dropped_only=dropped_only,
-        blocked_only=blocked_only,
-        next_only=next_only,
-        tag_filter=tag_filter,
-        query=query,
-        inbox_only=inbox_only
-    )
+    try:
+        tasks = client.get_tasks(
+            task_id=task_id,
+            parent_task_id=parent_task_id,
+            include_full_notes=include_full_notes,
+            project_id=project_id,
+            flagged_only=flagged_only,
+            include_completed=include_completed,
+            available_only=available_only,
+            overdue=overdue,
+            dropped_only=dropped_only,
+            blocked_only=blocked_only,
+            next_only=next_only,
+            tag_filter=tag_filter,
+            query=query,
+            inbox_only=inbox_only
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     if not tasks:
         if query:
@@ -547,19 +563,20 @@ def create_task(
         except json.JSONDecodeError as e:
             return f"Error: Invalid JSON for tags parameter: {e}"
 
-    # Validation errors should raise immediately (before calling client)
-    # This allows MCP to report them properly
-    task_id = client.create_task(
-        task_name=task_name,
-        project_id=project_id,
-        parent_task_id=parent_task_id,
-        note=note,
-        due_date=due_date,
-        defer_date=defer_date,
-        flagged=flagged,
-        tags=tags_list,
-        estimated_minutes=estimated_minutes
-    )
+    try:
+        task_id = client.create_task(
+            task_name=task_name,
+            project_id=project_id,
+            parent_task_id=parent_task_id,
+            note=note,
+            due_date=due_date,
+            defer_date=defer_date,
+            flagged=flagged,
+            tags=tags_list,
+            estimated_minutes=estimated_minutes
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     # Build human-readable response
     if parent_task_id:
@@ -647,23 +664,26 @@ def update_task(
         task_name = name
 
     client = get_client()
-    result = client.update_task(
-        task_id=task_id,
-        task_name=task_name,
-        project_id=project_id,
-        parent_task_id=parent_task_id,
-        note=note,
-        due_date=due_date,
-        defer_date=defer_date,
-        flagged=flagged,
-        tags=tags,
-        add_tags=add_tags,
-        remove_tags=remove_tags,
-        estimated_minutes=estimated_minutes,
-        completed=completed,
-        status=status,
-        name=name  # Pass to client for its own backward compat handling
-    )
+    try:
+        result = client.update_task(
+            task_id=task_id,
+            task_name=task_name,
+            project_id=project_id,
+            parent_task_id=parent_task_id,
+            note=note,
+            due_date=due_date,
+            defer_date=defer_date,
+            flagged=flagged,
+            tags=tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+            estimated_minutes=estimated_minutes,
+            completed=completed,
+            status=status,
+            name=name  # Pass to client for its own backward compat handling
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     # Handle dict return from client (NEW API)
     if result["success"]:
@@ -729,20 +749,23 @@ def update_tasks(
         update_tasks(["task-001", "task-002", "task-003"], status="dropped")  # Drop multiple
     """
     client = get_client()
-    result = client.update_tasks(
-        task_ids=task_ids,
-        flagged=flagged,
-        status=status,
-        completed=completed,
-        project_id=project_id,
-        parent_task_id=parent_task_id,
-        tags=tags,
-        add_tags=add_tags,
-        remove_tags=remove_tags,
-        due_date=due_date,
-        defer_date=defer_date,
-        estimated_minutes=estimated_minutes
-    )
+    try:
+        result = client.update_tasks(
+            task_ids=task_ids,
+            flagged=flagged,
+            status=status,
+            completed=completed,
+            project_id=project_id,
+            parent_task_id=parent_task_id,
+            tags=tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+            due_date=due_date,
+            defer_date=defer_date,
+            estimated_minutes=estimated_minutes
+        )
+    except ValueError as e:
+        return f"Error: {str(e)}"
 
     # Handle dict return with counts
     updated_count = result["updated_count"]
@@ -838,6 +861,8 @@ def delete_tasks(task_ids: Union[str, list[str]]) -> str:
         else:
             # Partial success
             return f"Deleted {deleted_count} tasks successfully, {failed_count} failed"
+    except ValueError as e:
+        return f"Error: {str(e)}"
     except Exception as e:
         return f"Error deleting tasks: {str(e)}"
 
@@ -877,6 +902,8 @@ def delete_projects(project_ids: Union[str, list[str]]) -> str:
                 return f"Successfully deleted {deleted_count} projects"
         else:
             return f"Deleted {deleted_count} of {total_count} projects ({failed_count} failed)"
+    except ValueError as e:
+        return f"Error: {str(e)}"
     except Exception as e:
         return f"Error deleting projects: {str(e)}"
 

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -1261,148 +1261,6 @@ class TestSetFocus:
             mock_run.assert_called_once()
 
 
-class TestBuildTaskUpdateCommands:
-    """Tests for _build_task_update_commands() helper method."""
-
-    @pytest.fixture
-    def client(self):
-        return OmniFocusConnector(enable_safety_checks=False)
-
-    def test_flagged_returns_property(self, client):
-        """Flagged should produce a property, not a separate command."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            flagged=True
-        )
-        assert any("flagged:true" in p for p in properties)
-        assert "flagged" in updated_fields
-
-    def test_completed_true_uses_mark_complete(self, client):
-        """completed=True must use 'mark complete' for recurring task safety."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            completed=True
-        )
-        assert any("mark complete theTask" in cmd for cmd in separate_commands)
-        assert "completed" in updated_fields
-
-    def test_completed_false_uses_set_completed(self, client):
-        """completed=False should use 'set completed of theTask to false'."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            completed=False
-        )
-        assert any("set completed of theTask to false" in cmd for cmd in separate_commands)
-
-    def test_due_date_produces_separate_command(self, client):
-        """Due date should produce a separate command with converted date."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            due_date="2026-12-25"
-        )
-        assert any("set due date of theTask" in cmd for cmd in separate_commands)
-        assert any("December 25, 2026" in cmd for cmd in separate_commands)
-        assert "due_date" in updated_fields
-
-    def test_clear_due_date(self, client):
-        """Empty string due_date should set to missing value."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            due_date=""
-        )
-        assert any("missing value" in cmd for cmd in separate_commands)
-
-    def test_defer_date(self, client):
-        """Defer date should produce a separate command."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            defer_date="2026-12-20"
-        )
-        assert any("set defer date of theTask" in cmd for cmd in separate_commands)
-        assert "defer_date" in updated_fields
-
-    def test_estimated_minutes(self, client):
-        """Estimated minutes should produce a separate command."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            estimated_minutes=30
-        )
-        assert any("set estimated minutes of theTask to 30" in cmd for cmd in separate_commands)
-        assert "estimated_minutes" in updated_fields
-
-    def test_status_dropped(self, client):
-        """Dropped status should use 'mark dropped'."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            status="dropped"
-        )
-        assert any("mark dropped theTask" in cmd for cmd in separate_commands)
-        assert "status" in updated_fields
-
-    def test_status_active(self, client):
-        """Active status should unset dropped."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            status="active"
-        )
-        assert any("set dropped of theTask to false" in cmd for cmd in separate_commands)
-
-    def test_tags_replacement(self, client):
-        """Tags list should replace all tags."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            tags=["work", "urgent"]
-        )
-        cmds_str = "\n".join(separate_commands)
-        assert "work" in cmds_str
-        assert "urgent" in cmds_str
-        assert "tags" in updated_fields
-
-    def test_add_tags(self, client):
-        """add_tags should add tags incrementally."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            add_tags=["new-tag"]
-        )
-        cmds_str = "\n".join(separate_commands)
-        assert "add tagObj to tags of theTask" in cmds_str
-        assert "new-tag" in cmds_str
-        assert "add_tags" in updated_fields
-
-    def test_remove_tags(self, client):
-        """remove_tags should remove tags."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            remove_tags=["old-tag"]
-        )
-        cmds_str = "\n".join(separate_commands)
-        assert "remove tagObj from tags of theTask" in cmds_str
-        assert "old-tag" in cmds_str
-
-    def test_project_id_move(self, client):
-        """project_id should move task to project."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            project_id="proj-123"
-        )
-        cmds_str = "\n".join(separate_commands)
-        assert "proj-123" in cmds_str
-        assert "move theTask" in cmds_str
-        assert "project_id" in updated_fields
-
-    def test_parent_task_id(self, client):
-        """parent_task_id should move task under parent."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            parent_task_id="parent-001"
-        )
-        cmds_str = "\n".join(separate_commands)
-        assert "parent-001" in cmds_str
-        assert "move theTask" in cmds_str
-        assert "parent_task_id" in updated_fields
-
-    def test_multiple_fields(self, client):
-        """Multiple fields should all appear in output."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands(
-            flagged=True, completed=True, estimated_minutes=45
-        )
-        assert "flagged" in updated_fields
-        assert "completed" in updated_fields
-        assert "estimated_minutes" in updated_fields
-
-    def test_no_fields_returns_empty(self, client):
-        """No fields should return empty lists."""
-        properties, separate_commands, updated_fields = client._build_task_update_commands()
-        assert properties == []
-        assert separate_commands == []
-        assert updated_fields == []
-
 
 class TestBatchUpdateTasks:
     """Tests for batched update_tasks() — or-chain optimization (#215).
@@ -1727,3 +1585,62 @@ class TestBuildWhoseOrChain:
     def test_escapes_ids(self, client):
         result = client._build_whose_or_chain(['a"b'], "flattened task")
         assert 'a\\"b' in result
+
+
+class TestIdEscapingInMethods:
+    """Verify _escape_applescript_string is applied to IDs in all methods."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_get_tasks_escapes_task_id(self, client):
+        """get_tasks() should escape task_id in whose clause."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "[]"
+            client.get_tasks(task_id='id"inject')
+            script = mock_run.call_args[0][0]
+            assert 'id\\"inject' in script
+            assert 'id"inject' not in script
+
+    def test_get_tasks_escapes_project_id(self, client):
+        """get_tasks() should escape project_id in whose clause."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "[]"
+            client.get_tasks(project_id='proj"bad')
+            script = mock_run.call_args[0][0]
+            assert 'proj\\"bad' in script
+
+    def test_get_projects_escapes_project_id(self, client):
+        """get_projects() should escape project_id in whose clause."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "[]"
+            client.get_projects(project_id='p"inject')
+            script = mock_run.call_args[0][0]
+            assert 'p\\"inject' in script
+
+    def test_delete_tasks_escapes_ids(self, client):
+        """delete_tasks() should escape IDs in the AppleScript list."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "1"
+            client.delete_tasks(['t"bad'])
+            script = mock_run.call_args[0][0]
+            assert 't\\"bad' in script
+            assert 't"bad' not in script
+
+    def test_delete_projects_escapes_ids(self, client):
+        """delete_projects() should escape IDs in the AppleScript list."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "1"
+            client.delete_projects(['p"bad'])
+            script = mock_run.call_args[0][0]
+            assert 'p\\"bad' in script
+
+    def test_reorder_task_escapes_ids(self, client):
+        """reorder_task() should escape task_id and reference_task_id."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            client.reorder_task(task_id='t"1', before_task_id='t"2')
+            script = mock_run.call_args[0][0]
+            assert 't\\"1' in script
+            assert 't\\"2' in script

--- a/tests/test_server_formatting.py
+++ b/tests/test_server_formatting.py
@@ -173,3 +173,26 @@ class TestProjectFormatting:
         result = _format_project(project, truncate_notes=False)
         assert f"Note: {long_note}" in result
         assert result.count("x") >= 300
+
+    def test_format_project_with_last_activity_date(self):
+        """Test formatting project with lastActivityDate."""
+        project = {
+            "id": "proj123",
+            "name": "Project",
+            "status": "active",
+            "lastActivityDate": "2026-03-05T14:30:00"
+        }
+
+        result = _format_project(project)
+        assert "Last Activity: 2026-03-05T14:30:00" in result
+
+    def test_format_project_without_last_activity_date(self):
+        """Test formatting project without lastActivityDate omits the line."""
+        project = {
+            "id": "proj123",
+            "name": "Project",
+            "status": "active",
+        }
+
+        result = _format_project(project)
+        assert "Last Activity" not in result

--- a/tests/test_server_redesign_create.py
+++ b/tests/test_server_redesign_create.py
@@ -3,7 +3,6 @@
 This file tests the MCP server layer for the NEW API (v1.0.0 redesign).
 Tests are written FIRST (TDD) before implementing server changes.
 """
-import pytest
 from unittest import mock
 
 # Import server module
@@ -146,7 +145,7 @@ class TestCreateTaskServerRedesign:
     # ========================================================================
 
     def test_create_task_handles_client_error(self):
-        """NEW API: Server handles client exceptions gracefully."""
+        """NEW API: Server handles client ValueError gracefully."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
             mock_client.create_task.side_effect = ValueError(
@@ -154,15 +153,16 @@ class TestCreateTaskServerRedesign:
             )
             mock_get_client.return_value = mock_client
 
-            with pytest.raises(ValueError) as exc_info:
-                create_task(
-                    task_name="Bad Task",
-                    project_id="proj-123",
-                    parent_task_id="task-parent"
-                )
+            result = create_task(
+                task_name="Bad Task",
+                project_id="proj-123",
+                parent_task_id="task-parent"
+            )
 
-            assert "project_id" in str(exc_info.value).lower()
-            assert "parent_task_id" in str(exc_info.value).lower()
+            assert isinstance(result, str)
+            assert "error" in result.lower()
+            assert "project_id" in result.lower()
+            assert "parent_task_id" in result.lower()
 
     # ========================================================================
     # Return Format
@@ -181,3 +181,18 @@ class TestCreateTaskServerRedesign:
             assert "task-new-id" in result
             # Should be human-readable, not just the ID
             assert len(result) > len("task-new-id")
+
+
+class TestCreateProjectServerRedesign:
+    """Tests for create_project() MCP tool ValueError handling."""
+
+    def test_create_project_handles_value_error(self):
+        """Server: create_project() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.side_effect = ValueError("Project name cannot be empty")
+            mock_get_client.return_value = mock_client
+
+            result = server.create_project(name="")
+            assert isinstance(result, str)
+            assert "error" in result.lower()

--- a/tests/test_server_redesign_delete.py
+++ b/tests/test_server_redesign_delete.py
@@ -3,7 +3,6 @@
 This file tests the MCP server layer for the NEW API (v1.0.0 redesign).
 Tests are written FIRST (TDD) before implementing server changes.
 """
-import pytest
 from unittest import mock
 
 # Import server module
@@ -11,6 +10,7 @@ import omnifocus_mcp.server_fastmcp as server
 
 # Extract function from FunctionTool wrapper
 delete_tasks = server.delete_tasks
+delete_projects = server.delete_projects
 
 
 class TestDeleteTasksServerRedesign:
@@ -120,3 +120,25 @@ class TestDeleteTasksServerRedesign:
             result = delete_tasks(["task-001", "task-002"])
 
             assert "0" in result or "no tasks" in result.lower() or "failed" in result.lower()
+
+    def test_delete_tasks_handles_value_error(self):
+        """Server: delete_tasks() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.delete_tasks.side_effect = ValueError("Empty task IDs")
+            mock_get_client.return_value = mock_client
+
+            result = delete_tasks([""])
+            assert isinstance(result, str)
+            assert "error" in result.lower()
+
+    def test_delete_projects_handles_value_error(self):
+        """Server: delete_projects() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.delete_projects.side_effect = ValueError("Empty project IDs")
+            mock_get_client.return_value = mock_client
+
+            result = delete_projects([""])
+            assert isinstance(result, str)
+            assert "error" in result.lower()

--- a/tests/test_server_redesign_get_projects.py
+++ b/tests/test_server_redesign_get_projects.py
@@ -1,5 +1,4 @@
 """Server tests for get_projects() enhancements (Phase 3.2)."""
-import pytest
 from unittest import mock
 import omnifocus_mcp.server_fastmcp as server
 
@@ -37,3 +36,15 @@ class TestGetProjectsServerEnhancements:
             call_kwargs = mock_client.get_projects.call_args[1]
             assert call_kwargs['include_full_notes'] is True
             assert isinstance(result, str)
+
+    def test_get_projects_handles_value_error(self):
+        """Server: get_projects() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.get_projects.side_effect = ValueError("Invalid date range")
+            mock_get_client.return_value = mock_client
+
+            result = server.get_projects()
+            assert isinstance(result, str)
+            assert "error" in result.lower()
+            assert "invalid date range" in result.lower()

--- a/tests/test_server_redesign_get_tasks.py
+++ b/tests/test_server_redesign_get_tasks.py
@@ -1,5 +1,4 @@
 """Server tests for get_tasks() enhancements (Phase 3.1)."""
-import pytest
 from unittest import mock
 import omnifocus_mcp.server_fastmcp as server
 
@@ -50,3 +49,15 @@ class TestGetTasksServerEnhancements:
             call_kwargs = mock_client.get_tasks.call_args[1]
             assert call_kwargs['include_full_notes'] is True
             assert isinstance(result, str)
+
+    def test_get_tasks_handles_value_error(self):
+        """Server: get_tasks() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.get_tasks.side_effect = ValueError("Invalid date filter")
+            mock_get_client.return_value = mock_client
+
+            result = server.get_tasks()
+            assert isinstance(result, str)
+            assert "error" in result.lower()
+            assert "invalid date filter" in result.lower()

--- a/tests/test_server_redesign_update.py
+++ b/tests/test_server_redesign_update.py
@@ -466,3 +466,25 @@ class TestUpdateTasksServerRedesign:
 
             assert "failed" in result.lower() or "Failed" in result
             assert "2" in result  # 2 failed
+
+    def test_update_task_handles_value_error(self):
+        """Server: update_task() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.side_effect = ValueError("Empty task_id")
+            mock_get_client.return_value = mock_client
+
+            result = update_task(task_id="", flagged=True)
+            assert isinstance(result, str)
+            assert "error" in result.lower()
+
+    def test_update_tasks_handles_value_error(self):
+        """Server: update_tasks() catches ValueError and returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tasks.side_effect = ValueError("task_name is not allowed")
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks(["task-001"], flagged=True)
+            assert isinstance(result, str)
+            assert "error" in result.lower()

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -172,14 +172,16 @@ class TestUpdateProjectServerRedesign:
             assert "not found" in result.lower() or "999" in result
 
     def test_update_project_handles_client_exception(self):
-        """Server: update_project() handles client exceptions."""
+        """Server: update_project() handles client ValueError gracefully."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
             mock_client.update_project.side_effect = ValueError("Invalid status")
             mock_get_client.return_value = mock_client
 
-            with pytest.raises(ValueError):
-                update_project(project_id="proj-001", status="invalid")
+            result = update_project(project_id="proj-001", status="invalid")
+            assert isinstance(result, str)
+            assert "error" in result.lower()
+            assert "invalid status" in result.lower()
 
     # ========================================================================
     # Response Format


### PR DESCRIPTION
## Summary

Fixes all issues identified in the full codebase review (#222):

- **ID escaping**: Applied `_escape_applescript_string()` to all IDs embedded in AppleScript (7 locations in `get_tasks`, `get_projects`, `delete_tasks`, `delete_projects`, `reorder_task`)
- **Path/tag escaping**: Escaped folder path components in `create_folder()` and replaced hand-rolled tag escaping with `_escape_applescript_string()` (2 locations)
- **Server ValueError handling**: Added `try/except ValueError` to 9 MCP tools that were missing it (`get_projects`, `get_tasks`, `create_project`, `create_task`, `update_project`, `update_task`, `update_tasks`, `delete_tasks`, `delete_projects`); fixed 2 existing tests that expected ValueError to propagate
- **lastActivityDate rendering**: Added to `_format_project()` output
- **Dead code removal**: Deleted 4 unused helper methods (`_build_date_command`, `_build_tag_commands`, `_build_task_update_commands`, `_build_project_update_commands`) and their 16 tests
- **Docstring update**: Documented `updated_ids` approximation limitation in `update_tasks()` and `update_projects()`

## Test plan

- [x] 486 unit tests passing (`make test`)
- [x] 108 integration tests passing (`make test-integration`)
- [x] Complexity check passing (`check_complexity.sh`)
- [x] Client-server parity passing (`check_client_server_parity.sh`)
- [ ] Verify no remaining unescaped ID interpolation: `grep -n 'whose id is "{' src/omnifocus_mcp/omnifocus_connector.py`

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)