### PR TITLE
docs: codify testing requirements and add tag CRUD integration tests (#236)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,6 +81,17 @@ Default timeout: 60s, max: 300s (configurable).
 
 Destructive operations require `OMNIFOCUS_TEST_MODE=true` and `OMNIFOCUS_TEST_DATABASE=OmniFocus-TEST.ofocus` environment variables. Each destructive operation verifies the database name via AppleScript before proceeding. This prevents accidental production data loss during development.
 
+## Testing Requirements
+
+| Type | When Required | How |
+|------|--------------|-----|
+| Unit tests | Every code change | `make test` (pre-push hook) |
+| Integration tests | New/modified AppleScript operations | `make test-integration` (requires test DB) |
+| Performance benchmarks | Changes to fetch/filter paths | `tests/benchmarks/` |
+| Blind agent evals | Before release if tool descriptions changed | Issue #227 |
+
+**Hard rule:** If you wrote or modified an AppleScript string in the connector, integration tests must cover that operation before merge. Unit tests mock `run_applescript()` and cannot catch AppleScript syntax errors, variable naming collisions, or OmniFocus behavioral quirks.
+
 ## Branch Convention
 
 `{type}/issue-{num}-{description}` — e.g., `feature/issue-42-batch-tags`, `fix/issue-99-timeout`

--- a/.claude/skills/applescript-omnifocus/SKILL.md
+++ b/.claude/skills/applescript-omnifocus/SKILL.md
@@ -151,6 +151,10 @@ The connector has a safety system that prevents destructive operations on produc
 
 This adds ~100ms per destructive call but prevents catastrophic data loss. Do not bypass it.
 
+## Integration Test Requirement
+
+If you wrote or modified AppleScript in the connector, you MUST write or update integration tests before the PR is ready. Unit tests mock `run_applescript()` — they prove your Python logic works but say nothing about whether the AppleScript is valid. Offer to run `make test-integration` before creating the PR.
+
 ## OmniFocus-Specific AppleScript Quirks
 
 - **`first flattened task whose id is X`** — works for tasks. Use `flattened projects` for projects, `folders` for folders.

--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -134,6 +134,32 @@ def test_create_and_retrieve_task():
 - Modifying server-level parameter handling
 - Updating response formatting in server_fastmcp.py
 
+## Smoke Test Pattern for CRUD Operations
+
+Every CRUD connector method should have a minimal integration test:
+
+1. **Create** — make a test entity, verify it gets an ID back
+2. **Read** — fetch it, verify the fields match what was created
+3. **Update** — change a field, re-fetch, verify the change took
+4. **Delete** — delete it, verify it's gone
+
+Use try/finally for cleanup. Prefix test data with `test-` or `Test `.
+
+```python
+tag_id = None
+try:
+    tag_id = client.create_tag(f"test-integ-{uuid.uuid4()}")
+    assert tag_id  # Create returns ID
+    tags = client.get_tags()
+    assert any(t['id'] == tag_id for t in tags)  # Read confirms
+finally:
+    if tag_id:
+        try:
+            client.delete_tags(tag_id)
+        except Exception as e:
+            warnings.warn(f"Cleanup failed: {e}")
+```
+
 ## Detailed Setup Guide
 
 For complete setup instructions including troubleshooting, see `docs/guides/INTEGRATION_TESTING.md`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,24 +437,37 @@ def ensure_test_tags():
     """Ensure required test tags exist in OmniFocus.
 
     Creates tags needed by integration tests if they don't already exist.
-    Tags persist across tests in the class (not cleaned up, as OmniFocus
-    doesn't support tag deletion via AppleScript).
+    Cleans up created tags after the test class completes.
 
     Tags created: test-work, test-urgent, urgent, work
     """
     tag_names = ["test-work", "test-urgent", "urgent", "work"]
+    created_tag_ids = []
     for tag_name in tag_names:
         try:
-            run_applescript(f'''
+            result = run_applescript(f'''
                 tell application "OmniFocus"
                     tell front document
                         try
-                            first flattened tag whose name is "{tag_name}"
+                            set theTag to first flattened tag whose name is "{tag_name}"
                         on error
-                            make new tag with properties {{name:"{tag_name}"}}
+                            set theTag to make new tag with properties {{name:"{tag_name}"}}
                         end try
+                        return id of theTag
                     end tell
                 end tell
             ''')
+            if result:
+                created_tag_ids.append(result.strip())
         except Exception as e:
             warnings.warn(f"Failed to create test tag '{tag_name}': {e}")
+
+    yield
+
+    # Teardown: delete tags we created
+    client = OmniFocusConnector(enable_safety_checks=True)
+    for tag_id in created_tag_ids:
+        try:
+            client.delete_tags(tag_id)
+        except Exception as e:
+            warnings.warn(f"Failed to clean up test tag {tag_id}: {e}")

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -1023,6 +1023,158 @@ class TestTagBatchOperations:
                 assert "work" not in task.get('tags', [])
 
 
+class TestTagCRUD:
+    """Integration tests for tag Create/Update/Delete operations.
+
+    Tests verify that the AppleScript for tag CRUD actually works
+    against real OmniFocus. Unit tests mock run_applescript() and
+    cannot catch AppleScript syntax errors or behavioral quirks.
+    """
+
+    def test_create_tag(self, client):
+        """Create a root-level tag and verify it exists."""
+        import uuid
+        import warnings
+        tag_name = f"test-integ-{uuid.uuid4()}"
+        tag_id = None
+        try:
+            tag_id = client.create_tag(tag_name)
+            assert tag_id, "create_tag should return a tag ID"
+
+            # Verify tag appears in get_tags
+            tags = client.get_tags()
+            matching = [t for t in tags if t['id'] == tag_id]
+            assert len(matching) == 1
+            assert matching[0]['name'] == tag_name
+        finally:
+            if tag_id:
+                try:
+                    client.delete_tags(tag_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up test tag {tag_id}: {e}")
+
+    def test_create_nested_tag(self, client):
+        """Create a nested tag under a parent."""
+        import uuid
+        import warnings
+        parent_name = f"test-parent-{uuid.uuid4()}"
+        child_name = f"test-child-{uuid.uuid4()}"
+        parent_id = None
+        child_id = None
+        try:
+            parent_id = client.create_tag(parent_name)
+            assert parent_id
+
+            child_id = client.create_tag(child_name, parent_tag=parent_name)
+            assert child_id
+            assert child_id != parent_id
+
+            # Both should appear in get_tags (flattened)
+            tags = client.get_tags()
+            tag_ids = [t['id'] for t in tags]
+            assert parent_id in tag_ids
+            assert child_id in tag_ids
+        finally:
+            for tid in [child_id, parent_id]:
+                if tid:
+                    try:
+                        client.delete_tags(tid)
+                    except Exception as e:
+                        warnings.warn(f"Failed to clean up test tag {tid}: {e}")
+
+    def test_create_tag_already_exists(self, client):
+        """Creating a duplicate tag raises ValueError."""
+        import uuid
+        import warnings
+        tag_name = f"test-dup-{uuid.uuid4()}"
+        tag_id = None
+        try:
+            tag_id = client.create_tag(tag_name)
+            with pytest.raises(ValueError, match="already exists"):
+                client.create_tag(tag_name)
+        finally:
+            if tag_id:
+                try:
+                    client.delete_tags(tag_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up test tag {tag_id}: {e}")
+
+    def test_update_tag_name(self, client):
+        """Rename a tag and verify the change took."""
+        import uuid
+        import warnings
+        original_name = f"test-rename-{uuid.uuid4()}"
+        new_name = f"test-renamed-{uuid.uuid4()}"
+        tag_id = None
+        try:
+            tag_id = client.create_tag(original_name)
+            result = client.update_tag(tag_id, name=new_name)
+            assert result["success"] is True
+            assert "name" in result["updated_fields"]
+
+            # Verify rename in get_tags
+            tags = client.get_tags()
+            matching = [t for t in tags if t['id'] == tag_id]
+            assert len(matching) == 1
+            assert matching[0]['name'] == new_name
+        finally:
+            if tag_id:
+                try:
+                    client.delete_tags(tag_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up test tag {tag_id}: {e}")
+
+    def test_update_tag_active(self, client):
+        """Set a tag to on-hold and verify."""
+        import uuid
+        import warnings
+        tag_name = f"test-active-{uuid.uuid4()}"
+        tag_id = None
+        try:
+            tag_id = client.create_tag(tag_name)
+            result = client.update_tag(tag_id, active=False)
+            assert result["success"] is True
+            assert "active" in result["updated_fields"]
+
+            # Note: get_tags currently hardcodes status to "active"
+            # so we can't verify via get_tags. But the AppleScript
+            # ran without error, confirming 'allows next action'
+            # property is settable.
+        finally:
+            if tag_id:
+                try:
+                    client.delete_tags(tag_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up test tag {tag_id}: {e}")
+
+    def test_delete_tags(self, client):
+        """Delete multiple tags and verify they're gone."""
+        import uuid
+        import warnings
+        tag_ids = []
+        try:
+            for i in range(2):
+                tid = client.create_tag(f"test-delete-{uuid.uuid4()}")
+                tag_ids.append(tid)
+
+            result = client.delete_tags(tag_ids)
+            assert result["deleted_count"] == 2
+            assert result["failed_count"] == 0
+
+            # Verify tags are gone
+            tags = client.get_tags()
+            remaining_ids = [t['id'] for t in tags]
+            for tid in tag_ids:
+                assert tid not in remaining_ids
+            tag_ids = []  # Already deleted, skip cleanup
+        finally:
+            for tid in tag_ids:
+                try:
+                    client.delete_tags(tid)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up test tag {tid}: {e}")
+
+
 class TestTimeEstimation:
     """Test time estimation operations.
 


### PR DESCRIPTION
## Summary

- Adds four-tier testing philosophy (unit, integration, benchmarks, blind evals) to CLAUDE.md with hard rule: AppleScript changes require integration tests before merge
- Adds integration test gate to `applescript-omnifocus` skill and CRUD smoke test pattern to `integration-testing` skill
- Writes 6 tag CRUD integration tests (`TestTagCRUD`): create, nested create, duplicate detection, rename, active status toggle, batch delete — all verified against real OmniFocus
- Updates `ensure_test_tags` fixture with proper teardown cleanup via `delete_tags`

Closes #236

## Test plan

- [x] `make test` — 515 unit tests pass
- [x] Tag CRUD integration tests pass against real OmniFocus test DB (6/6)
- [x] No leftover `test-integ-*` tags after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)