### PR TITLE
feat: expose next_review_date in update_project/update_projects (#257)

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-13 (folder status for #258)
+- **Date:** 2026-03-13 (next review date for #257)
 - **Model:** claude-sonnet-4-6
-- **Total Score:** 72/72 (100%)
+- **Total Score:** 74/74 (100%)
 - **Critical Failures:** 0 of 4
-- **Previous Score:** 70/70 (100%) — added scenario 36 (#258)
+- **Previous Score:** 72/72 (100%) — added scenario 37 (#257)
 
 ## Category Scores
 
@@ -23,6 +23,7 @@
 | Tag Status | 33-34 | 4 | 4 | 100% |
 | Project Type | 35 | 2 | 2 | 100% |
 | Folder Status | 36 | 2 | 2 | 100% |
+| Next Review Date | 37 | 2 | 2 | 100% |
 
 ## Per-Scenario Results
 
@@ -242,6 +243,12 @@
 - **Parameters:** Correct — `folder_id="folder-999"`, `status="dropped"`
 - **Concept Understanding:** Excellent — immediately identified that "archive without deleting" = drop. Explained dropped = hidden but preserved. Also noted that `status='active'` would restore it.
 
+### Scenario 37: Force Project Review Date
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `update_project`
+- **Parameters:** Correct — `project_id="proj-abc"`, `next_review_date="2026-04-15"`
+- **Concept Understanding:** Excellent — immediately matched "force regardless of last_reviewed + interval" to `next_review_date`. Quoted the docstring "overrides the date OmniFocus calculates" to justify the choice.
+
 ## Key Findings
 
 ### What Worked Well
@@ -275,4 +282,4 @@
 
 ## Conclusion
 
-After adding folder status support (#258), the tool descriptions achieve 72/72 (100%) across 36 scenarios. The new `projectType` field ("parallel", "sequential", "single_actions") replaces the ambiguous `sequential` boolean. Agents correctly use `project_type="single_actions"` when creating grab-bag lists and distinguish all three project types from the `projectType` field in get_projects output. Scenario 22 scoring notes updated to reflect that the old "API can't distinguish" limitation is now resolved.
+After adding next review date support (#257), the tool descriptions achieve 74/74 (100%) across 37 scenarios. The new `next_review_date` parameter in `update_project`/`update_projects` allows agents to force a specific review date that overrides the OmniFocus-calculated date from last_reviewed + review_interval. The `get_projects` return documentation now includes `lastReviewDate`, `nextReviewDate`, and `reviewIntervalWeeks` fields.

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -851,4 +851,27 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    {
+        "id": 37,
+        "category": "Next Review Date",
+        "name": "Force Project Review Date",
+        "prompt": (
+            "I have a project with ID proj-abc. I want to force it to come up for review "
+            "on April 15th, 2026, regardless of when it was last reviewed or what the "
+            "review interval is set to. How do I do that?"
+        ),
+        "expected": {
+            "tools": ["update_project"],
+            "key_params": {
+                "update_project": {"project_id": "proj-abc", "next_review_date": "2026-04-15"},
+            },
+        },
+        "scoring_notes": (
+            "PASS: update_project(project_id='proj-abc', next_review_date='2026-04-15'). "
+            "Correctly uses next_review_date to override the calculated date. "
+            "PARTIAL: Uses last_reviewed instead of next_review_date, or uses both. "
+            "FAIL: Says it can't be done, uses review_interval_weeks only, or uses wrong tool."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -40,7 +40,7 @@ Retrieve ALL active projects with full details and hierarchy, optionally filtere
 - `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
 - `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
 
-**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, creationDate, note (truncated unless include_full_notes=True). `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
+**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, creationDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
 
 ---
 
@@ -76,6 +76,7 @@ Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_
 - `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
 - `review_interval_weeks: int` (optional) — Review interval in weeks (0 to clear)
 - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
+- `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
 
 **Returns:** Success message with project ID and updated fields, or error message
 
@@ -94,6 +95,7 @@ IMPORTANT: This function does NOT accept project_name or note parameters because
 - `status: str` (optional) — Project status - "active", "on_hold", "done", "dropped"
 - `review_interval_weeks: int` (optional) — Review interval in weeks
 - `last_reviewed: str` (optional) — Last review date ("now" or ISO format)
+- `next_review_date: str` (optional) — Explicit next review date in ISO format
 
 **Returns:** Success message with updated and failed counts
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -303,7 +303,8 @@ def update_project(
     project_type: Optional[str] = None,
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
-    last_reviewed: Optional[str] = None
+    last_reviewed: Optional[str] = None,
+    next_review_date: Optional[str] = None
 ) -> str:
     """Update an existing project in OmniFocus.
 
@@ -317,6 +318,7 @@ def update_project(
         status: Project status - "active", "on_hold", "done", or "dropped"
         review_interval_weeks: Review interval in weeks (0 to clear)
         last_reviewed: Last reviewed date in ISO format or "now"
+        next_review_date: Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval. (optional)
 
     Returns:
         Success message with project ID and updated fields, or error message
@@ -345,7 +347,8 @@ def update_project(
             project_type=project_type,
             status=status,
             review_interval_weeks=review_interval_weeks,
-            last_reviewed=last_reviewed
+            last_reviewed=last_reviewed,
+            next_review_date=next_review_date
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -373,7 +376,8 @@ def update_projects(
     sequential: Optional[str] = None,
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
-    last_reviewed: Optional[str] = None
+    last_reviewed: Optional[str] = None,
+    next_review_date: Optional[str] = None
 ) -> str:
     """Update multiple projects with the same properties (NEW API - Phase 2, Batch Function).
 
@@ -391,6 +395,7 @@ def update_projects(
         status: Project status - one of: "active", "on_hold", "done", "dropped"
         review_interval_weeks: Review interval in weeks
         last_reviewed: Last review date ("now" or ISO format like "2025-01-15")
+        next_review_date: Explicit next review date in ISO format — overrides OmniFocus-calculated date (optional)
 
     Returns:
         Success message with updated and failed counts, or error message
@@ -425,7 +430,8 @@ def update_projects(
             sequential=sequential_bool,
             status=status,
             review_interval_weeks=review_interval_weeks,
-            last_reviewed=last_reviewed
+            last_reviewed=last_reviewed,
+            next_review_date=next_review_date
         )
 
         # Handle dict return from client

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -42,7 +42,8 @@ class TestUpdateProjectServerRedesign:
                 project_type=None,
                 status="active",
                 review_interval_weeks=None,
-                last_reviewed=None
+                last_reviewed=None,
+                next_review_date=None
             )
 
             assert isinstance(result, str)
@@ -256,3 +257,24 @@ class TestUpdateProjectServerRedesign:
             assert call_kwargs["folder_path"] == "Work : Projects"
 
             assert isinstance(result, str)
+
+
+class TestUpdateProjectNextReviewDate:
+    """Tests for next_review_date parameter in update_project server tool."""
+
+    def test_update_project_next_review_date_passed_to_connector(self):
+        """next_review_date is passed through to the connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-001",
+                "updated_fields": ["next_review_date"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-001", next_review_date="2026-04-01")
+
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["next_review_date"] == "2026-04-01"
+            assert "updated" in result.lower() or "success" in result.lower()


### PR DESCRIPTION
## Summary

- Adds `next_review_date: Optional[str]` parameter to `update_project` and `update_projects` MCP tools
- Passes through to the connector (which already fully implemented `next_review_date` support in AppleScript)
- Updates `get_projects` tool description to document `lastReviewDate`, `nextReviewDate`, `reviewIntervalWeeks` return fields
- Adds blind eval scenario 37 (Force Project Review Date) — 74/74 (100%)

## What changed

**Server layer only** — no AppleScript changes needed. The connector's `update_project` and `update_projects` already accepted and handled `next_review_date`. This PR wires up the MCP tool parameters.

## Test plan

- [x] Unit tests: 601 pass (`python -m pytest tests/ -q --ignore=tests/test_integration_real.py --ignore=tests/benchmarks`)
- [x] New test: `TestUpdateProjectNextReviewDate.test_update_project_next_review_date_passed_to_connector`
- [x] Updated existing mock assertion in `test_update_project_set_status` to include `next_review_date=None`
- [x] Blind eval scenario 37: PASS (2/2)

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)