### PR TITLE
docs: document focus automation capabilities (#240)

### DIFF
--- a/docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md
+++ b/docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md
@@ -250,3 +250,25 @@ Tested against OmniFocus 4.8.4 with Pro license.
 ### Limitation
 
 Cannot programmatically configure what a perspective shows (filter rules, sorting, grouping, icons). Created perspectives are blank — users must configure them in the OmniFocus UI.
+
+## Focus Automation (March 2026)
+
+Tested against OmniFocus 4.8.4.
+
+### AppleScript
+
+**Multi-item focus:** `set focus to {project1, project2, folder1}` — any mix of projects and folders.
+
+**Read focus:** `get every item of focus` returns focused items with class (project/folder) and name. `count of every item of focus` returns 0 when unfocused.
+
+**Clear focus:** `set focus to {}` (empty list). `missing value` does NOT work.
+
+**Focus + perspectives:** Focus persists across perspective switches. Setting focus on a project then switching to "Flagged" shows only flagged items within that project. This is the primary mechanism for programmatically narrowing what the user sees.
+
+### OmniAutomation (JavaScript)
+
+Focus is read-only: `window.focus` returns a `SectionArray` with `.length` and `.byName()`. Cannot set focus via JS.
+
+### Key Insight
+
+Focus + perspective switching is more useful than programmatic perspective creation. While perspectives can't have their filter rules set via API (#235), focus can narrow scope to specific projects/folders, and perspective switching applies filters within that scope. This combination achieves ad-hoc filtered views without needing custom perspective configuration.


### PR DESCRIPTION
## Summary

- Documents focus capabilities discovered via AppleScript and OmniAutomation testing against OmniFocus 4.8.4
- Adds "Focus Automation" section to `docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md`

Key findings:
- **Multi-item focus works** — any mix of projects and folders via `set focus to {item1, item2}`
- **Focus is readable** — `get every item of focus` returns focused items
- **Focus is clearable** — `set focus to {}` clears all focus
- **Focus persists across perspectives** — set focus + switch perspective = filtered view within scope

Closes #240

## Test plan

- [x] Research completed against production OmniFocus
- [x] Focus set, read, and cleared — no side effects
- [x] Findings posted as comment on #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)