### PR TITLE
fix: available_only excludes tasks with On Hold tags (#261)

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -480,6 +480,35 @@ class OmniFocusConnector:
 
         return filtered_tasks
 
+    def _get_on_hold_tag_names(self) -> list[str]:
+        """Pre-fetch names of all On Hold tags.
+
+        Used by get_tasks(available_only=True) to exclude tasks with On Hold
+        tags, matching OmniFocus's native Available perspective behavior.
+
+        Returns:
+            List of tag names where allows next action is false.
+            Empty list if no On Hold tags exist or on error.
+        """
+        script = '''
+        tell application "OmniFocus"
+            tell front document
+                try
+                    return name of (flattened tags whose allows next action is false)
+                on error
+                    return {}
+                end try
+            end tell
+        end tell
+        '''
+        try:
+            result = run_applescript(script)
+            if not result or not result.strip():
+                return []
+            return [name.strip() for name in result.split(", ") if name.strip()]
+        except Exception:
+            return []
+
     def _get_task_ids_for_tags(
         self,
         tag_names: list[str],
@@ -2071,6 +2100,32 @@ class OmniFocusConnector:
             if tag_prefiltered_ids is not None and len(tag_prefiltered_ids) == 0:
                 return []  # No tasks match — early return
 
+        # Pre-fetch On Hold tag names for available_only filtering.
+        # OmniFocus's Available perspective excludes tasks with On Hold tags.
+        on_hold_tag_names: list[str] = []
+        on_hold_tags_decl = ""
+        on_hold_available_check = ""
+        on_hold_available_check_batch = ""
+        if available_only:
+            on_hold_tag_names = self._get_on_hold_tag_names()
+            if on_hold_tag_names:
+                escaped = [f'"{self._escape_applescript_string(n)}"' for n in on_hold_tag_names]
+                on_hold_tags_decl = f"set onHoldTags to {{{', '.join(escaped)}}}"
+                # Per-task check (filter-first / extract-then-filter)
+                on_hold_available_check = """
+                        -- Skip tasks with On Hold tags
+                        set taskTagNms to name of (tags of t)
+                        repeat with tn in taskTagNms
+                            if tn is in onHoldTags then error "skip unavailable task"
+                        end repeat"""
+                # Batch check (uses already batch-read tagNameLists)
+                on_hold_available_check_batch = """
+                        -- Skip tasks with On Hold tags (batch data)
+                        set taskTagNms to contents of (item i of tagNameLists)
+                        repeat with tn in taskTagNms
+                            if tn is in onHoldTags then error "skip unavailable"
+                        end repeat"""
+
         # Build task source with native 'whose' pre-filtering where possible.
         # OmniFocus evaluates 'whose' clauses natively (~20-30x faster than
         # manual iteration with per-task property checks). See PERFORMANCE_PROFILING.md.
@@ -2169,8 +2224,8 @@ class OmniFocusConnector:
                             error "skip non-next task"
                         end if"""
 
-        # Build available filter (not dropped, not blocked, not deferred)
-        available_check = "" if not available_only else """
+        # Build available filter (not dropped, not blocked, not deferred, not On Hold tagged)
+        available_check = "" if not available_only else f"""
                         -- Skip unavailable tasks
                         if dropped of t then
                             error "skip unavailable task"
@@ -2186,7 +2241,7 @@ class OmniFocusConnector:
                                     error "skip unavailable task"
                                 end if
                             end if
-                        end try"""
+                        end try{on_hold_available_check}"""
 
         # Overdue filter — skip if whose already filters by due date
         overdue_check = ""
@@ -2394,14 +2449,14 @@ class OmniFocusConnector:
         # Build batch-mode filter checks (use indexed batch data instead of per-task reads)
         available_check_batch = ""
         if available_only:
-            available_check_batch = """
+            available_check_batch = f"""
                         -- Skip unavailable tasks (using batch-read data)
                         if item i of taskDrops then error "skip unavailable"
                         if item i of taskBlocks then error "skip unavailable"
                         set dVal to contents of (item i of deferDates)
                         if dVal is not missing value then
                             if dVal > (current date) then error "skip unavailable"
-                        end if"""
+                        end if{on_hold_available_check_batch}"""
 
         due_relative_check_batch = ""
         if due_relative:
@@ -2559,6 +2614,7 @@ class OmniFocusConnector:
                 set tagNameLists to name of (tags of ft)
 
                 set taskCount to count of ids
+                {on_hold_tags_decl}
 
                 -- Build JSON from parallel lists (local loop, minimal IPC)
                 repeat with i from 1 to taskCount
@@ -2727,6 +2783,7 @@ class OmniFocusConnector:
 
         set output to ""
         set taskIndex to 0
+        {on_hold_tags_decl}
 
         tell application "OmniFocus"
             tell front document
@@ -2766,6 +2823,7 @@ class OmniFocusConnector:
 
         set output to ""
         set taskIndex to 0
+        {on_hold_tags_decl}
 
         tell application "OmniFocus"
             tell front document

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -2009,6 +2009,53 @@ class TestAvailabilityFields:
             client.delete_projects(project_id)
 
 
+class TestAvailableOnlyOnHoldTags:
+    """Test that available_only=True excludes tasks with On Hold tags (#261).
+
+    Validates parity with OmniFocus's native Available perspective.
+    """
+
+    def test_on_hold_tag_task_excluded_from_available(self, client, test_project):
+        """Task with an On Hold tag should NOT appear in available_only results."""
+        # Create an On Hold tag
+        tag_id = client.create_tag("test-on-hold-261")
+        try:
+            client.update_tag(tag_id, active=False)
+
+            # Create a task and assign the On Hold tag via update_task
+            # (create_task with On Hold tags silently skips tag assignment)
+            task_id = client.create_task(
+                "On Hold Tagged Task",
+                project_id=test_project,
+            )
+            client.update_task(task_id, add_tags=["test-on-hold-261"])
+
+            # Verify the task exists in unfiltered results with the tag
+            all_tasks = client.get_tasks(project_id=test_project)
+            task = next(t for t in all_tasks if t['name'] == "On Hold Tagged Task")
+            assert "test-on-hold-261" in task['tags']
+
+            # Verify the task is excluded from available_only
+            available_tasks = client.get_tasks(
+                project_id=test_project, available_only=True
+            )
+            available_names = [t['name'] for t in available_tasks]
+            assert "On Hold Tagged Task" not in available_names
+        finally:
+            client.delete_tags(tag_id)
+            client.delete_projects(test_project)
+
+    def test_get_on_hold_tag_names_returns_on_hold_tags(self, client):
+        """_get_on_hold_tag_names() returns names of tags set to On Hold."""
+        tag_id = client.create_tag("test-on-hold-261-lookup")
+        try:
+            client.update_tag(tag_id, active=False)
+            on_hold = client._get_on_hold_tag_names()
+            assert "test-on-hold-261-lookup" in on_hold
+        finally:
+            client.delete_tags(tag_id)
+
+
 class TestUINavigation:
     """Test UI navigation operations (set_focus, get_focus, get_perspectives).
 

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -1886,3 +1886,67 @@ class TestGetTags:
             client.get_tags()
             script = mock_run.call_args[0][0]
             assert "allows next action" in script
+
+
+class TestAvailableOnlyOnHoldTags:
+    """Tests for available_only excluding tasks with On Hold tags (#261)."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_available_only_script_contains_on_hold_tag_check(self, client):
+        """When On Hold tags exist, the get_tasks script should check for them."""
+        tasks_json = json.dumps([])
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            # First call: _get_on_hold_tag_names returns On Hold tags
+            # Second call: get_tasks main script returns empty task list
+            mock_run.side_effect = ["Waiting, On Hold", tasks_json]
+            client.get_tasks(available_only=True)
+            # The main get_tasks script (second call) should reference onHoldTags
+            main_script = mock_run.call_args_list[1][0][0]
+            assert "onHoldTags" in main_script
+            assert "Waiting" in main_script
+            assert "On Hold" in main_script
+
+    def test_available_only_without_on_hold_tags_skips_check(self, client):
+        """When no On Hold tags exist, the script should not include the check."""
+        tasks_json = json.dumps([])
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            # First call: no On Hold tags
+            # Second call: get_tasks main script
+            mock_run.side_effect = ["", tasks_json]
+            client.get_tasks(available_only=True)
+            main_script = mock_run.call_args_list[1][0][0]
+            assert "onHoldTags" not in main_script
+
+
+class TestGetOnHoldTagNames:
+    """Tests for _get_on_hold_tag_names() — pre-fetches On Hold tag names."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_returns_on_hold_tag_names(self, client):
+        """Returns list of tag names where allows next action is false."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "Waiting, On Hold"
+            result = client._get_on_hold_tag_names()
+            assert result == ["Waiting", "On Hold"]
+            script = mock_run.call_args[0][0]
+            assert "allows next action is false" in script
+
+    def test_returns_empty_list_when_no_on_hold_tags(self, client):
+        """Returns empty list when no tags are On Hold."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = ""
+            result = client._get_on_hold_tag_names()
+            assert result == []
+
+    def test_handles_applescript_error_gracefully(self, client):
+        """Returns empty list if AppleScript errors."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.side_effect = Exception("AppleScript error")
+            result = client._get_on_hold_tag_names()
+            assert result == []


### PR DESCRIPTION
## Summary

- `get_tasks(available_only=True)` now excludes tasks with On Hold tags, matching OmniFocus's native Available perspective
- Adds `_get_on_hold_tag_names()` — pre-fetches On Hold tag names via single `whose allows next action is false` call (~0.2s)
- Checks task tags against On Hold set in all three code paths (batch, filter-first, extract-then-filter)
- Zero additional IPC in batch mode (reuses already batch-read `tagNameLists`)
- No impact when `available_only=False` or when no On Hold tags exist

Closes #261

Also filed #267: `create_task` silently fails to assign On Hold tags (discovered during integration testing, separate bug).

## Test plan

- [x] Unit tests: 551 passed (`make test`)
- [x] 3 new unit tests for `_get_on_hold_tag_names()`
- [x] 2 new unit tests for available_only On Hold tag check
- [x] 2 new integration tests against real OmniFocus (tag exclusion + pre-fetch verification)
- [x] Complexity check passes
- [x] Client-server parity passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)