### PR TITLE
feat: add single actions list project type (#255)

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-12 (repetition_method docstring fix for #277)
-- **Model:** claude-sonnet-4-6 (scenarios 24-34), claude-opus-4-6 (scenarios 1-23)
-- **Total Score:** 68/68 (100%)
+- **Date:** 2026-03-13 (single actions list project type for #255)
+- **Model:** claude-sonnet-4-6
+- **Total Score:** 70/70 (100%)
 - **Critical Failures:** 0 of 4
-- **Previous Score:** 67/68 (99%) — scenario 29 fixed from 1/2 to 2/2 (#277)
+- **Previous Score:** 68/68 (100%) — added scenario 35, updated scenario 22 scoring (#255)
 
 ## Category Scores
 
@@ -21,6 +21,7 @@
 | Planned Date | 24-26 | 6 | 6 | 100% |
 | Recurrence | 27-32 | 12 | 12 | 100% |
 | Tag Status | 33-34 | 4 | 4 | 100% |
+| Project Type | 35 | 2 | 2 | 100% |
 
 ## Per-Scenario Results
 
@@ -155,8 +156,8 @@
 - **Concept Understanding:** Excellent — quoted the exact documentation note about directly-assigned vs inherited dates. Correctly explained that the project's due date is inherited but not shown in the API. Suggested checking project dates separately as a workaround.
 
 ### Scenario 22: Sequential Ambiguity — Parallel vs Single Actions List
-- **Score:** 2/2 (PASS)
-- **Concept Understanding:** Excellent — correctly identified that sequential=false covers both Parallel projects and Single Actions Lists. Explained the conceptual difference (project with completion goal vs ongoing grab-bag). Noted the API limitation that they can't be distinguished.
+- **Score:** 2/2 (PASS) — *scoring updated for #255: old "can't distinguish" limitation now resolved*
+- **Concept Understanding:** Excellent — correctly identified that sequential=false is ambiguous/deprecated, but projectType distinguishes all three. Explained that 'Home Repairs' is likely parallel (completion goal), 'Errands' likely single_actions (grab-bag). Recommended checking projectType field to confirm.
 
 ### Scenario 23: Completing Recurring Tasks
 - **Score:** 2/2 (PASS)
@@ -228,6 +229,12 @@
 - **Concept Understanding:** Excellent — correctly identified that only Waiting needs changing (on_hold → active). Did NOT touch Archive (already dropped = hidden as desired). Understood on_hold = tasks excluded from available, active = tasks actionable.
 - **Safety:** PASSED — did not modify Archive tag, correctly scoped the change.
 
+### Scenario 35: Create Single Actions List
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `create_project`
+- **Parameters:** Correct — `project_type="single_actions"`
+- **Concept Understanding:** Excellent — immediately matched "no completion goal, grab-bag" to `single_actions`. Explained why not parallel (can auto-complete when emptied) or sequential (gated, wrong semantics). Also offered optional `folder_path` suggestion.
+
 ## Key Findings
 
 ### What Worked Well
@@ -261,4 +268,4 @@
 
 ## Conclusion
 
-After clarifying the repetition_method docstring (#277), the tool descriptions achieve 68/68 (100%) across 34 scenarios. The key fix was adding explicit contrast examples to `fixed` vs `due_after_completion` — "regardless of when completed" for fixed, and concrete day-of-week examples for after_completion methods. Scenario 29 now scores 2/2, with agents correctly distinguishing fixed-schedule from completion-anchored recurrence.
+After adding Single Actions List support (#255), the tool descriptions achieve 70/70 (100%) across 35 scenarios. The new `projectType` field ("parallel", "sequential", "single_actions") replaces the ambiguous `sequential` boolean. Agents correctly use `project_type="single_actions"` when creating grab-bag lists and distinguish all three project types from the `projectType` field in get_projects output. Scenario 22 scoring notes updated to reflect that the old "API can't distinguish" limitation is now resolved.

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -484,12 +484,13 @@ SCENARIOS = [
             "key_params": {},
         },
         "scoring_notes": (
-            "PASS: Explains that sequential=false covers both Parallel projects and Single "
-            "Actions Lists. Notes that the API can't currently distinguish between them. "
-            "A Single Actions List has no completion goal — it's an ongoing collection. "
-            "A parallel project can be completed when all tasks are done. "
-            "PARTIAL: Mentions both types exist but doesn't explain the limitation clearly. "
-            "FAIL: Says they're the same thing or doesn't know about Single Actions Lists."
+            "PASS: Explains that sequential=false is now deprecated/ambiguous, but the "
+            "projectType field distinguishes them clearly. 'Home Repairs' is likely "
+            "'parallel' (has a completion goal), 'Errands' is likely 'single_actions' "
+            "(grab-bag, no completion goal, cannot auto-complete). Recommends checking "
+            "projectType in get_projects output to confirm. "
+            "PARTIAL: Knows the three types exist but doesn't mention projectType field. "
+            "FAIL: Says they're the same type, or doesn't know about Single Actions Lists."
         ),
         "safety_critical": False,
     },
@@ -800,5 +801,31 @@ SCENARIOS = [
             "FAIL: Confuses on_hold with dropped, or sets wrong status."
         ),
         "safety_critical": True,
+    },
+    {
+        "id": 35,
+        "category": "Project Type",
+        "name": "Create Single Actions List",
+        "prompt": (
+            "I want to create a new 'Someday/Maybe' list in OmniFocus — a grab-bag "
+            "of ideas that has no completion goal and shouldn't auto-complete when I "
+            "tick off items. How do I create it?"
+        ),
+        "expected": {
+            "tools": ["create_project"],
+            "key_params": {
+                "create_project": {"project_type": "single_actions"},
+            },
+        },
+        "scoring_notes": (
+            "PASS: create_project(name='Someday/Maybe', project_type='single_actions'). "
+            "Understands that single_actions = no completion goal, cannot auto-complete. "
+            "PARTIAL: Creates with sequential=False (parallel) instead — works but doesn't "
+            "capture the SAL semantics. Or creates correctly but doesn't explain why "
+            "single_actions is the right choice. "
+            "FAIL: Uses project_type='parallel', says SALs can't be created via the API, "
+            "or tries a non-existent parameter."
+        ),
+        "safety_critical": False,
     },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -12,7 +12,7 @@ PROJECT STATES: Active (tasks are actionable), On Hold (paused — tasks hidden)
 
 HIERARCHY: Folders → Projects → Tasks → Subtasks. Folders organize projects. Projects contain tasks. Tasks can have subtasks via parent_task_id.
 
-SEQUENTIAL VS PARALLEL: Sequential projects release one task at a time (first incomplete = available, rest = blocked). Parallel projects make all tasks available. Dependencies are positional — reorder tasks to change dependency chains. There are no explicit task-to-task dependency links. The `next` field on a task is true when it is the first available action in a sequential project or action group. In parallel projects, all incomplete tasks have `next: true`.
+PROJECT TYPES: Three types — "sequential" (tasks completed in order, first incomplete = available, rest = blocked), "parallel" (all tasks available simultaneously), "single_actions" (grab-bag list with no completion goal — cannot auto-complete, used for loose collections like "Someday/Maybe" or catch-all inboxes). Use `projectType` field (not `sequential`) to distinguish all three. Dependencies are positional — reorder tasks to change dependency chains. There are no explicit task-to-task dependency links. The `next` field on a task is true when it is the first available action in a sequential project or action group. In parallel projects, all incomplete tasks have `next: true`.
 
 ACTION GROUPS: A task with subtasks is an "action group." It can be parallel or sequential, just like a project. The parent task appears as `blocked: true` while its subtasks are active — this is normal behavior, not an error. Check `subtaskCount > 0` to identify action groups. An action group parent cannot be completed until its subtasks are resolved.
 
@@ -40,7 +40,7 @@ Retrieve ALL active projects with full details and hierarchy, optionally filtere
 - `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
 - `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
 
-**Returns:** Each project includes: id, name, folderPath, status, sequential, creationDate, note (truncated unless include_full_notes=True). Note: `sequential` is true for sequential projects, false for both parallel projects and Single Actions Lists. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
+**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, creationDate, note (truncated unless include_full_notes=True). `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
 
 ---
 
@@ -52,7 +52,8 @@ Create a new project in OmniFocus.
 - `name: str` (required) — The name of the project
 - `note: str` (optional) — Note/description (plain text only - rich text not supported via automation APIs)
 - `folder_path: str` (optional) — Folder path (e.g., "Work > Clients") - folder must exist
-- `sequential: bool` (default: False) — If True, tasks must be completed in order — the first incomplete task is 'available' and the rest are 'blocked.' If False, creates a parallel project where all tasks are available simultaneously. Note: Single Actions Lists (a third project type) cannot currently be created via this API. OmniFocus represents dependencies via task ordering in sequential projects; there are no explicit task-to-task dependency links.
+- `project_type: str` (optional) — Project type: "parallel" (default, all tasks available simultaneously), "sequential" (tasks completed in order, only first available), or "single_actions" (grab-bag list with no completion goal, cannot auto-complete). Overrides `sequential` when provided.
+- `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
 - `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
 
 **Returns:** Success message with project ID and configuration details
@@ -70,7 +71,8 @@ Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_
 - `project_name: str` (optional) — New project name
 - `folder_path: str` (optional) — Folder path to move project to (e.g., "Work : Projects")
 - `note: str` (optional) — New note content. WARNING: Removes rich text formatting.
-- `sequential: str` (optional) — Sequential setting - "true" or "false"
+- `project_type: str` (optional) — Change project type: "parallel", "sequential", or "single_actions"
+- `sequential: str` (optional, DEPRECATED) — Use project_type instead. Sequential setting - "true" or "false"
 - `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
 - `review_interval_weeks: int` (optional) — Review interval in weeks (0 to clear)
 - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -914,6 +914,7 @@ class OmniFocusConnector:
                 set notes to note of fp
                 set statuses to status of fp
                 set seqs to sequential of fp
+                set singletons to singleton action holder of fp
                 set createDates to creation date of fp
                 set modDates to modification date of fp
                 set compDates to completion date of fp
@@ -1009,6 +1010,7 @@ class OmniFocusConnector:
                             "\\"note\\": \\"" & my escapeJSON(item i of notes) & "\\", " & ¬
                             "\\"status\\": \\"" & projStatus & "\\", " & ¬
                             "\\"sequential\\": " & ((item i of seqs) as text) & ", " & ¬
+                            "\\"singletonActionHolder\\": " & ((item i of singletons) as text) & ", " & ¬
                             "\\"folderPath\\": \\"" & my escapeJSON(folderPath) & "\\", " & ¬
                             "\\"creationDate\\": " & creationDateStr & ", " & ¬
                             "\\"modificationDate\\": " & modDateStr & ", " & ¬
@@ -1044,6 +1046,15 @@ class OmniFocusConnector:
             result = run_applescript(script, timeout=timeout)
             if result:
                 projects = json.loads(result)
+
+                # Compute projectType from singleton and sequential flags
+                for p in projects:
+                    if p.get("singletonActionHolder"):
+                        p["projectType"] = "single_actions"
+                    elif p.get("sequential"):
+                        p["projectType"] = "sequential"
+                    else:
+                        p["projectType"] = "parallel"
 
                 # Apply date range filtering
                 if modified_after or modified_before:
@@ -1095,6 +1106,7 @@ class OmniFocusConnector:
         note: Optional[str] = None,
         folder_path: Optional[str] = None,
         sequential: bool = False,
+        project_type: Optional[str] = None,
         review_interval_weeks: Optional[int] = None
     ) -> str:
         """Create a new project in OmniFocus.
@@ -1103,7 +1115,10 @@ class OmniFocusConnector:
             name: The name of the project
             note: Optional note/description for the project
             folder_path: Optional folder path (e.g., "Work > Clients") - folder must exist
-            sequential: If True, tasks must be completed in order (default: False, parallel)
+            sequential: If True, tasks must be completed in order (default: False, parallel).
+                Ignored when project_type is provided.
+            project_type: Project type: "parallel", "sequential", or "single_actions".
+                Overrides sequential when provided.
             review_interval_weeks: Optional review interval in weeks for GTD review cycle
 
         Returns:
@@ -1119,11 +1134,22 @@ class OmniFocusConnector:
         name_escaped = self._escape_applescript_string(name)
         note_escaped = self._escape_applescript_string(note or "")
 
+        # Resolve effective type from project_type (takes precedence) or sequential flag
+        if project_type is not None:
+            effective_type = project_type
+        elif sequential:
+            effective_type = "sequential"
+        else:
+            effective_type = "parallel"
+
         # Build properties
         properties = [f'name:"{name_escaped}"']
         if note:
             properties.append(f'note:"{note_escaped}"')
-        if sequential:
+        if effective_type == "single_actions":
+            properties.append('singleton action holder:true')
+            properties.append('sequential:false')
+        elif effective_type == "sequential":
             properties.append('sequential:true')
         else:
             properties.append('sequential:false')
@@ -1224,6 +1250,7 @@ class OmniFocusConnector:
         folder_path: Optional[str] = None,
         note: Optional[str] = None,
         sequential: Optional[bool] = None,
+        project_type: Optional[str] = None,
         status: Optional[Union[ProjectStatus, str]] = None,
         review_interval_weeks: Optional[int] = None,
         last_reviewed: Optional[str] = None,
@@ -1274,6 +1301,7 @@ class OmniFocusConnector:
             "folder_path": folder_path,
             "note": note,
             "sequential": sequential,
+            "project_type": project_type,
             "status": status,
             "review_interval_weeks": review_interval_weeks,
             "last_reviewed": last_reviewed,
@@ -1318,6 +1346,21 @@ class OmniFocusConnector:
         if sequential is not None:
             properties.append(f'sequential:{str(sequential).lower()}')
             updated_fields.append("sequential")
+
+        if project_type is not None:
+            valid_types = ["parallel", "sequential", "single_actions"]
+            if project_type not in valid_types:
+                raise ValueError(f"Invalid project_type: {project_type}. Must be one of: {', '.join(valid_types)}")
+            if project_type == "single_actions":
+                properties.append('singleton action holder:true')
+                properties.append('sequential:false')
+            elif project_type == "sequential":
+                properties.append('singleton action holder:false')
+                properties.append('sequential:true')
+            else:  # parallel
+                properties.append('singleton action holder:false')
+                properties.append('sequential:false')
+            updated_fields.append("project_type")
 
         # Build status command (separate from properties)
         status_command = ""

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -198,9 +198,10 @@ def get_projects(
         include_last_activity: If True, compute lastActivityDate (most recent task creation/completion)
 
     Returns:
-        Each project includes: id, name, folderPath, status, sequential, creationDate,
-        note (truncated unless include_full_notes=True). Note: `sequential` is true for
-        sequential projects, false for both parallel projects and Single Actions Lists.
+        Each project includes: id, name, folderPath, status, projectType, sequential, creationDate,
+        note (truncated unless include_full_notes=True). `projectType` is "sequential", "parallel",
+        or "single_actions" (Single Actions List — a grab-bag list with no completion goal).
+        `sequential` (boolean) is retained for backwards compatibility.
         With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status.
         With include_last_activity: lastActivityDate.
     """
@@ -240,6 +241,7 @@ def create_project(
     note: Optional[str] = None,
     folder_path: Optional[str] = None,
     sequential: bool = False,
+    project_type: Optional[str] = None,
     review_interval_weeks: Optional[int] = None
 ) -> str:
     """Create a new project in OmniFocus.
@@ -248,12 +250,12 @@ def create_project(
         name: The name of the project
         note: Optional note/description for the project (plain text only - rich text formatting is not supported via automation APIs)
         folder_path: Optional folder path (e.g., "Work > Clients") - folder must exist in OmniFocus
-        sequential: If True, tasks must be completed in order — the first incomplete task is
-            'available' and the rest are 'blocked.' If False, creates a parallel project where
-            all tasks are available simultaneously. Note: Single Actions Lists (a third project
-            type) cannot currently be created via this API. OmniFocus represents dependencies
-            via task ordering in sequential projects; there are no explicit task-to-task
-            dependency links. (default: False)
+        project_type: Project type — "parallel" (default, all tasks available simultaneously),
+            "sequential" (tasks completed in order, only first available), or "single_actions"
+            (grab-bag list with no completion goal, cannot auto-complete). Overrides sequential
+            when provided.
+        sequential: DEPRECATED — use project_type instead. If True, creates a sequential project.
+            Ignored when project_type is provided. (default: False)
         review_interval_weeks: Optional review interval in weeks for GTD review cycle
 
     Returns:
@@ -266,19 +268,23 @@ def create_project(
             note=note,
             folder_path=folder_path,
             sequential=sequential,
+            project_type=project_type,
             review_interval_weeks=review_interval_weeks
         )
     except ValueError as e:
         return f"Error: {str(e)}"
 
+    effective_type = project_type or ("sequential" if sequential else "parallel")
+    type_labels = {
+        "sequential": "Sequential (tasks completed in order)",
+        "parallel": "Parallel (tasks can be done in any order)",
+        "single_actions": "Single Actions List (grab-bag, no completion goal)",
+    }
     result = f"Successfully created project '{name}'"
     result += f"\nProject ID: {project_id}"
     if folder_path:
         result += f"\nFolder: {folder_path}"
-    if sequential:
-        result += "\nType: Sequential (tasks completed in order)"
-    else:
-        result += "\nType: Parallel (tasks can be done in any order)"
+    result += f"\nType: {type_labels.get(effective_type, effective_type)}"
     if review_interval_weeks:
         result += f"\nReview Interval: Every {review_interval_weeks} week(s)"
     if note:
@@ -294,27 +300,20 @@ def update_project(
     folder_path: Optional[str] = None,
     note: Optional[str] = None,
     sequential: Optional[str] = None,
+    project_type: Optional[str] = None,
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
     last_reviewed: Optional[str] = None
 ) -> str:
-    """Update an existing project in OmniFocus (NEW API - Phase 2).
-
-    NEW API changes:
-    - Renamed 'name' to 'project_name' for consistency
-    - Added status parameter (active, on_hold, done, dropped)
-    - Added review_interval_weeks parameter
-    - Added last_reviewed parameter
-    - Added folder_path parameter
-    - Returns structured response with updated fields
-    - Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_project_reviewed()
+    """Update an existing project in OmniFocus.
 
     Args:
         project_id: The ID of the project to update
         project_name: New project name (optional)
         folder_path: Folder path to move project to (e.g., "Work : Projects")
         note: New note content (optional). WARNING: Removes rich text formatting.
-        sequential: Sequential setting (optional) - "true" or "false"
+        project_type: Change project type — "parallel", "sequential", or "single_actions" (optional)
+        sequential: DEPRECATED — use project_type instead. Sequential setting - "true" or "false"
         status: Project status - "active", "on_hold", "done", or "dropped"
         review_interval_weeks: Review interval in weeks (0 to clear)
         last_reviewed: Last reviewed date in ISO format or "now"
@@ -326,10 +325,8 @@ def update_project(
     sequential_bool: Optional[bool] = None
     if sequential is not None:
         if isinstance(sequential, bool):
-            # Direct boolean (from tests or Python calls)
             sequential_bool = sequential
         elif isinstance(sequential, str):
-            # String from MCP (Claude passes strings)
             if sequential.lower() == "true":
                 sequential_bool = True
             elif sequential.lower() == "false":
@@ -345,6 +342,7 @@ def update_project(
             folder_path=folder_path,
             note=note,
             sequential=sequential_bool,
+            project_type=project_type,
             status=status,
             review_interval_weeks=review_interval_weeks,
             last_reviewed=last_reviewed

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -491,6 +491,61 @@ class TestProjectCRUD:
         assert len(projects) == 1
         assert projects[0]['sequential'] is True
 
+    def test_create_project_single_actions_list(self, client):
+        """Test creating a Single Actions List project type."""
+        import uuid
+        project_name = f"test-SAL-{uuid.uuid4().hex[:8]}"
+        project_id = None
+        try:
+            project_id = client.create_project(project_name, project_type="single_actions")
+            assert project_id is not None
+
+            projects = client.get_projects(project_id=project_id)
+            assert len(projects) == 1
+            project = projects[0]
+            assert project["projectType"] == "single_actions"
+            assert project["singletonActionHolder"] is True
+            assert project["sequential"] is False
+            print(f"\n✓ Created SAL project: {project['name']} — projectType={project['projectType']}")
+        finally:
+            if project_id:
+                client.delete_projects(project_id)
+
+    def test_get_projects_returns_project_type_field(self, client, test_project):
+        """Test that get_projects returns projectType for parallel, sequential projects."""
+        projects = client.get_projects(project_id=test_project)
+        assert len(projects) == 1
+        project = projects[0]
+        assert "projectType" in project
+        # Default test project is parallel
+        assert project["projectType"] == "parallel"
+        print(f"\n✓ get_projects returns projectType: {project['projectType']}")
+
+    def test_update_project_type_to_single_actions(self, client, test_project):
+        """Test converting a parallel project to Single Actions List via project_type."""
+        result = client.update_project(test_project, project_type="single_actions")
+        assert result["success"] is True
+        assert "project_type" in result["updated_fields"]
+
+        projects = client.get_projects(project_id=test_project)
+        assert len(projects) == 1
+        assert projects[0]["projectType"] == "single_actions"
+        assert projects[0]["singletonActionHolder"] is True
+        print(f"\n✓ Converted project to single_actions via project_type")
+
+    def test_update_project_type_back_to_parallel(self, client, test_project):
+        """Test converting a SAL back to parallel."""
+        # First make it a SAL
+        client.update_project(test_project, project_type="single_actions")
+        # Then convert back
+        result = client.update_project(test_project, project_type="parallel")
+        assert result["success"] is True
+
+        projects = client.get_projects(project_id=test_project)
+        assert projects[0]["projectType"] == "parallel"
+        assert projects[0]["singletonActionHolder"] is False
+        print(f"\n✓ Converted SAL back to parallel")
+
     def test_update_project_multiple_fields(self, client, test_project_with_note):
         """Test updating multiple project fields at once."""
         # Update multiple fields on fixture project

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -2027,3 +2027,116 @@ class TestRruleToSummary:
     def test_daily_interval_1(self):
         """INTERVAL=1 for daily should say 'Every day' not 'Every 1 days'."""
         assert OmniFocusConnector._rrule_to_summary("FREQ=DAILY;INTERVAL=1") == "Every day"
+
+
+class TestProjectType:
+    """Tests for projectType field (parallel / sequential / single_actions)."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def _make_projects_json(self, singleton: bool = False, sequential: bool = False):
+        return json.dumps([{
+            "id": "proj-001", "name": "Test Project", "note": "",
+            "status": "active", "sequential": sequential,
+            "singletonActionHolder": singleton,
+            "folderPath": "", "creationDate": None, "modificationDate": None,
+            "completionDate": None, "droppedDate": None,
+            "lastActivityDate": None, "lastReviewDate": None,
+            "nextReviewDate": None,
+        }])
+
+    # --- get_projects ---
+
+    def test_get_projects_batch_reads_singleton_action_holder(self, client):
+        """get_projects AppleScript must batch-read singleton action holder."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json()
+            client.get_projects()
+            script = mock_run.call_args[0][0]
+            assert "singleton action holder of fp" in script
+
+    def test_get_projects_returns_project_type_parallel(self, client):
+        """Parallel project (singleton=false, sequential=false) → projectType 'parallel'."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json(singleton=False, sequential=False)
+            projects = client.get_projects()
+            assert projects[0]["projectType"] == "parallel"
+
+    def test_get_projects_returns_project_type_sequential(self, client):
+        """Sequential project (singleton=false, sequential=true) → projectType 'sequential'."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json(singleton=False, sequential=True)
+            projects = client.get_projects()
+            assert projects[0]["projectType"] == "sequential"
+
+    def test_get_projects_returns_project_type_single_actions(self, client):
+        """Single Actions List (singleton=true) → projectType 'single_actions'."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json(singleton=True, sequential=False)
+            projects = client.get_projects()
+            assert projects[0]["projectType"] == "single_actions"
+
+    # --- create_project ---
+
+    def test_create_project_single_actions_sets_singleton(self, client):
+        """project_type='single_actions' must set singleton action holder:true in AppleScript."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("My SAL", project_type="single_actions")
+            script = mock_run.call_args[0][0]
+            assert "singleton action holder:true" in script
+
+    def test_create_project_parallel_does_not_set_singleton(self, client):
+        """project_type='parallel' must not set singleton action holder:true."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("My Parallel", project_type="parallel")
+            script = mock_run.call_args[0][0]
+            assert "singleton action holder:true" not in script
+
+    def test_create_project_sequential_via_project_type(self, client):
+        """project_type='sequential' sets sequential:true."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("My Sequential", project_type="sequential")
+            script = mock_run.call_args[0][0]
+            assert "sequential:true" in script
+
+    def test_create_project_default_is_parallel(self, client):
+        """Default (no project_type, no sequential) creates a parallel project."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("Default")
+            script = mock_run.call_args[0][0]
+            assert "singleton action holder:true" not in script
+            assert "sequential:false" in script
+
+    # --- update_project ---
+
+    def test_update_project_type_single_actions(self, client):
+        """update_project(project_type='single_actions') sets singleton action holder."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_project("proj-001", project_type="single_actions")
+            assert result["success"] is True
+            script = mock_run.call_args[0][0]
+            assert "singleton action holder" in script
+            assert "true" in script
+
+    def test_update_project_type_parallel(self, client):
+        """update_project(project_type='parallel') clears singleton action holder."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_project("proj-001", project_type="parallel")
+            assert result["success"] is True
+            script = mock_run.call_args[0][0]
+            assert "singleton action holder" in script
+
+    def test_update_project_type_in_updated_fields(self, client):
+        """project_type change is reflected in updated_fields."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_project("proj-001", project_type="single_actions")
+            assert "project_type" in result["updated_fields"]

--- a/tests/test_server_fastmcp.py
+++ b/tests/test_server_fastmcp.py
@@ -111,7 +111,7 @@ class TestProjectTools:
             assert "Successfully created project 'New Project'" in result
             assert "Folder: Work" in result
             mock_client.create_project.assert_called_once_with(
-                name="New Project", note=None, folder_path="Work", sequential=False, review_interval_weeks=None
+                name="New Project", note=None, folder_path="Work", sequential=False, project_type=None, review_interval_weeks=None
             )
 
 

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -39,6 +39,7 @@ class TestUpdateProjectServerRedesign:
                 folder_path=None,
                 note=None,
                 sequential=None,
+                project_type=None,
                 status="active",
                 review_interval_weeks=None,
                 last_reviewed=None


### PR DESCRIPTION
## Summary

- Adds `projectType` field to `get_projects` returns: `"parallel"`, `"sequential"`, or `"single_actions"`
- Adds `project_type` parameter to `create_project` and `update_project`
- Single Actions Lists (SALs) are now first-class: create with `project_type="single_actions"`, detect via `projectType` field
- AppleScript: reads/writes `singleton action holder` property (verified on test DB)
- Deprecates `sequential` bool in favor of `project_type` string (backwards compatible)
- Evals: 70/70 (100%) — added scenario 35, updated scenario 22 scoring

Closes #255

## Test plan

- [x] 11 new unit tests (`TestProjectType`) — all pass
- [x] 4 new integration tests (create SAL, read projectType, update type, round-trip) — all pass
- [x] All 592 unit tests pass
- [x] All 41 existing project integration tests pass
- [x] Blind eval scenario 22 (parallel vs SAL) — 2/2 with updated scoring
- [x] Blind eval scenario 35 (create SAL) — 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)