### PR TITLE
fix: create_task silently fails to assign On Hold tags (#267)

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1830,12 +1830,8 @@ class OmniFocusConnector:
             for tag in tags:
                 tag_escaped = self._escape_applescript_string(tag)
                 tag_commands.append(f'''
-                    try
-                        set tagObj to first flattened tag whose name is "{tag_escaped}"
-                        add tagObj to tags of newTask
-                    on error
-                        -- Tag doesn't exist, skip it
-                    end try''')
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of newTask''')
 
         properties_str = ", ".join(properties)
         date_commands_str = "\n                    ".join(date_commands)

--- a/tests/test_api_redesign_create.py
+++ b/tests/test_api_redesign_create.py
@@ -142,6 +142,41 @@ class TestCreateTaskRedesign:
             assert "estimated minutes" in script.lower()
 
     # ========================================================================
+    # Tag Assignment (#267)
+    # ========================================================================
+
+    def test_create_task_tag_assignment_no_silent_swallow(self, client):
+        """Bug #267: Tag assignment must not silently swallow errors.
+
+        create_task previously wrapped tag lookup in try/on error, which
+        silently skipped On Hold tags. The generated AppleScript should
+        match update_task's pattern: no try/on error around tag assignment.
+        """
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "task-267"
+            client.create_task(
+                task_name="Tag Test",
+                tags=["MyTag"],
+            )
+            script = mock_run.call_args[0][0]
+            # Tag lookup and add should be present
+            assert 'first flattened tag whose name is "MyTag"' in script
+            assert 'add tagObj to tags of newTask' in script
+            # The tag block must NOT contain "on error" (silent error swallowing)
+            # Extract from tag lookup to end of tag section
+            tag_start = script.index('set tagObj to first flattened tag')
+            tag_end = script.index('add tagObj to tags of newTask') + len('add tagObj to tags of newTask')
+            tag_block = script[tag_start:tag_end]
+            # Check there's no try/on error wrapping this block
+            before_tag = script[:tag_start]
+            after_tag = script[tag_end:]
+            # Count try/end try pairs: the tag block should not introduce its own
+            # Simplest check: "on error" between "Add tags" comment and "return id"
+            tags_section = script[script.index('Add tags if provided'):script.index('return id')]
+            assert 'on error' not in tags_section, \
+                "Tag assignment section should not contain on error (bug #267)"
+
+    # ========================================================================
     # Return Format
     # ========================================================================
 

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -2023,7 +2023,7 @@ class TestAvailableOnlyOnHoldTags:
             client.update_tag(tag_id, active=False)
 
             # Create a task and assign the On Hold tag via update_task
-            # (create_task with On Hold tags silently skips tag assignment)
+            # (create_task On Hold tag bug was fixed in #267)
             task_id = client.create_task(
                 "On Hold Tagged Task",
                 project_id=test_project,
@@ -2041,6 +2041,28 @@ class TestAvailableOnlyOnHoldTags:
             )
             available_names = [t['name'] for t in available_tasks]
             assert "On Hold Tagged Task" not in available_names
+        finally:
+            client.delete_tags(tag_id)
+            client.delete_projects(test_project)
+
+    def test_create_task_assigns_on_hold_tag(self, client, test_project):
+        """Bug #267: create_task should successfully assign On Hold tags."""
+        tag_id = client.create_tag("test-on-hold-267")
+        try:
+            client.update_tag(tag_id, active=False)
+
+            # create_task should assign the On Hold tag directly
+            task_id = client.create_task(
+                "On Hold Tag Create Test",
+                project_id=test_project,
+                tags=["test-on-hold-267"],
+            )
+
+            # Verify the tag was actually assigned
+            all_tasks = client.get_tasks(project_id=test_project)
+            task = next(t for t in all_tasks if t['name'] == "On Hold Tag Create Test")
+            assert "test-on-hold-267" in task['tags'], \
+                f"On Hold tag should be assigned by create_task. Got tags: {task['tags']}"
         finally:
             client.delete_tags(tag_id)
             client.delete_projects(test_project)


### PR DESCRIPTION
## Summary

- Removed `try/on error` wrapper from `create_task`'s tag assignment AppleScript, which silently swallowed errors when assigning On Hold tags
- Now matches `update_task`'s proven pattern where the same lookup works correctly
- Non-existent tag names now raise errors instead of being silently skipped (consistent with `update_task` behavior)

## Test plan

- [x] Unit test verifies generated AppleScript has no `on error` in tag section
- [x] Integration test confirms `create_task(tags=["on-hold-tag"])` assigns On Hold tags
- [x] Existing `test_on_hold_tag_task_excluded_from_available` still passes
- [x] Full unit suite passes (552 tests)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)