### PR TITLE
feat: add create_tag tool (#226)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,14 +18,14 @@ make test-e2e              # End-to-end MCP tool tests (requires test DB)
 
 **Running the server:** `uv run python -m omnifocus_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (17 functions: 16 core + UI navigation)
+## API Surface (18 functions: 17 core + UI navigation)
 
 The API was consolidated from 40+ functions to 16 in October 2025. This is intentional — resist adding new functions.
 
 **Projects (5):** create_project, get_projects, update_project, update_projects, delete_projects
 **Tasks (6):** create_task, get_tasks, update_task, update_tasks, delete_tasks, reorder_task
 **Folders (2):** create_folder, get_folders
-**Tags (1):** get_tags
+**Tags (2):** create_tag, get_tags
 **Perspectives (2):** get_perspectives, switch_perspective
 **Navigation (1):** set_focus
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -104,7 +104,7 @@ class OmniFocusConnector:
     DESTRUCTIVE_OPERATIONS = {
         'create_task', 'update_task', 'update_tasks',
         'create_project', 'update_project', 'update_projects',
-        'create_folder', 'delete_tasks', 'delete_projects',
+        'create_folder', 'create_tag', 'delete_tasks', 'delete_projects',
         'reorder_task',
     }
 
@@ -3646,7 +3646,81 @@ class OmniFocusConnector:
         except json.JSONDecodeError as e:
             raise Exception(f"Error parsing tags output: {e}")
 
+    def create_tag(self, name: str, parent_tag: Optional[str] = None) -> str:
+        """Create a new tag in OmniFocus.
 
+        Args:
+            name: The name of the tag to create
+            parent_tag: Optional parent tag name for nesting (e.g., "Energy" to create "Energy : High")
+
+        Returns:
+            The ID of the created tag
+
+        Raises:
+            ValueError: If a tag with the same name already exists at the target level
+            Exception: If parent tag not found or creation fails
+        """
+        self._verify_database_safety('create_tag')
+
+        name_escaped = self._escape_applescript_string(name)
+
+        if parent_tag is None:
+            script = f'''
+            tell application "OmniFocus"
+                tell front document
+                    try
+                        set existingTag to first flattened tag whose name is "{name_escaped}"
+                        return "EXISTS: " & id of existingTag
+                    on error
+                        -- Tag doesn't exist, create it
+                    end try
+                    try
+                        set newTag to make new tag with properties {{name:"{name_escaped}"}}
+                        return id of newTag
+                    on error errMsg
+                        return "ERROR: " & errMsg
+                    end try
+                end tell
+            end tell
+            '''
+        else:
+            parent_escaped = self._escape_applescript_string(parent_tag)
+            script = f'''
+            tell application "OmniFocus"
+                tell front document
+                    try
+                        set parentTag to first flattened tag whose name is "{parent_escaped}"
+                    on error
+                        return "ERROR: Parent tag '{parent_escaped}' not found"
+                    end try
+                    -- Check if child tag already exists under parent
+                    try
+                        set existingChild to first tag of parentTag whose name is "{name_escaped}"
+                        return "EXISTS: " & id of existingChild
+                    on error
+                        -- Child doesn't exist, create it
+                    end try
+                    try
+                        set newTag to make new tag at end of tags of parentTag with properties {{name:"{name_escaped}"}}
+                        return id of newTag
+                    on error errMsg
+                        return "ERROR: " & errMsg
+                    end try
+                end tell
+            end tell
+            '''
+
+        try:
+            result = run_applescript(script)
+            result = result.strip()
+            if result.startswith("EXISTS:"):
+                tag_id = result[len("EXISTS:"):].strip()
+                raise ValueError(f"Tag '{name}' already exists (ID: {tag_id})")
+            if result.startswith("ERROR:"):
+                raise Exception(f"Error creating tag: {result[len('ERROR:'):]}")
+            return result
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Error creating tag: {e.stderr}")
 
 
     def delete_tasks(self, task_ids: Union[str, list[str]]) -> dict:

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -861,6 +861,39 @@ def get_tags() -> str:
     return result
 
 
+@mcp.tool()
+def create_tag(
+    name: str,
+    parent_tag: Optional[str] = None
+) -> str:
+    """Create a new tag in OmniFocus.
+
+    Tags (formerly 'contexts') represent contexts for doing work — location, tools,
+    energy level, people, or workflow states. Tags can be nested (e.g., create "High"
+    under parent "Energy" to get "Energy : High").
+
+    Args:
+        name: The name of the tag to create
+        parent_tag: Optional parent tag name for nesting (e.g., "Energy" to create
+            "Energy : High"). Parent tag must already exist.
+
+    Returns:
+        Success message with tag ID and name
+
+    Raises:
+        ValueError: If a tag with the same name already exists
+    """
+    client = get_client()
+    try:
+        tag_id = client.create_tag(name=name, parent_tag=parent_tag)
+    except ValueError as e:
+        return f"Error: {str(e)}"
+
+    result = f"Successfully created tag '{name}'\nTag ID: {tag_id}"
+    if parent_tag:
+        result += f"\nParent: {parent_tag}"
+
+    return result
 
 
 @mcp.tool()

--- a/tests/test_create_tag.py
+++ b/tests/test_create_tag.py
@@ -1,0 +1,134 @@
+"""Tests for create_tag MCP tool and connector method.
+
+Tests both the server layer (MCP tool) and the connector layer (AppleScript client).
+"""
+from unittest import mock
+
+import pytest
+
+import omnifocus_mcp.server_fastmcp as server
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+
+create_tag = server.create_tag
+
+
+class TestCreateTagServer:
+    """Tests for create_tag() MCP tool."""
+
+    def test_create_tag_success(self):
+        """Server creates tag and returns human-readable response."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.return_value = "tag-new-001"
+            mock_get_client.return_value = mock_client
+
+            result = create_tag(name="Automation")
+
+            mock_client.create_tag.assert_called_once_with(
+                name="Automation", parent_tag=None
+            )
+            assert "tag-new-001" in result
+            assert "Automation" in result
+            assert "Successfully created tag" in result
+
+    def test_create_tag_with_parent(self):
+        """Server creates nested tag under parent."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.return_value = "tag-new-002"
+            mock_get_client.return_value = mock_client
+
+            result = create_tag(name="High", parent_tag="Energy")
+
+            mock_client.create_tag.assert_called_once_with(
+                name="High", parent_tag="Energy"
+            )
+            assert "tag-new-002" in result
+            assert "High" in result
+            assert "Energy" in result
+
+    def test_create_tag_already_exists(self):
+        """Server returns error when tag already exists."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.side_effect = ValueError(
+                "Tag 'Work' already exists (ID: tag-existing-001)"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = create_tag(name="Work")
+
+            assert "Error" in result
+            assert "already exists" in result
+
+
+class TestCreateTagConnector:
+    """Tests for create_tag() connector method (AppleScript layer)."""
+
+    def test_create_tag_calls_applescript(self):
+        """Connector builds correct AppleScript for root-level tag creation."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "tag-abc-123"
+
+            client = OmniFocusConnector()
+            result = client.create_tag("Automation")
+
+            assert result == "tag-abc-123"
+            # Verify AppleScript was called
+            call_args = mock_run.call_args[0][0]
+            assert "make new tag" in call_args
+            assert "Automation" in call_args
+
+    def test_create_tag_with_parent_calls_applescript(self):
+        """Connector builds correct AppleScript for nested tag creation."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "tag-child-456"
+
+            client = OmniFocusConnector()
+            result = client.create_tag("High", parent_tag="Energy")
+
+            assert result == "tag-child-456"
+            call_args = mock_run.call_args[0][0]
+            assert "make new tag" in call_args
+            assert "Energy" in call_args
+            assert "High" in call_args
+
+    def test_create_tag_already_exists_raises_valueerror(self):
+        """Connector raises ValueError when tag already exists."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "EXISTS: tag-existing-001"
+
+            client = OmniFocusConnector()
+            with pytest.raises(ValueError, match="already exists"):
+                client.create_tag("Work")
+
+    def test_create_tag_error_raises_exception(self):
+        """Connector raises Exception on AppleScript error."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "ERROR: Some AppleScript error"
+
+            client = OmniFocusConnector()
+            with pytest.raises(Exception, match="Error creating tag"):
+                client.create_tag("BadTag")
+
+    def test_create_tag_escapes_special_characters(self):
+        """Connector escapes quotes in tag name."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "tag-escaped-789"
+
+            client = OmniFocusConnector()
+            result = client.create_tag('Tag with "quotes"')
+
+            assert result == "tag-escaped-789"
+            call_args = mock_run.call_args[0][0]
+            # Should contain escaped quotes
+            assert '\\"' in call_args or 'quotes' in call_args
+
+    def test_create_tag_parent_not_found(self):
+        """Connector raises Exception when parent tag doesn't exist."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "ERROR: Parent tag 'NonExistent' not found"
+
+            client = OmniFocusConnector()
+            with pytest.raises(Exception, match="Parent tag"):
+                client.create_tag("Child", parent_tag="NonExistent")


### PR DESCRIPTION
## Summary

- Add `create_tag(name, parent_tag=None)` to connector and server
- Root-level or nested tag creation (e.g., "High" under "Energy")
- Returns tag ID, raises ValueError if tag already exists
- 9 unit tests (server + connector layers)
- API surface: 17 → 18 functions

Also filed #230 (update_tag) and #231 (delete_tag) for full CRUD.

Closes #226

## Test plan

- [x] `make test` — 495 passed
- [x] `check_client_server_parity.sh` — 18 functions
- [ ] Integration test with real OmniFocus (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)