### PR TITLE
feat: add completedByChildren to get/create/update_project (#254)

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-13 (next review date for #257)
+- **Date:** 2026-03-13 (completedByChildren for #254)
 - **Model:** claude-sonnet-4-6
-- **Total Score:** 74/74 (100%)
+- **Total Score:** 76/76 (100%)
 - **Critical Failures:** 0 of 4
-- **Previous Score:** 72/72 (100%) — added scenario 37 (#257)
+- **Previous Score:** 74/74 (100%) — added scenario 37 (#257)
 
 ## Category Scores
 
@@ -280,6 +280,10 @@
 
 7. **Recurring task completion behavior unclear (Scenario 23):** Added `mark complete` clarification to update_task completed parameter. **Eval: PASS.**
 
+### Issues Found and Fixed (Current Round — #254)
+
+8. **`completed_by_children` not documented (Scenario 38):** Added `completed_by_children` param to `create_project` and `update_project`, `completedByChildren` field to `get_projects` returns. **Eval: PASS.**
+
 ## Conclusion
 
-After adding next review date support (#257), the tool descriptions achieve 74/74 (100%) across 37 scenarios. The new `next_review_date` parameter in `update_project`/`update_projects` allows agents to force a specific review date that overrides the OmniFocus-calculated date from last_reviewed + review_interval. The `get_projects` return documentation now includes `lastReviewDate`, `nextReviewDate`, and `reviewIntervalWeeks` fields.
+After adding `completedByChildren` support (#254), the tool descriptions achieve 76/76 (100%) across 38 scenarios. The new `completed_by_children` parameter in `update_project`/`create_project` allows agents to enable auto-completion of projects when their last action is checked off. The agent also correctly noted the constraint that `single_actions` projects cannot auto-complete.

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -874,4 +874,26 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    {
+        "id": 38,
+        "category": "Complete With Last Action",
+        "name": "Enable Auto-Complete When Last Task Done",
+        "prompt": (
+            "I have a project with ID proj-xyz. I want it to automatically mark itself "
+            "as complete when I check off its last remaining task. How do I enable that?"
+        ),
+        "expected": {
+            "tools": ["update_project"],
+            "key_params": {
+                "update_project": {"project_id": "proj-xyz", "completed_by_children": True},
+            },
+        },
+        "scoring_notes": (
+            "PASS: update_project(project_id='proj-xyz', completed_by_children=True). "
+            "Correctly uses completed_by_children to enable auto-completion. "
+            "PARTIAL: Mentions the right concept but uses wrong parameter name or tool. "
+            "FAIL: Says it can't be done, uses status='done', or doesn't mention completed_by_children."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -40,7 +40,7 @@ Retrieve ALL active projects with full details and hierarchy, optionally filtere
 - `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
 - `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
 
-**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, creationDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
+**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, creationDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
 
 ---
 
@@ -55,6 +55,7 @@ Create a new project in OmniFocus.
 - `project_type: str` (optional) — Project type: "parallel" (default, all tasks available simultaneously), "sequential" (tasks completed in order, only first available), or "single_actions" (grab-bag list with no completion goal, cannot auto-complete). Overrides `sequential` when provided.
 - `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
 - `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
+- `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
 
 **Returns:** Success message with project ID and configuration details
 
@@ -77,6 +78,7 @@ Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_
 - `review_interval_weeks: int` (optional) — Review interval in weeks (0 to clear)
 - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
 - `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
+- `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
 
 **Returns:** Success message with project ID and updated fields, or error message
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -915,6 +915,7 @@ class OmniFocusConnector:
                 set statuses to status of fp
                 set seqs to sequential of fp
                 set singletons to singleton action holder of fp
+                set completionsByChildren to completed by children of fp
                 set createDates to creation date of fp
                 set modDates to modification date of fp
                 set compDates to completion date of fp
@@ -1011,6 +1012,7 @@ class OmniFocusConnector:
                             "\\"status\\": \\"" & projStatus & "\\", " & ¬
                             "\\"sequential\\": " & ((item i of seqs) as text) & ", " & ¬
                             "\\"singletonActionHolder\\": " & ((item i of singletons) as text) & ", " & ¬
+                            "\\"completedByChildren\\": " & ((item i of completionsByChildren) as text) & ", " & ¬
                             "\\"folderPath\\": \\"" & my escapeJSON(folderPath) & "\\", " & ¬
                             "\\"creationDate\\": " & creationDateStr & ", " & ¬
                             "\\"modificationDate\\": " & modDateStr & ", " & ¬
@@ -1107,7 +1109,8 @@ class OmniFocusConnector:
         folder_path: Optional[str] = None,
         sequential: bool = False,
         project_type: Optional[str] = None,
-        review_interval_weeks: Optional[int] = None
+        review_interval_weeks: Optional[int] = None,
+        completed_by_children: Optional[bool] = None
     ) -> str:
         """Create a new project in OmniFocus.
 
@@ -1157,6 +1160,8 @@ class OmniFocusConnector:
             # Convert weeks to days for OmniFocus review interval
             review_days = review_interval_weeks * 7
             properties.append(f'review interval:{review_days}')
+        if completed_by_children is not None:
+            properties.append(f'completed by children:{str(completed_by_children).lower()}')
 
         properties_str = ", ".join(properties)
 
@@ -1254,7 +1259,8 @@ class OmniFocusConnector:
         status: Optional[Union[ProjectStatus, str]] = None,
         review_interval_weeks: Optional[int] = None,
         last_reviewed: Optional[str] = None,
-        next_review_date: Optional[str] = None
+        next_review_date: Optional[str] = None,
+        completed_by_children: Optional[bool] = None
     ) -> dict:
         """Update properties of an existing project (NEW API - Phase 2).
 
@@ -1305,7 +1311,8 @@ class OmniFocusConnector:
             "status": status,
             "review_interval_weeks": review_interval_weeks,
             "last_reviewed": last_reviewed,
-            "next_review_date": next_review_date
+            "next_review_date": next_review_date,
+            "completed_by_children": completed_by_children
         }
 
         # Check if at least one field is provided
@@ -1403,6 +1410,12 @@ class OmniFocusConnector:
             next_review_command = f'set next review date of theProject to date "{next_review_date}"'
             updated_fields.append("next_review_date")
 
+        # Build completed by children command
+        completed_by_children_command = ""
+        if completed_by_children is not None:
+            completed_by_children_command = f'set completed by children of theProject to {str(completed_by_children).lower()}'
+            updated_fields.append("completed_by_children")
+
         # Build folder path command
         folder_command = ""
         if folder_path is not None:
@@ -1481,6 +1494,7 @@ class OmniFocusConnector:
                     {review_command}
                     {reviewed_command}
                     {next_review_command}
+                    {completed_by_children_command}
                     {folder_command}
 
                     return "true"

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -198,10 +198,12 @@ def get_projects(
         include_last_activity: If True, compute lastActivityDate (most recent task creation/completion)
 
     Returns:
-        Each project includes: id, name, folderPath, status, projectType, sequential, creationDate,
-        note (truncated unless include_full_notes=True). `projectType` is "sequential", "parallel",
-        or "single_actions" (Single Actions List — a grab-bag list with no completion goal).
-        `sequential` (boolean) is retained for backwards compatibility.
+        Each project includes: id, name, folderPath, status, projectType, sequential,
+        completedByChildren, creationDate, note (truncated unless include_full_notes=True).
+        `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List —
+        a grab-bag list with no completion goal). `sequential` (boolean) is retained for
+        backwards compatibility. `completedByChildren` (boolean) indicates whether the project
+        auto-completes when its last remaining action is completed.
         With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status.
         With include_last_activity: lastActivityDate.
     """
@@ -242,7 +244,8 @@ def create_project(
     folder_path: Optional[str] = None,
     sequential: bool = False,
     project_type: Optional[str] = None,
-    review_interval_weeks: Optional[int] = None
+    review_interval_weeks: Optional[int] = None,
+    completed_by_children: Optional[bool] = None
 ) -> str:
     """Create a new project in OmniFocus.
 
@@ -257,6 +260,7 @@ def create_project(
         sequential: DEPRECATED — use project_type instead. If True, creates a sequential project.
             Ignored when project_type is provided. (default: False)
         review_interval_weeks: Optional review interval in weeks for GTD review cycle
+        completed_by_children: Auto-complete the project when its last remaining action is completed. (optional)
 
     Returns:
         Success message with project ID and configuration details
@@ -269,7 +273,8 @@ def create_project(
             folder_path=folder_path,
             sequential=sequential,
             project_type=project_type,
-            review_interval_weeks=review_interval_weeks
+            review_interval_weeks=review_interval_weeks,
+            completed_by_children=completed_by_children
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -304,7 +309,8 @@ def update_project(
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
     last_reviewed: Optional[str] = None,
-    next_review_date: Optional[str] = None
+    next_review_date: Optional[str] = None,
+    completed_by_children: Optional[bool] = None
 ) -> str:
     """Update an existing project in OmniFocus.
 
@@ -319,6 +325,7 @@ def update_project(
         review_interval_weeks: Review interval in weeks (0 to clear)
         last_reviewed: Last reviewed date in ISO format or "now"
         next_review_date: Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval. (optional)
+        completed_by_children: Auto-complete the project when its last remaining action is completed. (optional)
 
     Returns:
         Success message with project ID and updated fields, or error message
@@ -348,7 +355,8 @@ def update_project(
             status=status,
             review_interval_weeks=review_interval_weeks,
             last_reviewed=last_reviewed,
-            next_review_date=next_review_date
+            next_review_date=next_review_date,
+            completed_by_children=completed_by_children
         )
     except ValueError as e:
         return f"Error: {str(e)}"

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -546,6 +546,40 @@ class TestProjectCRUD:
         assert projects[0]["singletonActionHolder"] is False
         print(f"\n✓ Converted SAL back to parallel")
 
+    def test_get_projects_returns_completed_by_children_field(self, client, test_project):
+        """get_projects includes completedByChildren field."""
+        projects = client.get_projects(project_id=test_project)
+        assert len(projects) == 1
+        assert "completedByChildren" in projects[0]
+        assert isinstance(projects[0]["completedByChildren"], bool)
+        print(f"\n✓ completedByChildren field present: {projects[0]['completedByChildren']}")
+
+    def test_create_and_update_project_completed_by_children(self, client):
+        """Create a project with completedByChildren=True, verify, update to False, verify."""
+        project_id = None
+        try:
+            project_id = client.create_project(
+                "test-completed-by-children",
+                completed_by_children=True
+            )
+            assert project_id is not None
+
+            projects = client.get_projects(project_id=project_id)
+            assert len(projects) == 1
+            assert projects[0]["completedByChildren"] is True
+            print(f"\n✓ Created project with completedByChildren=True")
+
+            result = client.update_project(project_id, completed_by_children=False)
+            assert result["success"] is True
+            assert "completed_by_children" in result["updated_fields"]
+
+            projects = client.get_projects(project_id=project_id)
+            assert projects[0]["completedByChildren"] is False
+            print(f"\n✓ Updated completedByChildren to False")
+        finally:
+            if project_id:
+                client.delete_projects([project_id])
+
     def test_update_project_multiple_fields(self, client, test_project_with_note):
         """Test updating multiple project fields at once."""
         # Update multiple fields on fixture project

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -2217,3 +2217,95 @@ class TestProjectType:
             mock_run.return_value = "true"
             result = client.update_project("proj-001", project_type="single_actions")
             assert "project_type" in result["updated_fields"]
+
+
+class TestCompletedByChildren:
+    """Tests for completed_by_children (completed by children) property."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def _make_projects_json(self, completed_by_children: bool = False):
+        return json.dumps([{
+            "id": "proj-001", "name": "Test Project", "note": "",
+            "status": "active", "sequential": False,
+            "singletonActionHolder": False,
+            "completedByChildren": completed_by_children,
+            "folderPath": "", "creationDate": None, "modificationDate": None,
+            "completionDate": None, "droppedDate": None,
+            "lastActivityDate": None, "lastReviewDate": None,
+            "nextReviewDate": None,
+        }])
+
+    # --- get_projects ---
+
+    def test_get_projects_batch_reads_completed_by_children(self, client):
+        """get_projects AppleScript must batch-read 'completed by children'."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json()
+            client.get_projects()
+            script = mock_run.call_args[0][0]
+            assert "completed by children of fp" in script
+
+    def test_get_projects_returns_completed_by_children_true(self, client):
+        """completedByChildren=true in JSON → True in returned project dict."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json(completed_by_children=True)
+            projects = client.get_projects()
+            assert projects[0]["completedByChildren"] is True
+
+    def test_get_projects_returns_completed_by_children_false(self, client):
+        """completedByChildren=false in JSON → False in returned project dict."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_projects_json(completed_by_children=False)
+            projects = client.get_projects()
+            assert projects[0]["completedByChildren"] is False
+
+    # --- create_project ---
+
+    def test_create_project_completed_by_children_true(self, client):
+        """create_project(completed_by_children=True) sets the property in AppleScript."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("My Project", completed_by_children=True)
+            script = mock_run.call_args[0][0]
+            assert "completed by children:true" in script
+
+    def test_create_project_completed_by_children_false(self, client):
+        """create_project(completed_by_children=False) sets the property to false."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("My Project", completed_by_children=False)
+            script = mock_run.call_args[0][0]
+            assert "completed by children:false" in script
+
+    def test_create_project_completed_by_children_none_not_set(self, client):
+        """Default None does not set completed by children in AppleScript."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "proj-new-001"
+            client.create_project("My Project")
+            script = mock_run.call_args[0][0]
+            assert "completed by children" not in script
+
+    # --- update_project ---
+
+    def test_update_project_completed_by_children_true(self, client):
+        """update_project(completed_by_children=True) → updated_fields contains the key."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_project("proj-001", completed_by_children=True)
+            assert result["success"] is True
+            assert "completed_by_children" in result["updated_fields"]
+            script = mock_run.call_args[0][0]
+            assert "completed by children" in script
+
+    def test_update_project_completed_by_children_false(self, client):
+        """update_project(completed_by_children=False) sets property to false."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_project("proj-001", completed_by_children=False)
+            assert result["success"] is True
+            assert "completed_by_children" in result["updated_fields"]
+            script = mock_run.call_args[0][0]
+            assert "completed by children" in script

--- a/tests/test_server_fastmcp.py
+++ b/tests/test_server_fastmcp.py
@@ -111,7 +111,7 @@ class TestProjectTools:
             assert "Successfully created project 'New Project'" in result
             assert "Folder: Work" in result
             mock_client.create_project.assert_called_once_with(
-                name="New Project", note=None, folder_path="Work", sequential=False, project_type=None, review_interval_weeks=None
+                name="New Project", note=None, folder_path="Work", sequential=False, project_type=None, review_interval_weeks=None, completed_by_children=None
             )
 
 

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -43,7 +43,8 @@ class TestUpdateProjectServerRedesign:
                 status="active",
                 review_interval_weeks=None,
                 last_reviewed=None,
-                next_review_date=None
+                next_review_date=None,
+                completed_by_children=None
             )
 
             assert isinstance(result, str)
@@ -277,4 +278,25 @@ class TestUpdateProjectNextReviewDate:
 
             call_kwargs = mock_client.update_project.call_args[1]
             assert call_kwargs["next_review_date"] == "2026-04-01"
+            assert "updated" in result.lower() or "success" in result.lower()
+
+
+class TestUpdateProjectCompletedByChildren:
+    """Tests for completed_by_children parameter in update_project server tool."""
+
+    def test_update_project_completed_by_children_passed_to_connector(self):
+        """completed_by_children=True is passed through to the connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-001",
+                "updated_fields": ["completed_by_children"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-001", completed_by_children=True)
+
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["completed_by_children"] is True
             assert "updated" in result.lower() or "success" in result.lower()


### PR DESCRIPTION
## Summary

- Exposes OmniFocus `completed by children` boolean across `get_projects`, `create_project`, and `update_project`
- Projects with this enabled auto-complete when their last remaining action is checked off
- AppleScript property name: `completed by children` (SDEF code `FCbc`)

## Changes

- **Connector:** batch-reads `completed by children of fp` in `get_projects`; adds `completed_by_children: Optional[bool]` to `create_project` and `update_project`
- **Server:** wires `completed_by_children` through all three MCP tools with docstring updates
- **Evals:** adds `completedByChildren` to `get_projects` returns doc, param to `create_project`/`update_project`; scenario 38 scores 2/2 — total 76/76 (100%)

## Test plan

- [x] 8 new unit tests (`TestCompletedByChildren`) — all passing
- [x] 2 integration tests against real OmniFocus test DB — both passing
- [x] 1 server passthrough test (`TestUpdateProjectCompletedByChildren`) — passing
- [x] Full unit suite: 610 passed, 81 skipped, 0 failures
- [x] Blind eval scenario 38: PASS (agent correctly used `update_project(completed_by_children=True)`)

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)