### PR TITLE
chore: add /merge-and-status slash command

### DIFF
--- a/.claude/commands/merge-and-status.md
+++ b/.claude/commands/merge-and-status.md
@@ -1,0 +1,30 @@
+Merge the current PR, pull main, and show open milestone issues.
+
+## Steps
+
+1. **Find the open PR** for the current branch:
+   ```bash
+   gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number'
+   ```
+
+2. **Squash merge** the PR and delete the branch:
+   ```bash
+   gh pr merge <number> --squash --delete-branch
+   ```
+
+3. **Switch to main and pull:**
+   ```bash
+   git checkout main && git pull
+   ```
+
+4. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
+   ```bash
+   gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // .title) | map(select(.state == "open")) | .[0].title'
+   ```
+
+5. **List open issues** on that milestone:
+   ```bash
+   gh issue list --milestone "<milestone>" --state open
+   ```
+
+6. **Display results** as a formatted table with issue number, title, and labels.


### PR DESCRIPTION
## Summary

- Add `/merge-and-status` slash command that automates the repeated workflow: squash-merge current PR, pull main, show open milestone issues

## Test plan

- [x] Command file created at `.claude/commands/merge-and-status.md`
- [ ] Manual test: invoke `/merge-and-status` after next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)