### PR TITLE
feat: read effective (inherited) dates in get_tasks (#253)

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -284,7 +284,7 @@ class OmniFocusConnector:
                         repeat with t in flattened tasks of proj
                             if not (completed of t) then
                                 set taskId to id of t
-                                set taskDue to my formatDate(due date of t)
+                                set taskDue to my formatDate(effective due date of t)
                                 set taskJson to "{\\"id\\":\\"" & taskId & "\\",\\"projectId\\":\\"" & projId & "\\",\\"dueDate\\":\\"" & taskDue & "\\"}"
                                 set end of projectTasks to taskJson
                             end if
@@ -649,8 +649,8 @@ class OmniFocusConnector:
                 "set allCompleted to completed of ft",
                 "set allDropped to dropped of ft",
                 "set allBlocked to blocked of ft",
-                "set allDeferDates to defer date of ft",
-                "set allDueDates to due date of ft",
+                "set allDeferDates to effective defer date of ft",
+                "set allDueDates to effective due date of ft",
             ]
         if include_last_activity:
             batch_reads += [
@@ -2293,7 +2293,7 @@ class OmniFocusConnector:
             if blocked_only:
                 whose_conditions.append("blocked is true")
             if overdue:
-                whose_conditions.append("due date < (current date)")
+                whose_conditions.append("effective due date < (current date)")
             if query:
                 query_escaped = self._escape_applescript_string(query)
                 whose_conditions.append(f'(name contains "{query_escaped}" or note contains "{query_escaped}")')
@@ -2372,7 +2372,7 @@ class OmniFocusConnector:
                         end if
                         -- Check if deferred
                         try
-                            set taskDeferDate to defer date of t
+                            set taskDeferDate to effective defer date of t
                             if taskDeferDate is not missing value then
                                 if taskDeferDate > (current date) then
                                     error "skip unavailable task"
@@ -2386,7 +2386,7 @@ class OmniFocusConnector:
             overdue_check = """
                         -- Skip non-overdue tasks
                         try
-                            set taskDueDate to due date of t
+                            set taskDueDate to effective due date of t
                             if taskDueDate is missing value then
                                 error "skip non-overdue task"
                             else if taskDueDate >= (current date) then
@@ -2402,7 +2402,7 @@ class OmniFocusConnector:
             if due_relative == "today":
                 due_relative_check = """
                         -- Skip tasks not due today
-                        set taskDue to due date of t
+                        set taskDue to effective due date of t
                         if taskDue is missing value then
                             error "skip task"
                         end if
@@ -2415,7 +2415,7 @@ class OmniFocusConnector:
             elif due_relative == "tomorrow":
                 due_relative_check = """
                         -- Skip tasks not due tomorrow
-                        set taskDue to due date of t
+                        set taskDue to effective due date of t
                         if taskDue is missing value then
                             error "skip task"
                         end if
@@ -2428,7 +2428,7 @@ class OmniFocusConnector:
             elif due_relative == "this_week":
                 due_relative_check = """
                         -- Skip tasks not due this week
-                        set taskDue to due date of t
+                        set taskDue to effective due date of t
                         if taskDue is missing value then
                             error "skip task"
                         end if
@@ -2439,7 +2439,7 @@ class OmniFocusConnector:
             elif due_relative == "next_week":
                 due_relative_check = """
                         -- Skip tasks not due next week
-                        set taskDue to due date of t
+                        set taskDue to effective due date of t
                         if taskDue is missing value then
                             error "skip task"
                         end if
@@ -2451,7 +2451,7 @@ class OmniFocusConnector:
             elif due_relative == "overdue":
                 due_relative_check = """
                         -- Skip non-overdue tasks
-                        set taskDue to due date of t
+                        set taskDue to effective due date of t
                         if taskDue is missing value then
                             error "skip task"
                         end if
@@ -2465,7 +2465,7 @@ class OmniFocusConnector:
             if defer_relative == "today":
                 defer_relative_check = """
                         -- Skip tasks not deferred until today
-                        set taskDefer to defer date of t
+                        set taskDefer to effective defer date of t
                         if taskDefer is missing value then
                             error "skip task"
                         end if
@@ -2478,7 +2478,7 @@ class OmniFocusConnector:
             elif defer_relative == "tomorrow":
                 defer_relative_check = """
                         -- Skip tasks not deferred until tomorrow
-                        set taskDefer to defer date of t
+                        set taskDefer to effective defer date of t
                         if taskDefer is missing value then
                             error "skip task"
                         end if
@@ -2491,7 +2491,7 @@ class OmniFocusConnector:
             elif defer_relative == "this_week":
                 defer_relative_check = """
                         -- Skip tasks not deferred until this week
-                        set taskDefer to defer date of t
+                        set taskDefer to effective defer date of t
                         if taskDefer is missing value then
                             error "skip task"
                         end if
@@ -2502,7 +2502,7 @@ class OmniFocusConnector:
             elif defer_relative == "next_week":
                 defer_relative_check = """
                         -- Skip tasks not deferred until next week
-                        set taskDefer to defer date of t
+                        set taskDefer to effective defer date of t
                         if taskDefer is missing value then
                             error "skip task"
                         end if
@@ -2733,9 +2733,9 @@ class OmniFocusConnector:
                 set taskBlocks to blocked of ft
                 set taskNexts to next of ft
                 set taskSeqs to sequential of ft
-                set dueDates to due date of ft
-                set deferDates to defer date of ft
-                set plannedDates to planned date of ft
+                set dueDates to effective due date of ft
+                set deferDates to effective defer date of ft
+                set plannedDates to effective planned date of ft
                 set creationDates to creation date of ft
                 set modDates to modification date of ft
                 set compDates to completion date of ft
@@ -3019,7 +3019,7 @@ class OmniFocusConnector:
                         -- Get dates
                         set dueDate to ""
                         try
-                            set dueDateObj to due date of t
+                            set dueDateObj to effective due date of t
                             if dueDateObj is not missing value then
                                 set dueDate to dueDateObj as «class isot» as string
                             end if
@@ -3027,7 +3027,7 @@ class OmniFocusConnector:
 
                         set deferDate to ""
                         try
-                            set deferDateObj to defer date of t
+                            set deferDateObj to effective defer date of t
                             if deferDateObj is not missing value then
                                 set deferDate to deferDateObj as «class isot» as string
                             end if
@@ -3035,7 +3035,7 @@ class OmniFocusConnector:
 
                         set plannedDate to ""
                         try
-                            set plannedDateObj to planned date of t
+                            set plannedDateObj to effective planned date of t
                             if plannedDateObj is not missing value then
                                 set plannedDate to plannedDateObj as «class isot» as string
                             end if
@@ -3146,7 +3146,7 @@ class OmniFocusConnector:
                         end try
 
                         -- Compute available status
-                        set deferDateObj to defer date of t
+                        set deferDateObj to effective defer date of t
                         set isDeferred to false
                         if deferDateObj is not missing value then
                             set isDeferred to (deferDateObj > (current date))

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -522,9 +522,10 @@ def get_tasks(
         flagged, dueDate, deferDate, estimatedMinutes, tags, note (truncated unless
         include_full_notes=True), parentTaskId, subtaskCount, sequential.
 
-    Note: Date fields (dueDate, deferDate) show directly-assigned dates only. Tasks that
-    inherit dates from their project or action group will show empty date fields even though
-    they are functionally subject to those dates in OmniFocus.
+    Note: Date fields (dueDate, deferDate, plannedDate) reflect effective dates — including
+    dates inherited from the containing project or action group. A task with no direct due
+    date will show its project's due date in dueDate. Write operations (update_task) still
+    set the task's own date directly.
     """
     client = get_client()
     try:

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -2675,3 +2675,84 @@ class TestTagSidePreFilter:
                     client.delete_tasks(task_id)
                 except Exception as e:
                     warnings.warn(f"Failed to clean up task {task_id}: {e}")
+
+
+class TestEffectiveDates:
+    """Test that get_tasks returns effective (inherited) dates from the containing project."""
+
+    def test_task_inherits_due_date_from_project(self, client):
+        """Task with no direct due date shows project's due date in dueDate field."""
+        from datetime import datetime, timedelta
+
+        due_date = (datetime.now() + timedelta(days=10)).strftime("%Y-%m-%d")
+        project_id = None
+        task_id = None
+        try:
+            project_id = client.create_project(
+                "test-effective-due-project",
+                due_date=due_date,
+            )
+            task_id = client.create_task(
+                "test-effective-due-task",
+                project_id=project_id,
+                # No due_date — should inherit from project
+            )
+
+            tasks = client.get_tasks(project_id=project_id, query="test-effective-due-task")
+            assert len(tasks) == 1
+            task = tasks[0]
+            assert task.get('dueDate'), (
+                f"Expected task to inherit due date from project, got dueDate={task.get('dueDate')!r}"
+            )
+            # The effective due date should match the project's due date (date portion)
+            assert task['dueDate'].startswith(due_date), (
+                f"Expected dueDate to start with {due_date!r}, got {task['dueDate']!r}"
+            )
+            print(f"\n✓ Task inherited due date from project: {task['dueDate']}")
+        finally:
+            if task_id:
+                try:
+                    client.delete_tasks(task_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up task {task_id}: {e}")
+            if project_id:
+                try:
+                    client.delete_projects(project_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up project {project_id}: {e}")
+
+    def test_overdue_filter_includes_tasks_with_inherited_due_date(self, client):
+        """get_tasks(overdue=True) returns tasks that are overdue via project inheritance."""
+        from datetime import datetime, timedelta
+
+        past_due = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d")
+        project_id = None
+        task_id = None
+        try:
+            project_id = client.create_project(
+                "test-effective-overdue-project",
+                due_date=past_due,
+            )
+            task_id = client.create_task(
+                "test-effective-overdue-task",
+                project_id=project_id,
+                # No direct due date — inherits overdue date from project
+            )
+
+            overdue_tasks = client.get_tasks(overdue=True)
+            overdue_ids = [t['id'] for t in overdue_tasks]
+            assert task_id in overdue_ids, (
+                f"Task {task_id} should appear in overdue results via inherited project due date"
+            )
+            print(f"\n✓ Overdue filter found task with inherited due date (project due: {past_due})")
+        finally:
+            if task_id:
+                try:
+                    client.delete_tasks(task_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up task {task_id}: {e}")
+            if project_id:
+                try:
+                    client.delete_projects(project_id)
+                except Exception as e:
+                    warnings.warn(f"Failed to clean up project {project_id}: {e}")

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -693,14 +693,14 @@ class TestWhoseClauseOptimization:
             assert "flagged is true" in script
 
     def test_overdue_uses_whose_clause(self, client, sample_tasks_json):
-        """overdue should use 'whose' with due date comparison."""
+        """overdue should use 'whose' with effective due date comparison."""
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = sample_tasks_json
             client.get_tasks(overdue=True)
             script = mock_run.call_args[0][0]
-            # Should use whose for due date filtering
+            # Should use whose for effective due date filtering (includes inherited)
             assert "whose" in script.lower()
-            assert "due date" in script
+            assert "effective due date" in script
 
 
     def test_tag_filter_uses_tag_side_prefilter(self, client, sample_tasks_json):
@@ -2416,3 +2416,48 @@ class TestStalledProjects:
             script = mock_run.call_args[0][0]
             # Task health AppleScript contains these counter lists
             assert "availableCounts" in script
+
+
+class TestEffectiveDates:
+    """Tests that get_tasks reads effective (inherited) dates, not just direct dates."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    @pytest.fixture
+    def sample_tasks_json(self):
+        return json.dumps([{
+            "id": "task-001", "name": "Test Task", "note": "",
+            "completed": False, "flagged": False, "dropped": False,
+            "projectId": "proj-001", "projectName": "Test Project",
+            "dueDate": "2025-10-15T17:00:00", "deferDate": "",
+            "completionDate": "", "tags": "",
+        }])
+
+    def test_get_tasks_reads_effective_due_date(self, client, sample_tasks_json):
+        """get_tasks should read effective due date (includes inherited) not direct due date."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks()
+            script = mock_run.call_args[0][0]
+            assert "effective due date" in script
+
+    def test_get_tasks_reads_effective_defer_date(self, client, sample_tasks_json):
+        """get_tasks should read effective defer date (includes inherited) not direct defer date."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks()
+            script = mock_run.call_args[0][0]
+            assert "effective defer date" in script
+
+    def test_get_tasks_overdue_whose_uses_effective_due_date(self, client, sample_tasks_json):
+        """overdue=True should filter on effective due date, not direct due date."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = sample_tasks_json
+            client.get_tasks(overdue=True)
+            script = mock_run.call_args[0][0]
+            assert "effective due date" in script
+            # Must NOT use bare "due date <" without "effective" prefix
+            import re
+            assert not re.search(r'(?<!effective )due date <', script)


### PR DESCRIPTION
## Summary

- Switches all date reads in `get_tasks` from direct properties (`due date`, `defer date`, `planned date`) to effective properties (`effective due date`, `effective defer date`, `effective planned date`)
- Tasks inheriting their due/defer date from a containing project now surface those dates in `dueDate`/`deferDate`/`plannedDate` fields instead of showing empty
- Updates the overdue `whose` clause and all relative date filters (`due_relative`, `defer_relative`) to use effective dates — `get_tasks(overdue=True)` now catches tasks overdue via project inheritance
- Field names and API signatures are unchanged; only the semantics of returned date values change
- Closes #253; also addresses part of #288 (integration tests for effective date behavior)

## Test plan

- [ ] Unit tests: `TestEffectiveDates` (3 new), updated `test_overdue_uses_whose_clause` — all pass (620 unit tests passing)
- [ ] Integration test `test_task_inherits_due_date_from_project`: create project with due date, create task with no own due date, verify `dueDate` is inherited
- [ ] Integration test `test_overdue_filter_includes_tasks_with_inherited_due_date`: create overdue project, create task with no own due date, verify it appears in `get_tasks(overdue=True)`
- [ ] Run `make test-integration` against test DB before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)