### PR TITLE
feat: add dependency and AppleScript safety audits

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,6 +14,8 @@ make test-e2e              # End-to-end MCP tool tests (requires test DB)
 ./scripts/check_complexity.sh       # Cyclomatic complexity check
 ./scripts/check_client_server_parity.sh  # Verify all client functions are exposed in server
 ./scripts/check_version_sync.sh     # Version consistency across files
+./scripts/check_dependencies.sh     # Dependency vulnerability scan (pip-audit)
+./scripts/check_applescript_safety.sh   # AppleScript unsafe pattern detection
 ```
 
 **Running the server:** `uv run python -m omnifocus_mcp.server_fastmcp` or via Claude Desktop config.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -102,6 +102,16 @@ Run ALL validation checks. Stop on any failure.
    make test
    ```
 
+5. **Dependency audit:**
+   ```bash
+   ./scripts/check_dependencies.sh
+   ```
+
+6. **AppleScript safety audit:**
+   ```bash
+   ./scripts/check_applescript_safety.sh
+   ```
+
 If any check fails, fix the issue and re-run. Do not proceed with failures.
 
 ## Phase 7: Commit, Push, and PR

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-integration test-e2e test-verbose install clean complexity help
+.PHONY: test test-unit test-integration test-e2e test-verbose install clean complexity audit help
 
 help:
 	@echo "Available targets:"
@@ -34,6 +34,10 @@ test-verbose:
 
 complexity:
 	@./scripts/check_complexity.sh
+
+audit:
+	@./scripts/check_dependencies.sh
+	@./scripts/check_applescript_safety.sh
 
 clean:
 	rm -rf __pycache__ .pytest_cache .coverage htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "radon>=6.0.0",
+    "pip-audit>=2.7.0",
 ]
 
 [project.scripts]

--- a/scripts/check_applescript_safety.sh
+++ b/scripts/check_applescript_safety.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Audit AppleScript code in the connector for known unsafe patterns.
+# Based on patterns documented in APPLESCRIPT_GOTCHAS.md and CLAUDE.md.
+#
+# Checks:
+#   1. Variable naming conflicts with OmniFocus properties
+#   2. Missing _verify_database_safety calls for destructive operations
+#   3. Unescaped string interpolation in AppleScript blocks
+#   4. Unsafe recurring task completion patterns
+#
+# Usage: ./scripts/check_applescript_safety.sh
+
+set -euo pipefail
+
+CONNECTOR="src/omnifocus_mcp/omnifocus_connector.py"
+WARNINGS=0
+ERRORS=0
+
+echo "Running AppleScript safety audit on $CONNECTOR..."
+echo ""
+
+# --- Check 1: Variable naming conflicts ---
+# OmniFocus property names that should never be used as bare AppleScript variables.
+# Safe pattern: "set taskName to" not "set name to"
+echo "--- Check 1: Variable naming conflicts ---"
+
+UNSAFE_VARS="set name to |set note to |set status to |set flagged to |set completed to |set sequential to "
+if matches=$(grep -n "$UNSAFE_VARS" "$CONNECTOR" 2>/dev/null); then
+    echo "WARNING: Possible variable naming conflicts with OmniFocus properties:"
+    echo "$matches"
+    WARNINGS=$((WARNINGS + $(echo "$matches" | wc -l)))
+else
+    echo "OK: No variable naming conflicts found."
+fi
+echo ""
+
+# --- Check 2: Missing safety checks ---
+# Every operation in DESTRUCTIVE_OPERATIONS must have a _verify_database_safety call.
+echo "--- Check 2: Destructive operation safety coverage ---"
+
+# Extract DESTRUCTIVE_OPERATIONS from the source (stop at closing brace)
+DESTRUCTIVE_OPS=$(sed -n '/DESTRUCTIVE_OPERATIONS = {/,/}/p' "$CONNECTOR" | \
+    grep -oE "'[a-z_]+'" | tr -d "'" | sort)
+
+MISSING_SAFETY=0
+for op in $DESTRUCTIVE_OPS; do
+    if ! grep -q "_verify_database_safety('$op')" "$CONNECTOR"; then
+        echo "ERROR: Missing _verify_database_safety('$op') call"
+        MISSING_SAFETY=$((MISSING_SAFETY + 1))
+    fi
+done
+
+if [ "$MISSING_SAFETY" -eq 0 ]; then
+    echo "OK: All $(echo "$DESTRUCTIVE_OPS" | wc -w | tr -d ' ') destructive operations have safety checks."
+else
+    ERRORS=$((ERRORS + MISSING_SAFETY))
+fi
+echo ""
+
+# --- Check 3: Unescaped string interpolation ---
+# Look for f-string interpolations of common user-input parameters
+# that don't use an _escaped suffix variable.
+echo "--- Check 3: Unescaped string interpolation ---"
+
+# Look for bare {name}, {note}, etc. inside AppleScript f-string blocks.
+# These indicate user input embedded without _escape_applescript_string().
+# Only flag lines that look like AppleScript content (contain tell/set/make/return/etc.)
+UNESCAPED=0
+while IFS= read -r line; do
+    lineno=$(echo "$line" | cut -d: -f1)
+    content=$(echo "$line" | cut -d: -f2-)
+    # Skip Python-only lines (raise, return, comments, docstrings)
+    if echo "$content" | grep -qE "^\s*(#|raise |return |\"\"\"|\.\.\.)"; then
+        continue
+    fi
+    # Only flag lines that look like AppleScript content
+    if echo "$content" | grep -qE "(tell |set |make |return |delete |whose |of )"; then
+        echo "ERROR: Possible unescaped interpolation at line $lineno: $(echo "$content" | sed 's/^[[:space:]]*//')"
+        UNESCAPED=$((UNESCAPED + 1))
+    fi
+done < <(grep -n '{name}\|{note}\|{tag_name}\|{parent_tag}\|{folder_name}' "$CONNECTOR" 2>/dev/null || true)
+
+if [ "$UNESCAPED" -eq 0 ]; then
+    echo "OK: No unescaped string interpolations found."
+else
+    ERRORS=$((ERRORS + UNESCAPED))
+fi
+echo ""
+
+# --- Check 4: Unsafe completion pattern ---
+# "set completed of X to true" should be "mark complete X" for recurring tasks.
+echo "--- Check 4: Recurring task completion safety ---"
+
+if matches=$(grep -n "set completed of.*to true" "$CONNECTOR" 2>/dev/null); then
+    echo "WARNING: Found 'set completed of ... to true' — should use 'mark complete' for recurring tasks:"
+    echo "$matches"
+    WARNINGS=$((WARNINGS + $(echo "$matches" | wc -l)))
+else
+    echo "OK: No unsafe completion patterns found."
+fi
+echo ""
+
+# --- Summary ---
+echo "========================================="
+if [ "$ERRORS" -gt 0 ]; then
+    echo "❌ AppleScript safety audit FAILED"
+    echo "   $ERRORS error(s), $WARNINGS warning(s)"
+    exit 1
+elif [ "$WARNINGS" -gt 0 ]; then
+    echo "⚠️  AppleScript safety audit PASSED with warnings"
+    echo "   $WARNINGS warning(s)"
+    exit 0
+else
+    echo "✅ AppleScript safety audit PASSED"
+    exit 0
+fi

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Check for known security vulnerabilities in dependencies.
+# Uses pip-audit against the PyPI/OSV vulnerability database.
+#
+# Install: pip install pip-audit
+# Usage: ./scripts/check_dependencies.sh
+
+set -euo pipefail
+
+echo "Checking dependencies for known vulnerabilities..."
+echo ""
+
+# Check pip-audit is available
+if ! command -v pip-audit &> /dev/null; then
+    # Try the venv version
+    if [ -f "./venv/bin/pip-audit" ]; then
+        PIP_AUDIT="./venv/bin/pip-audit"
+    else
+        echo "ERROR: pip-audit not found."
+        echo "Install it: pip install pip-audit"
+        exit 1
+    fi
+else
+    PIP_AUDIT="pip-audit"
+fi
+
+# Run pip-audit on installed packages
+if $PIP_AUDIT 2>&1; then
+    echo ""
+    echo "✅ Dependency audit PASSED — no known vulnerabilities found."
+    exit 0
+else
+    echo ""
+    echo "❌ Dependency audit FAILED — vulnerabilities found above."
+    echo "Run 'pip-audit --fix' to attempt automatic fixes, or update affected packages manually."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #52, closes #54.

- **`scripts/check_dependencies.sh`** — Runs `pip-audit` to scan installed packages against PyPI/OSV vulnerability databases. Added `pip-audit>=2.7.0` as dev dependency.
- **`scripts/check_applescript_safety.sh`** — Detects 4 classes of unsafe patterns in the connector:
  1. Variable naming conflicts with OmniFocus properties
  2. Missing `_verify_database_safety` calls for destructive operations
  3. Unescaped string interpolation in AppleScript blocks
  4. Unsafe `set completed of X to true` patterns (should use `mark complete`)
- Both integrated into release skill Phase 6 and available via `make audit`

## Test plan

- [x] `./scripts/check_dependencies.sh` — passes clean
- [x] `./scripts/check_applescript_safety.sh` — passes clean (13/13 destructive ops covered)
- [x] `make audit` — runs both scripts successfully
- [x] `make test` — 515 passed, 187 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)