### PR TITLE
docs: document mutually exclusive tag research findings (#302)

### DIFF
--- a/docs/omnifocus-mcp-gap-analysis.md
+++ b/docs/omnifocus-mcp-gap-analysis.md
@@ -82,9 +82,10 @@ Ranked by likely utility for a power user with Claude integration.
 
 **3.6. Mutually Exclusive Tag Groups (new in OF 4.7)**
 - Tag groups can be marked so only one child tag from the group can be assigned per item.
-- **SDEF research finding:** The `mutually exclusive` *configuration* is NOT in the OmniFocus SDEF — it's UI-only and cannot be created or read via AppleScript.
-- **Open question:** Assigning any existing tag to a task via AppleScript should work normally (it's just `add tag X to task Y`). What's unknown is whether OmniFocus *enforces* the mutual exclusivity constraint at the data model level when a tag is assigned via AppleScript (automatically removing conflicting sibling tags, as the UI does) or only at the UI layer (potentially leaving a task in a technically invalid state). This is worth verifying against real OmniFocus.
-- **Impact:** Niche. Most users won't hit this. Worth noting in AppleScript gotchas doc if exclusivity is *not* enforced at the model level.
+- **SDEF research finding:** The `mutually exclusive` *configuration* is NOT in the OmniFocus SDEF — it cannot be created or read via AppleScript.
+- **OmniAutomation finding (2026-03-14):** The property `Tag.childrenAreMutuallyExclusive` IS readable and writable via `evaluate javascript`. This means the connector can detect and configure exclusivity through OmniAutomation, even though AppleScript/SDEF cannot.
+- **Enforcement finding (2026-03-14):** OmniFocus enforces exclusivity at the **data model level**, not just the UI. Adding a second tag from an exclusive group via AppleScript silently removes the first — only the last-assigned tag survives. This is OmniFocus behavior, not controllable by the connector.
+- **Impact:** The connector currently cannot warn about silent tag removal because it doesn't read `childrenAreMutuallyExclusive`. Future enhancement: expose this property in `get_tags` and optionally in `create_tag`/`update_tag`.
 
 ---
 
@@ -216,4 +217,4 @@ Tasks and projects have a `should use floating time zone` boolean property. When
 | **P3** | Uncomplete batch audit | Bug | Low | Open |
 | **P3** | Tag locations | Gap | Low | Open (reassessed — feasible but low-value) |
 | **P3** | `should use floating time zone` (new) | Gap | Very Low | Open (low priority) |
-| **P3** | Mutually exclusive tag enforcement | Unknown | Low | Open question — needs verification |
+| **P3** | Mutually exclusive tag enforcement | Verified | Low | Enforced at data model level; `childrenAreMutuallyExclusive` accessible via OmniAutomation (#302) |

--- a/docs/reference/APPLESCRIPT_GOTCHAS.md
+++ b/docs/reference/APPLESCRIPT_GOTCHAS.md
@@ -279,6 +279,52 @@ Remove operations use a single AppleScript call with `set repetition rule to mis
 
 ---
 
+## Mutually Exclusive Tag Groups
+
+- ✅ **Exclusivity is enforced at the data model level** — adding tag B from an exclusive group silently removes tag A, even via AppleScript
+- ❌ **AppleScript/SDEF cannot read or write the exclusivity configuration** — `mutually exclusive` is not an SDEF property
+- ✅ **OmniAutomation can read and write it** via `Tag.childrenAreMutuallyExclusive`
+
+### Empirical Investigation (2026-03-14, Issue #302)
+
+Tested with a parent tag "Mutual Exclusion Test" configured as exclusive in the UI, with child tags "Option 1", "Option 2", "Option 3".
+
+**Enforcement test (AppleScript):**
+```applescript
+-- Add Option 1 to a task
+set tagObj1 to first flattened tag whose name is "Option 1"
+add tagObj1 to tags of tempTask
+-- tags of tempTask → {"Option 1"}
+
+-- Add Option 2 (same exclusive group)
+set tagObj2 to first flattened tag whose name is "Option 2"
+add tagObj2 to tags of tempTask
+-- tags of tempTask → {"Option 2"} — Option 1 was silently removed!
+```
+
+Adding all three sequentially results in only the last one surviving: `{Option 3}`.
+
+**OmniAutomation access:**
+```applescript
+tell application "OmniFocus"
+    evaluate javascript "
+        var tag = flattenedTags.byName('Mutual Exclusion Test');
+        tag.childrenAreMutuallyExclusive;  // → true (readable)
+        tag.childrenAreMutuallyExclusive = false;  // writable
+    "
+end tell
+```
+
+⚠️ **Testing constraint:** Like all OmniAutomation features, `evaluate javascript` crashes on headless test databases. Testing must be done against the production DB.
+
+### Implications for the Connector
+
+- `update_task(add_tags=["Option 2"])` on a task with "Option 1" will silently remove "Option 1" — this is OmniFocus behavior, not a connector bug
+- The connector currently cannot detect or warn about this because it doesn't read `childrenAreMutuallyExclusive`
+- Future enhancement: expose `childrenAreMutuallyExclusive` in `get_tags` so agents can understand tag group behavior
+
+---
+
 ## Performance Characteristics
 
 **Context:** OmniFocus operations via AppleScript can be slow for large databases.


### PR DESCRIPTION
## Summary

- Documents research findings on mutually exclusive tag behavior via AppleScript and OmniAutomation
- Updates gap analysis §3.6 with enforcement finding (data model level) and OmniAutomation access (`Tag.childrenAreMutuallyExclusive`)
- Updates P3 tracking row from "Unknown" to "Verified"
- Adds new section to APPLESCRIPT_GOTCHAS.md with experiment results and code examples

Closes #302

## Test plan

- [ ] Doc-only change — no code or interface changes, no evals needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)