### PR TITLE
fix: clarify repetition_method docstring for due_after_completion (#277)

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-12 (tag dropped status for #259)
+- **Date:** 2026-03-12 (repetition_method docstring fix for #277)
 - **Model:** claude-sonnet-4-6 (scenarios 24-34), claude-opus-4-6 (scenarios 1-23)
-- **Total Score:** 67/68 (99%)
+- **Total Score:** 68/68 (100%)
 - **Critical Failures:** 0 of 4
-- **Previous Score:** 63/64 (98%) — 2 new tag status scenarios added (#259)
+- **Previous Score:** 67/68 (99%) — scenario 29 fixed from 1/2 to 2/2 (#277)
 
 ## Category Scores
 
@@ -19,7 +19,7 @@
 | Edge Cases | 16-18 | 6 | 6 | 100% |
 | Documentation Gaps | 19-23 | 10 | 10 | 100% |
 | Planned Date | 24-26 | 6 | 6 | 100% |
-| Recurrence | 27-32 | 11 | 12 | 92% |
+| Recurrence | 27-32 | 12 | 12 | 100% |
 | Tag Status | 33-34 | 4 | 4 | 100% |
 
 ## Per-Scenario Results
@@ -192,10 +192,9 @@
 - **Concept Understanding:** Excellent — correctly used RRULE INTERVAL=2 for biweekly. Noted that repetition_method is omitted to preserve existing method.
 
 ### Scenario 29: Repetition Method Semantics
-- **Score:** 1/2 (PARTIAL)
+- **Score:** 2/2 (PASS) — *previously 1/2, fixed by docstring clarification (#277)*
 - **Tool Selection:** Correct — no tool call needed (interpretive question)
-- **Concept Understanding:** Partial — correctly identified that `repetitionMethod` matters and distinguished `due_after_completion` from `fixed`. However, misinterpreted the mechanics: said the due date shifts from the *previous due date* (which is actually `fixed` behavior). In reality, `due_after_completion` means next due = completion date + interval. The tool description's wording ("due date shifts by N days/weeks after completion") is ambiguous — could be improved.
-- **Action item:** Clarify tool description to say "next due date = completion date + interval" for `due_after_completion`.
+- **Concept Understanding:** Excellent — correctly explained that `due_after_completion` means next due = completion date + interval (one week from today). Explicitly contrasted with `fixed` (next Monday regardless of completion date). Even provided a comparison table.
 
 ### Scenario 30: Remove Recurrence
 - **Score:** 2/2 (PASS)
@@ -262,4 +261,4 @@
 
 ## Conclusion
 
-After adding tag dropped status (#259), the tool descriptions achieve 67/68 (99%) across 34 scenarios. The 2 new tag status scenarios (33-34) test dropping a tag (hidden but preserved) and distinguishing all three tag states (active, on_hold, dropped). Both scored 2/2 — agents correctly use the `status` parameter on `update_tag` and understand the semantic differences between states. The only partial score remains scenario 29 (repetition method semantics — interpretive, no tool call needed) where the agent slightly misinterpreted the `due_after_completion` mechanism.
+After clarifying the repetition_method docstring (#277), the tool descriptions achieve 68/68 (100%) across 34 scenarios. The key fix was adding explicit contrast examples to `fixed` vs `due_after_completion` — "regardless of when completed" for fixed, and concrete day-of-week examples for after_completion methods. Scenario 29 now scores 2/2, with agents correctly distinguishing fixed-schedule from completion-anchored recurrence.

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -134,7 +134,7 @@ Get tasks from OmniFocus with optional filtering.
 
 Note: Date fields (dueDate, deferDate, plannedDate) show directly-assigned dates only. Tasks that inherit dates from their project or action group will show empty date fields even though they are functionally subject to those dates in OmniFocus.
 
-Note: `repeatSummary` is a human-readable version of the recurrence RRULE (e.g., "Every 2 weeks on Mon, Wed, Fri"). Use this for user-facing output instead of parsing the raw `recurrence` string. `repetitionMethod` indicates how the next occurrence is calculated: "fixed" (next occurrence keeps the same day-of-week/month — e.g., always Monday), "start_after_completion" (next defer date = completion date + interval), "due_after_completion" (next due date = completion date + interval). Recurrence rules can be set, modified, or removed via `update_task(recurrence=..., repetition_method=...)`. Use standard iCalendar RRULE format (e.g., `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR`). Pass `recurrence=""` to remove recurrence.
+Note: `repeatSummary` is a human-readable version of the recurrence RRULE (e.g., "Every 2 weeks on Mon, Wed, Fri"). Use this for user-facing output instead of parsing the raw `recurrence` string. `repetitionMethod` indicates how the next occurrence is calculated: "fixed" (next occurrence on the original schedule regardless of when completed — e.g., if due every Monday, completing on Wednesday still makes the next occurrence due Monday), "start_after_completion" (next defer date = completion date + interval — e.g., complete Wednesday, next defer = following Wednesday), "due_after_completion" (next due date = completion date + interval — e.g., complete Wednesday, next due = following Wednesday). Recurrence rules can be set, modified, or removed via `update_task(recurrence=..., repetition_method=...)`. Use standard iCalendar RRULE format (e.g., `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR`). Pass `recurrence=""` to remove recurrence.
 
 ---
 
@@ -187,7 +187,7 @@ Consolidates: complete_task(), drop_task(), move_task(), set_parent_task(), set_
 - `completed: bool` (optional) — Mark task complete/incomplete. Uses `mark complete` internally, which correctly handles recurring tasks by spawning the next occurrence.
 - `status: str` (optional) — Task status - "active" or "dropped"
 - `recurrence: str` (optional) — iCalendar RRULE string (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR"), or empty string to remove recurrence. Omitting means no change.
-- `repetition_method: str` (optional) — How the next occurrence is calculated. Values: "fixed" (same day each period), "start_after_completion" (next defer date = completion date + interval), "due_after_completion" (next due date = completion date + interval). Only meaningful when recurrence is set.
+- `repetition_method: str` (optional) — How the next occurrence is calculated. Values: "fixed" (next occurrence on the original schedule regardless of when completed), "start_after_completion" (next defer date = completion date + interval), "due_after_completion" (next due date = completion date + interval). Only meaningful when recurrence is set.
 
 **Returns:** Success message with updated fields, or error message
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -716,9 +716,10 @@ def update_task(
         recurrence: iCalendar RRULE string (e.g., "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"),
             or empty string to remove recurrence. Omitting means no change. (optional)
         repetition_method: How the next occurrence is calculated (optional). Only meaningful
-            when recurrence is set. Values: "fixed" (same day each period),
-            "start_after_completion" (next defer date = completion date + interval),
-            "due_after_completion" (next due date = completion date + interval).
+            when recurrence is set. Values: "fixed" (next occurrence on the original schedule
+            regardless of when completed), "start_after_completion" (next defer date =
+            completion date + interval), "due_after_completion" (next due date = completion
+            date + interval).
         name: DEPRECATED - Use task_name instead (optional, for backward compatibility)
 
     Returns:


### PR DESCRIPTION
## Summary

- Clarifies `repetition_method` descriptions in `server_fastmcp.py` and `tool_descriptions.md`
- `fixed`: now explicitly says "next occurrence on the original schedule regardless of when completed"
- `*_after_completion`: adds concrete day-of-week example (complete Wednesday → next due Wednesday)
- Re-ran blind eval scenario 29 → 2/2 (was 1/2). Total evals: 68/68 (100%)

Closes #277

## Test plan

- [ ] Blind eval scenario 29 re-run passes 2/2 (done — see scored_results.md)
- [ ] `make test` — no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)