### PR TITLE
release: v0.8.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.8.1 | **Tests:** 471 unit, 128 integration/E2E, 25 benchmark/profiling | **Coverage:** 89%
+**Version:** v0.8.2 | **Tests:** 486 unit, 128 integration/E2E, 25 benchmark/profiling | **Coverage:** 89%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-03-10
+
+### Fixed
+
+- **AppleScript injection hardening** (#222, #223)
+  - Applied `_escape_applescript_string()` to all IDs embedded in AppleScript (`get_tasks`, `get_projects`, `delete_tasks`, `delete_projects`, `reorder_task`)
+  - Escaped folder path components in `create_folder()` and tag names in `get_tasks()` tag filtering
+  - Added `ValueError` handling to 9 MCP server tools that were missing it
+
+### Changed
+
+- **Batch write or-chain optimization** (#215, #219)
+  - Applied `whose` or-chain pattern to `update_tasks()` and `update_projects()` bulk-settable fields
+  - Near-constant time (~0.25s) regardless of batch size for flagged, estimated_minutes, due_date, defer_date, completed
+
+- **Complexity refactoring** (#218, #220)
+  - Extracted `_build_date_command` and `_build_tag_commands` helpers from `_build_task_update_commands`
+  - Reduced cyclomatic complexity from CC 23 → CC 14
+
+### Removed
+
+- **Dead code cleanup** (#222, #223)
+  - Removed 4 unused helper methods: `_build_date_command`, `_build_tag_commands`, `_build_task_update_commands`, `_build_project_update_commands`
+  - Removed 16 associated dead code tests
+
+### Documentation
+
+- **Contribution policy** (#212, #221)
+  - Added CONTRIBUTING.md clarifying this is a personal project not accepting external contributions
+  - Added notice to README.md
+
 ## [0.8.1] - 2026-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MCP (Model Context Protocol) server that provides tools for interacting with 
 
 ## Features
 
-This server provides **17 comprehensive tools** for managing OmniFocus (v0.8.1 API):
+This server provides **17 comprehensive tools** for managing OmniFocus (v0.8.2 API):
 
 ### Project Management (5 tools)
 - **get_projects** - Get all projects with filtering (by ID, query, status) and optional full notes
@@ -37,7 +37,8 @@ This server provides **17 comprehensive tools** for managing OmniFocus (v0.8.1 A
 ### UI Navigation (1 tool)
 - **set_focus** - Focus on specific projects, folders, or tags in the OmniFocus UI
 
-**Key Changes in v0.8.1:**
+**Key Changes in v0.8.2:**
+- v0.8.2: AppleScript injection hardening, consistent server error handling, dead code removal, complexity refactoring
 - v0.8.1: 35x get_projects() performance optimization via batch AppleScript reads, tag filtering fix, integration test infrastructure improvements
 - v0.7.3: Performance benchmarks, release workflow automation, scripts audit, project review optimizations (task health, opt-in lastActivityDate, AppleScript query filter)
 - v0.7.2: CHANGELOG date validation, TaskPaper import for fixtures, performance optimization for get_tasks/get_projects, test fixture refactoring complete, test count synchronization
@@ -69,7 +70,7 @@ git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
 
 # Checkout latest stable release
-git checkout v0.8.1  # Or latest version from releases
+git checkout v0.8.2  # Or latest version from releases
 
 # Option 1: Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.8.1"
+version = "0.8.2"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Release v0.8.2

### Fixed
- AppleScript injection hardening — `_escape_applescript_string()` applied to all embedded IDs, folder paths, and tag names (#222, #223)
- `ValueError` handling added to 9 MCP server tools that were missing it

### Changed
- Batch write or-chain optimization for `update_tasks()`/`update_projects()` (#215, #219)
- Complexity refactoring: `_build_task_update_commands` CC 23 → 14 (#218, #220)

### Removed
- 4 dead helper methods and 16 associated tests (#222, #223)

### Documentation
- Contribution policy added (#212, #221)

---

**Merge strategy:** Use merge commit (not squash) to keep tag reachable from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)