### PR TITLE
feat: add update_tag and delete_tags for full tag CRUD

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.8.2 | **Tests:** 486 unit, 128 integration/E2E, 25 benchmark/profiling | **Coverage:** 89%
+**Version:** v0.8.2 | **Tests:** 515 unit, 128 integration/E2E, 25 benchmark/profiling | **Coverage:** 89%
 
 ## Commands
 
@@ -18,14 +18,14 @@ make test-e2e              # End-to-end MCP tool tests (requires test DB)
 
 **Running the server:** `uv run python -m omnifocus_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (18 functions: 17 core + UI navigation)
+## API Surface (20 functions: 19 core + UI navigation)
 
 The API was consolidated from 40+ functions to 16 in October 2025. This is intentional — resist adding new functions.
 
 **Projects (5):** create_project, get_projects, update_project, update_projects, delete_projects
 **Tasks (6):** create_task, get_tasks, update_task, update_tasks, delete_tasks, reorder_task
 **Folders (2):** create_folder, get_folders
-**Tags (2):** create_tag, get_tags
+**Tags (4):** get_tags, create_tag, update_tag, delete_tags
 **Perspectives (2):** get_perspectives, switch_perspective
 **Navigation (1):** set_focus
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -104,8 +104,8 @@ class OmniFocusConnector:
     DESTRUCTIVE_OPERATIONS = {
         'create_task', 'update_task', 'update_tasks',
         'create_project', 'update_project', 'update_projects',
-        'create_folder', 'create_tag', 'delete_tasks', 'delete_projects',
-        'reorder_task',
+        'create_folder', 'create_tag', 'update_tag', 'delete_tasks',
+        'delete_projects', 'delete_tags', 'reorder_task',
     }
 
     def __init__(self, enable_safety_checks: bool = True):
@@ -3722,6 +3722,159 @@ class OmniFocusConnector:
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error creating tag: {e.stderr}")
 
+    def update_tag(
+        self,
+        tag_id: str,
+        name: Optional[str] = None,
+        active: Optional[bool] = None
+    ) -> dict:
+        """Update properties of an existing tag.
+
+        Args:
+            tag_id: The ID of the tag to update
+            name: New tag name (optional)
+            active: Whether the tag is active (optional). False puts the tag
+                on hold — tasks with on-hold tags are excluded from available
+                task queries.
+
+        Returns:
+            dict: {
+                "success": bool,
+                "tag_id": str,
+                "updated_fields": list[str],
+                "error": Optional[str]
+            }
+
+        Raises:
+            ValueError: If tag_id is empty or no fields provided
+            Exception: If tag not found or update fails
+        """
+        self._verify_database_safety('update_tag')
+
+        if not tag_id:
+            raise ValueError("tag_id is required")
+
+        all_fields = {"name": name, "active": active}
+        if all(v is None for v in all_fields.values()):
+            raise ValueError("At least one field must be provided to update")
+
+        tag_id_escaped = self._escape_applescript_string(tag_id)
+        updated_fields = []
+        set_lines = []
+
+        if name is not None:
+            name_escaped = self._escape_applescript_string(name)
+            set_lines.append(f'set name of theTag to "{name_escaped}"')
+            updated_fields.append("name")
+
+        if active is not None:
+            active_str = "true" if active else "false"
+            set_lines.append(f'set allows next action of theTag to {active_str}')
+            updated_fields.append("active")
+
+        set_block = "\n                        ".join(set_lines)
+        fields_json = ", ".join(f'\\"{f}\\"' for f in updated_fields)
+
+        script = f'''
+        tell application "OmniFocus"
+            tell front document
+                try
+                    set theTag to first flattened tag whose id is "{tag_id_escaped}"
+                on error
+                    return "ERROR: Tag not found"
+                end try
+                try
+                    {set_block}
+                    return "{{\\"success\\": true, \\"updated_fields\\": [{fields_json}]}}"
+                on error errMsg
+                    return "ERROR: " & errMsg
+                end try
+            end tell
+        end tell
+        '''
+
+        try:
+            result = run_applescript(script)
+            result = result.strip()
+            if result.startswith("ERROR:"):
+                raise Exception(f"Error updating tag: {result[len('ERROR:'):]}")
+            parsed = json.loads(result)
+            parsed["tag_id"] = tag_id
+            parsed["error"] = None
+            return parsed
+        except json.JSONDecodeError:
+            raise Exception(f"Error parsing update tag result: {result}")
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Error updating tag: {e.stderr}")
+
+    def delete_tags(self, tag_ids: Union[str, list[str]]) -> dict:
+        """Delete one or more tags from OmniFocus.
+
+        Args:
+            tag_ids: Single tag ID (str) or list of tag IDs to delete
+
+        Returns:
+            dict: {
+                "deleted_count": int,
+                "failed_count": int,
+                "deleted_ids": list[str],
+                "failures": list[dict]
+            }
+
+        Raises:
+            ValueError: If tag_ids is empty
+            Exception: If the operation fails
+        """
+        self._verify_database_safety('delete_tags')
+
+        if isinstance(tag_ids, str):
+            ids_list_input = [tag_ids]
+        else:
+            ids_list_input = tag_ids
+
+        if not ids_list_input:
+            raise ValueError("tag_ids cannot be empty")
+
+        ids_list = ", ".join([f'"{self._escape_applescript_string(tid)}"' for tid in ids_list_input])
+
+        script = f'''
+        tell application "OmniFocus"
+            tell front document
+                set tagIdList to {{{ids_list}}}
+                set successCount to 0
+
+                repeat with tagId in tagIdList
+                    try
+                        set theTag to first flattened tag whose id is tagId
+                        delete theTag
+                        set successCount to successCount + 1
+                    on error
+                        -- Tag not found, skip
+                    end try
+                end repeat
+
+                return successCount as text
+            end tell
+        end tell
+        '''
+
+        try:
+            result = run_applescript(script)
+            deleted_count = int(result.strip())
+            total_count = len(ids_list_input)
+            failed_count = total_count - deleted_count
+            deleted_ids = ids_list_input[:deleted_count] if deleted_count > 0 else []
+
+            return {
+                "deleted_count": deleted_count,
+                "failed_count": failed_count,
+                "deleted_ids": deleted_ids,
+                "failures": []
+            }
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Error deleting tags: {e.stderr}")
+        except ValueError as e:
+            raise Exception(f"Error parsing delete result: {e}")
 
     def delete_tasks(self, task_ids: Union[str, list[str]]) -> dict:
         """Delete multiple tasks from OmniFocus in a single operation.

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -897,6 +897,80 @@ def create_tag(
 
 
 @mcp.tool()
+def update_tag(
+    tag_id: str,
+    name: Optional[str] = None,
+    active: Optional[bool] = None
+) -> str:
+    """Update properties of an existing tag in OmniFocus.
+
+    Tags can be renamed or put on hold. Setting active=False puts a tag on hold —
+    tasks with on-hold tags are excluded from available task queries.
+
+    Args:
+        tag_id: The ID of the tag to update (from get_tags)
+        name: New tag name (optional)
+        active: Whether the tag is active (optional). False = on hold (tasks with
+            this tag become unavailable). True = active.
+
+    Returns:
+        Success message with updated fields, or error message
+    """
+    client = get_client()
+    try:
+        result = client.update_tag(tag_id=tag_id, name=name, active=active)
+
+        fields = ", ".join(result["updated_fields"])
+        return f"Successfully updated tag {tag_id}\nUpdated fields: {fields}"
+    except ValueError as e:
+        return f"Error: {str(e)}"
+    except Exception as e:
+        return f"Error updating tag: {str(e)}"
+
+
+@mcp.tool()
+def delete_tags(tag_ids: Union[str, list[str]]) -> str:
+    """Delete one or more tags from OmniFocus.
+
+    WARNING: This permanently deletes the tags. Tasks that had these tags will
+    lose the tag association but are not themselves deleted.
+
+    Args:
+        tag_ids: Single tag ID (str) or list of tag IDs to delete
+
+    Returns:
+        Summary of deleted tags with count and any errors encountered
+
+    Examples:
+        delete_tags("tag-123")  # Delete single tag
+        delete_tags(["tag-001", "tag-002"])  # Delete multiple
+    """
+    client = get_client()
+    try:
+        result = client.delete_tags(tag_ids)
+
+        deleted_count = result["deleted_count"]
+        failed_count = result["failed_count"]
+
+        if failed_count == 0:
+            if deleted_count == 1:
+                return "Successfully deleted 1 tag"
+            else:
+                return f"Successfully deleted {deleted_count} tags"
+        elif deleted_count == 0:
+            if failed_count == 1:
+                return "Failed to delete tag (not found or error)"
+            else:
+                return f"Failed to delete all {failed_count} tags"
+        else:
+            return f"Deleted {deleted_count} tags successfully, {failed_count} failed"
+    except ValueError as e:
+        return f"Error: {str(e)}"
+    except Exception as e:
+        return f"Error deleting tags: {str(e)}"
+
+
+@mcp.tool()
 def delete_tasks(task_ids: Union[str, list[str]]) -> str:
     """Delete multiple tasks from OmniFocus in a single operation (NEW API - Enhanced).
 

--- a/tests/test_delete_tags.py
+++ b/tests/test_delete_tags.py
@@ -1,0 +1,136 @@
+"""Tests for delete_tags MCP tool and connector method.
+
+Tests both the server layer (MCP tool) and the connector layer (AppleScript client).
+"""
+from unittest import mock
+
+import pytest
+
+import omnifocus_mcp.server_fastmcp as server
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+
+delete_tags = server.delete_tags
+
+
+class TestDeleteTagsServer:
+    """Tests for delete_tags() MCP tool."""
+
+    def test_delete_single_tag(self):
+        """Server deletes single tag and returns success message."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.delete_tags.return_value = {
+                "deleted_count": 1,
+                "failed_count": 0,
+                "deleted_ids": ["tag-001"],
+                "failures": [],
+            }
+            mock_get_client.return_value = mock_client
+
+            result = delete_tags(tag_ids="tag-001")
+
+            mock_client.delete_tags.assert_called_once_with("tag-001")
+            assert "Successfully deleted 1 tag" in result
+
+    def test_delete_multiple_tags(self):
+        """Server deletes multiple tags and returns count."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.delete_tags.return_value = {
+                "deleted_count": 3,
+                "failed_count": 0,
+                "deleted_ids": ["tag-001", "tag-002", "tag-003"],
+                "failures": [],
+            }
+            mock_get_client.return_value = mock_client
+
+            result = delete_tags(tag_ids=["tag-001", "tag-002", "tag-003"])
+
+            assert "Successfully deleted 3 tags" in result
+
+    def test_delete_partial_failure(self):
+        """Server reports partial success when some tags not found."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.delete_tags.return_value = {
+                "deleted_count": 1,
+                "failed_count": 1,
+                "deleted_ids": ["tag-001"],
+                "failures": [],
+            }
+            mock_get_client.return_value = mock_client
+
+            result = delete_tags(tag_ids=["tag-001", "tag-bad"])
+
+            assert "1" in result
+            assert "failed" in result.lower()
+
+    def test_delete_empty_list_error(self):
+        """Server returns error for empty tag list."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.delete_tags.side_effect = ValueError(
+                "tag_ids cannot be empty"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = delete_tags(tag_ids=[])
+
+            assert "Error" in result
+
+
+class TestDeleteTagsConnector:
+    """Tests for delete_tags() connector method (AppleScript layer)."""
+
+    def test_delete_single_tag_calls_applescript(self):
+        """Connector builds correct AppleScript for single tag deletion."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "1"
+
+            client = OmniFocusConnector()
+            result = client.delete_tags("tag-001")
+
+            assert result["deleted_count"] == 1
+            assert result["failed_count"] == 0
+            call_args = mock_run.call_args[0][0]
+            assert "delete" in call_args
+            assert "tag-001" in call_args
+
+    def test_delete_multiple_tags_calls_applescript(self):
+        """Connector builds correct AppleScript for batch tag deletion."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "2"
+
+            client = OmniFocusConnector()
+            result = client.delete_tags(["tag-001", "tag-002"])
+
+            assert result["deleted_count"] == 2
+            call_args = mock_run.call_args[0][0]
+            assert "tag-001" in call_args
+            assert "tag-002" in call_args
+
+    def test_delete_empty_list_raises_valueerror(self):
+        """Connector raises ValueError for empty list."""
+        client = OmniFocusConnector()
+        with pytest.raises(ValueError, match="tag_ids cannot be empty"):
+            client.delete_tags([])
+
+    def test_delete_applescript_error_raises_exception(self):
+        """Connector raises Exception on AppleScript failure."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.side_effect = Exception("AppleScript error")
+
+            client = OmniFocusConnector()
+            with pytest.raises(Exception):
+                client.delete_tags("tag-001")
+
+    def test_delete_string_input_normalized_to_list(self):
+        """Connector normalizes string input to list internally."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "1"
+
+            client = OmniFocusConnector()
+            result = client.delete_tags("tag-single")
+
+            assert result["deleted_count"] == 1
+            assert result["deleted_ids"] == ["tag-single"]

--- a/tests/test_update_tag.py
+++ b/tests/test_update_tag.py
@@ -1,0 +1,162 @@
+"""Tests for update_tag MCP tool and connector method.
+
+Tests both the server layer (MCP tool) and the connector layer (AppleScript client).
+"""
+from unittest import mock
+
+import pytest
+
+import omnifocus_mcp.server_fastmcp as server
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+
+update_tag = server.update_tag
+
+
+class TestUpdateTagServer:
+    """Tests for update_tag() MCP tool."""
+
+    def test_update_tag_name(self):
+        """Server updates tag name and returns human-readable response."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True,
+                "tag_id": "tag-001",
+                "updated_fields": ["name"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-001", name="Renamed")
+
+            mock_client.update_tag.assert_called_once_with(
+                tag_id="tag-001", name="Renamed", active=None
+            )
+            assert "tag-001" in result
+            assert "Successfully" in result
+
+    def test_update_tag_active_status(self):
+        """Server updates tag active status."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True,
+                "tag_id": "tag-002",
+                "updated_fields": ["active"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-002", active=False)
+
+            mock_client.update_tag.assert_called_once_with(
+                tag_id="tag-002", name=None, active=False
+            )
+            assert "tag-002" in result
+            assert "Successfully" in result
+
+    def test_update_tag_multiple_fields(self):
+        """Server updates multiple tag fields at once."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True,
+                "tag_id": "tag-003",
+                "updated_fields": ["name", "active"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-003", name="New Name", active=True)
+
+            assert "tag-003" in result
+            assert "Successfully" in result
+
+    def test_update_tag_not_found(self):
+        """Server returns error when tag not found."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.side_effect = Exception(
+                "Error updating tag: Tag not found"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-nonexistent", name="Foo")
+
+            assert "Error" in result
+
+    def test_update_tag_no_fields(self):
+        """Server returns error when no fields provided."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.side_effect = ValueError(
+                "At least one field must be provided to update"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-001")
+
+            assert "Error" in result
+
+
+class TestUpdateTagConnector:
+    """Tests for update_tag() connector method (AppleScript layer)."""
+
+    def test_update_tag_name_calls_applescript(self):
+        """Connector builds correct AppleScript for tag rename."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = '{"success": true, "updated_fields": ["name"]}'
+
+            client = OmniFocusConnector()
+            result = client.update_tag("tag-001", name="Renamed")
+
+            assert result["success"] is True
+            assert "name" in result["updated_fields"]
+            call_args = mock_run.call_args[0][0]
+            assert "Renamed" in call_args
+            assert "tag-001" in call_args
+
+    def test_update_tag_active_calls_applescript(self):
+        """Connector builds correct AppleScript for active status change."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = '{"success": true, "updated_fields": ["active"]}'
+
+            client = OmniFocusConnector()
+            result = client.update_tag("tag-002", active=False)
+
+            assert result["success"] is True
+            call_args = mock_run.call_args[0][0]
+            assert "tag-002" in call_args
+            assert "allows next action" in call_args
+
+    def test_update_tag_no_fields_raises_valueerror(self):
+        """Connector raises ValueError when no fields provided."""
+        client = OmniFocusConnector()
+        with pytest.raises(ValueError, match="At least one field"):
+            client.update_tag("tag-001")
+
+    def test_update_tag_empty_id_raises_valueerror(self):
+        """Connector raises ValueError when tag_id is empty."""
+        client = OmniFocusConnector()
+        with pytest.raises(ValueError, match="tag_id is required"):
+            client.update_tag("")
+
+    def test_update_tag_error_raises_exception(self):
+        """Connector raises Exception on AppleScript error."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "ERROR: Tag not found"
+
+            client = OmniFocusConnector()
+            with pytest.raises(Exception, match="Error updating tag"):
+                client.update_tag("tag-bad", name="Foo")
+
+    def test_update_tag_escapes_special_characters(self):
+        """Connector escapes quotes in tag name."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = '{"success": true, "updated_fields": ["name"]}'
+
+            client = OmniFocusConnector()
+            client.update_tag("tag-001", name='Tag "quoted"')
+
+            call_args = mock_run.call_args[0][0]
+            assert '\\"' in call_args or 'quoted' in call_args


### PR DESCRIPTION
## Summary

Closes #230, closes #231.

- **update_tag**: Rename tags and set active/on-hold status (`allows next action` AppleScript property). Follows `update_project` pattern with dict return.
- **delete_tags**: Batch delete with `Union[str, list[str]]`. Follows `delete_tasks` pattern with success/failure counting.
- API surface: 18 → 20 functions. Tags now have full CRUD: `get_tags`, `create_tag`, `update_tag`, `delete_tags`.
- 20 new unit tests (11 update_tag + 9 delete_tags), all 515 passing.

## Test plan

- [x] `./scripts/check_client_server_parity.sh` — 20/20 functions matched
- [x] `make test` — 515 passed, 187 skipped
- [ ] Integration test against real OmniFocus (optional — requires test DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)