### PR TITLE
chore: add tmp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ config.json
 
 # Local scripts (not tracked)
 scripts/local/
+
+# Temporary working files
+tmp/


### PR DESCRIPTION
## Summary
- Add `tmp/` to `.gitignore` for temporary working files (used by one-off data migration scripts)

## Test plan
- [x] Verify `tmp/` directory contents are not tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)