### PR TITLE
feat: stalled project detection (#256)

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-13 (completedByChildren for #254)
+- **Date:** 2026-03-13 (stalled projects for #256)
 - **Model:** claude-sonnet-4-6
-- **Total Score:** 76/76 (100%)
+- **Total Score:** 78/78 (100%)
 - **Critical Failures:** 0 of 4
-- **Previous Score:** 74/74 (100%) — added scenario 37 (#257)
+- **Previous Score:** 76/76 (100%) — added scenario 38 (#254)
 
 ## Category Scores
 
@@ -284,6 +284,10 @@
 
 8. **`completed_by_children` not documented (Scenario 38):** Added `completed_by_children` param to `create_project` and `update_project`, `completedByChildren` field to `get_projects` returns. **Eval: PASS.**
 
+### Issues Found and Fixed (Current Round — #256)
+
+9. **`stalled_only` not documented (Scenario 39):** Added `stalled_only` param to `get_projects`, `stalled` field to task health returns. **Eval: PASS.**
+
 ## Conclusion
 
-After adding `completedByChildren` support (#254), the tool descriptions achieve 76/76 (100%) across 38 scenarios. The new `completed_by_children` parameter in `update_project`/`create_project` allows agents to enable auto-completion of projects when their last action is checked off. The agent also correctly noted the constraint that `single_actions` projects cannot auto-complete.
+After adding stalled project detection (#256), the tool descriptions achieve 78/78 (100%) across 39 scenarios. The new `stalled_only` parameter in `get_projects` returns active projects with no available actions, and the `stalled` boolean field (available with `include_task_health=True`) allows agents to identify projects needing attention. Projects where all tasks are deferred are correctly excluded from stalled results.

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -896,4 +896,27 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    {
+        "id": 39,
+        "category": "Stalled Projects",
+        "name": "Find Projects With No Available Actions",
+        "prompt": (
+            "Which of my projects have no available actions right now? "
+            "I want to review anything that might be stuck or needs new tasks added."
+        ),
+        "expected": {
+            "tools": ["get_projects"],
+            "key_params": {
+                "get_projects": {"stalled_only": True},
+            },
+        },
+        "scoring_notes": (
+            "PASS: get_projects(stalled_only=True). "
+            "PARTIAL: Uses get_projects(include_task_health=True) and filters manually, "
+            "or mentions stalled concept but uses wrong param name. "
+            "FAIL: Loops through all projects manually, uses get_tasks instead, "
+            "or says it can't be done."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -39,8 +39,9 @@ Retrieve ALL active projects with full details and hierarchy, optionally filtere
 - `query: str` (optional) — Search term to filter by name, note, or folder path (case-insensitive)
 - `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
 - `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
+- `stalled_only: bool` (default: False) — Only return active projects with no available actions (implies include_task_health=True)
 
-**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, creationDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status. With include_last_activity: lastActivityDate.
+**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, creationDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status. `stalled` (boolean) — true when availableCount=0 and tasks are not just deferred (project needs attention). With include_last_activity: lastActivityDate.
 
 ---
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -799,6 +799,7 @@ class OmniFocusConnector:
         query: Optional[str] = None,
         include_task_health: bool = False,
         include_last_activity: bool = False,
+        stalled_only: bool = False,
         timeout: int = 90
     ) -> list[dict[str, Any]]:
         """Get projects with their folder/hierarchy information using AppleScript.
@@ -858,6 +859,10 @@ class OmniFocusConnector:
             project_source = f'(flattened projects whose id is "{project_id_escaped}")'
         else:
             project_source = 'flattened projects'
+
+        # stalled_only requires task health data
+        if stalled_only:
+            include_task_health = True
 
         # Build task ops AppleScript blocks via helper
         task_ops_preamble, task_ops_block, health_init, task_health_json_fields = \
@@ -1086,6 +1091,19 @@ class OmniFocusConnector:
                         or query_lower in p.get('note', '').lower()
                         or query_lower in p.get('folderPath', '').lower()
                     ]
+
+                # Compute stalled field when task health is available
+                if include_task_health:
+                    for p in projects:
+                        p["stalled"] = (
+                            p.get("status") == "active status"
+                            and p.get("availableCount", 1) == 0
+                            and not p.get("hasDeferredOnly", False)
+                        )
+
+                # Filter to stalled projects only
+                if stalled_only:
+                    projects = [p for p in projects if p.get("stalled", False)]
 
                 # Apply sorting if requested
                 if sort_by:

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -163,6 +163,8 @@ def _format_project(proj: dict, truncate_notes: bool = True) -> str:
             result += "Health: No Remaining Tasks\n"
         else:
             result += "Health: Stuck\n"
+        if proj.get('stalled'):
+            result += "Stalled: Yes\n"
 
     # Last activity (when include_last_activity=True)
     if proj.get('lastActivityDate'):
@@ -182,7 +184,8 @@ def get_projects(
     on_hold_only: bool = False,
     query: Optional[str] = None,
     include_task_health: bool = False,
-    include_last_activity: bool = False
+    include_last_activity: bool = False,
+    stalled_only: bool = False
 ) -> str:
     """Retrieve ALL active projects with full details and hierarchy, optionally filtered by search query.
 
@@ -196,6 +199,7 @@ def get_projects(
         query: Optional search term to filter by name, note, or folder path (case-insensitive)
         include_task_health: If True, include per-project task health counts (remaining, available, overdue, deferred)
         include_last_activity: If True, compute lastActivityDate (most recent task creation/completion)
+        stalled_only: If True, only return active projects with no available actions — projects that need attention (implies include_task_health=True)
 
     Returns:
         Each project includes: id, name, folderPath, status, projectType, sequential,
@@ -204,7 +208,8 @@ def get_projects(
         a grab-bag list with no completion goal). `sequential` (boolean) is retained for
         backwards compatibility. `completedByChildren` (boolean) indicates whether the project
         auto-completes when its last remaining action is completed.
-        With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, health status.
+        With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status.
+        `stalled` (boolean) — true when availableCount=0 and not all tasks are deferred (project needs attention).
         With include_last_activity: lastActivityDate.
     """
     client = get_client()
@@ -216,6 +221,7 @@ def get_projects(
             query=query,
             include_task_health=include_task_health,
             include_last_activity=include_last_activity,
+            stalled_only=stalled_only,
         )
     except ValueError as e:
         return f"Error: {str(e)}"

--- a/tests/test_integration_performance.py
+++ b/tests/test_integration_performance.py
@@ -96,6 +96,25 @@ class TestIncludeTaskHealthIntegration:
             assert 'remainingCount' in proj
             assert 'availableCount' in proj
 
+    def test_stalled_field_present_with_task_health(self, client, project_with_tasks):
+        """include_task_health=True adds stalled boolean field to each project."""
+        project_id, _ = project_with_tasks
+        projects = client.get_projects(project_id=project_id, include_task_health=True)
+        assert len(projects) == 1
+        assert 'stalled' in projects[0]
+        assert isinstance(projects[0]['stalled'], bool)
+        # project_with_tasks has active tasks, so should not be stalled
+        assert projects[0]['stalled'] is False
+        print(f"\n✓ stalled field present: {projects[0]['stalled']}")
+
+    def test_stalled_only_returns_only_stalled_projects(self, client):
+        """stalled_only=True returns only projects with no available actions."""
+        projects = client.get_projects(stalled_only=True)
+        for proj in projects:
+            assert proj.get('stalled') is True
+            assert proj.get('availableCount', 0) == 0
+        print(f"\n✓ stalled_only returned {len(projects)} stalled projects (all verified)")
+
 
 class TestIncludeLastActivityIntegration:
     """Test include_last_activity against real OmniFocus."""

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -2309,3 +2309,110 @@ class TestCompletedByChildren:
             assert "completed_by_children" in result["updated_fields"]
             script = mock_run.call_args[0][0]
             assert "completed by children" in script
+
+
+class TestStalledProjects:
+    """Tests for stalled project detection (availableCount==0 and not hasDeferredOnly)."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def _make_health_json(self, status="active status", available=0, remaining=0, deferred_only=False):
+        return json.dumps([{
+            "id": "proj-001", "name": "Test Project", "note": "",
+            "status": status, "sequential": False,
+            "singletonActionHolder": False, "completedByChildren": False,
+            "folderPath": "", "creationDate": None, "modificationDate": None,
+            "completionDate": None, "droppedDate": None,
+            "lastActivityDate": None, "lastReviewDate": None,
+            "nextReviewDate": None,
+            "remainingCount": remaining, "availableCount": available,
+            "overdueCount": 0, "deferredCount": 0 if not deferred_only else remaining,
+            "hasDeferredOnly": deferred_only,
+        }])
+
+    # --- stalled field ---
+
+    def test_get_projects_stalled_true_when_no_available_tasks(self, client):
+        """Active project with availableCount=0 and hasDeferredOnly=False → stalled=True."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_health_json(available=0, remaining=2, deferred_only=False)
+            projects = client.get_projects(include_task_health=True)
+            assert projects[0]["stalled"] is True
+
+    def test_get_projects_stalled_false_when_available_tasks(self, client):
+        """Project with availableCount>0 → stalled=False."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_health_json(available=2, remaining=2)
+            projects = client.get_projects(include_task_health=True)
+            assert projects[0]["stalled"] is False
+
+    def test_get_projects_stalled_false_when_deferred_only(self, client):
+        """Project with hasDeferredOnly=True → stalled=False (appropriately scheduled)."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_health_json(available=0, remaining=2, deferred_only=True)
+            projects = client.get_projects(include_task_health=True)
+            assert projects[0]["stalled"] is False
+
+    def test_get_projects_stalled_true_when_no_remaining_tasks(self, client):
+        """Active project with remainingCount=0 → stalled=True."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = self._make_health_json(available=0, remaining=0, deferred_only=False)
+            projects = client.get_projects(include_task_health=True)
+            assert projects[0]["stalled"] is True
+
+    def test_get_projects_stalled_absent_without_task_health(self, client):
+        """Without include_task_health, stalled field is not present."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = json.dumps([{
+                "id": "proj-001", "name": "Test Project", "note": "",
+                "status": "active status", "sequential": False,
+                "singletonActionHolder": False, "completedByChildren": False,
+                "folderPath": "", "creationDate": None, "modificationDate": None,
+                "completionDate": None, "droppedDate": None,
+                "lastActivityDate": None, "lastReviewDate": None, "nextReviewDate": None,
+            }])
+            projects = client.get_projects()
+            assert "stalled" not in projects[0]
+
+    # --- stalled_only filter ---
+
+    def test_get_projects_stalled_only_returns_stalled_projects(self, client):
+        """stalled_only=True returns only stalled projects."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = json.dumps([
+                {
+                    "id": "proj-001", "name": "Stalled", "note": "",
+                    "status": "active status", "sequential": False,
+                    "singletonActionHolder": False, "completedByChildren": False,
+                    "folderPath": "", "creationDate": None, "modificationDate": None,
+                    "completionDate": None, "droppedDate": None,
+                    "lastActivityDate": None, "lastReviewDate": None, "nextReviewDate": None,
+                    "remainingCount": 0, "availableCount": 0, "overdueCount": 0,
+                    "deferredCount": 0, "hasDeferredOnly": False,
+                },
+                {
+                    "id": "proj-002", "name": "Active", "note": "",
+                    "status": "active status", "sequential": False,
+                    "singletonActionHolder": False, "completedByChildren": False,
+                    "folderPath": "", "creationDate": None, "modificationDate": None,
+                    "completionDate": None, "droppedDate": None,
+                    "lastActivityDate": None, "lastReviewDate": None, "nextReviewDate": None,
+                    "remainingCount": 2, "availableCount": 2, "overdueCount": 0,
+                    "deferredCount": 0, "hasDeferredOnly": False,
+                },
+            ])
+            projects = client.get_projects(stalled_only=True)
+            assert len(projects) == 1
+            assert projects[0]["id"] == "proj-001"
+            assert projects[0]["stalled"] is True
+
+    def test_get_projects_stalled_only_implies_task_health(self, client):
+        """stalled_only=True forces include_task_health=True in the AppleScript call."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = json.dumps([])
+            client.get_projects(stalled_only=True)
+            script = mock_run.call_args[0][0]
+            # Task health AppleScript contains these counter lists
+            assert "availableCounts" in script


### PR DESCRIPTION
Adds stalled boolean field and stalled_only filter to get_projects. Pure Python post-processing. 617 unit tests passing, 2 integration tests passing, eval 78/78 (100%). Closes #256.