### PR TITLE
fix: skip OmniAutomation calls on headless test database

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3820,7 +3820,8 @@ class OmniFocusConnector:
                 # Post-update: set/modify recurrence via OmniAutomation
                 # AppleScript property writes on repetition rules don't persist
                 # in OmniFocus 4.x, so we use evaluate javascript instead.
-                if _recurrence_js_needed:
+                # OmniAutomation crashes on headless test databases (#324)
+                if _recurrence_js_needed and not self._test_mode:
                     js_method_map = {
                         "fixed": "Task.RepetitionMethod.Fixed",
                         "due_after_completion": "Task.RepetitionMethod.DueDate",
@@ -4318,16 +4319,20 @@ class OmniFocusConnector:
                 tags = []
 
             # Enrich with OmniAutomation-only property (graceful fallback)
-            try:
-                exclusivity_map = self._get_tag_exclusivity_map()
-                for tag in tags:
-                    tag['childrenAreMutuallyExclusive'] = exclusivity_map.get(
-                        tag['id'], False
-                    )
-            except Exception:
-                # OmniAutomation unavailable (headless test DB) — default to False
+            if self._test_mode:
+                # OmniAutomation crashes on headless test databases (#324)
                 for tag in tags:
                     tag['childrenAreMutuallyExclusive'] = False
+            else:
+                try:
+                    exclusivity_map = self._get_tag_exclusivity_map()
+                    for tag in tags:
+                        tag['childrenAreMutuallyExclusive'] = exclusivity_map.get(
+                            tag['id'], False
+                        )
+                except Exception:
+                    for tag in tags:
+                        tag['childrenAreMutuallyExclusive'] = False
 
             return tags
         except subprocess.CalledProcessError as e:
@@ -4417,7 +4422,8 @@ class OmniFocusConnector:
                 raise Exception(f"Error creating tag: {result[len('ERROR:'):]}")
 
             # Post-create: set exclusivity via OmniAutomation (if requested)
-            if children_are_mutually_exclusive:
+            # OmniAutomation crashes on headless test databases (#324)
+            if children_are_mutually_exclusive and not self._test_mode:
                 self._set_tag_exclusivity(result, True)
 
             return result
@@ -4538,7 +4544,8 @@ class OmniFocusConnector:
             parsed = {"success": True, "updated_fields": []}
 
         # Post-update: set exclusivity via OmniAutomation (if requested)
-        if children_are_mutually_exclusive is not None:
+        # OmniAutomation crashes on headless test databases (#324)
+        if children_are_mutually_exclusive is not None and not self._test_mode:
             self._set_tag_exclusivity(tag_id, children_are_mutually_exclusive)
             parsed["updated_fields"].append(
                 "children_are_mutually_exclusive"

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -1822,23 +1822,9 @@ class TestRepeatSummaryIntegration:
 
         print("\n✓ Non-recurring task has repeatSummary=None")
 
-    def test_recurring_task_has_populated_repeat_summary(self, client, test_project):
-        """Recurring task should return a non-empty repeatSummary string."""
-        task_id = client.create_task("test-repeat-summary-task", project_id=test_project)
-        try:
-            # Set recurrence via update_task (AppleScript — safe on test DB)
-            client.update_task(task_id, recurrence="FREQ=DAILY;INTERVAL=1")
-
-            tasks = client.get_tasks(task_id=task_id)
-            assert len(tasks) == 1
-            task = tasks[0]
-            assert task.get('isRecurring') is True
-            assert task.get('repeatSummary') is not None
-            assert isinstance(task['repeatSummary'], str)
-            assert len(task['repeatSummary']) > 0
-            print(f"\n✓ Recurring task repeatSummary: {task['repeatSummary']!r}")
-        finally:
-            client.delete_tasks(task_id)
+    # test_recurring_task_has_populated_repeat_summary moved to
+    # test_prod_integration.py — requires OmniAutomation (evaluate javascript)
+    # which crashes on headless test databases. See #324.
 
 
 

--- a/tests/test_omniautomation_test_mode.py
+++ b/tests/test_omniautomation_test_mode.py
@@ -1,0 +1,119 @@
+"""Tests that OmniAutomation calls are skipped in test mode.
+
+OmniAutomation (`evaluate javascript`) crashes on headless test databases.
+These tests verify that all OmniAutomation call sites are properly guarded
+when OMNIFOCUS_TEST_MODE=true.
+
+See: docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md (lines 96-112)
+See: #324 — OmniFocus crashes during integration test suite
+"""
+import json
+import os
+import pytest
+from unittest import mock
+
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+
+
+@pytest.fixture
+def client_test_mode():
+    """Create a client with test mode enabled."""
+    os.environ['OMNIFOCUS_TEST_MODE'] = 'true'
+    os.environ['OMNIFOCUS_TEST_DATABASE'] = 'OmniFocus-TEST.ofocus'
+    client = OmniFocusConnector(enable_safety_checks=True)
+    yield client
+    os.environ.pop('OMNIFOCUS_TEST_MODE', None)
+    os.environ.pop('OMNIFOCUS_TEST_DATABASE', None)
+
+
+@pytest.fixture
+def client_prod_mode():
+    """Create a client without test mode (production)."""
+    os.environ.pop('OMNIFOCUS_TEST_MODE', None)
+    os.environ.pop('OMNIFOCUS_TEST_DATABASE', None)
+    client = OmniFocusConnector()
+    yield client
+
+
+class TestGetTagsSkipsOmniAutomationInTestMode:
+    """get_tags() must not call _get_tag_exclusivity_map() in test mode."""
+
+    def test_get_tags_skips_exclusivity_in_test_mode(self, client_test_mode):
+        """In test mode, get_tags should default exclusivity to False without OmniAutomation."""
+        tags_json = json.dumps([
+            {"id": "tag-1", "name": "Home", "status": "active", "hidden": False}
+        ])
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript', return_value=tags_json):
+            with mock.patch.object(client_test_mode, '_get_tag_exclusivity_map') as mock_exclusivity:
+                tags = client_test_mode.get_tags()
+                mock_exclusivity.assert_not_called()
+                assert tags[0]['childrenAreMutuallyExclusive'] is False
+
+    def test_get_tags_calls_exclusivity_in_prod_mode(self, client_prod_mode):
+        """In production mode, get_tags should call _get_tag_exclusivity_map()."""
+        tags_json = json.dumps([
+            {"id": "tag-1", "name": "Home", "status": "active", "hidden": False}
+        ])
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript', return_value=tags_json):
+            with mock.patch.object(client_prod_mode, '_get_tag_exclusivity_map', return_value={"tag-1": True}) as mock_exclusivity:
+                tags = client_prod_mode.get_tags()
+                mock_exclusivity.assert_called_once()
+                assert tags[0]['childrenAreMutuallyExclusive'] is True
+
+
+class TestCreateTagSkipsOmniAutomationInTestMode:
+    """create_tag() must not call _set_tag_exclusivity() in test mode."""
+
+    def test_create_tag_skips_exclusivity_in_test_mode(self, client_test_mode):
+        """In test mode, create_tag with exclusivity=True should skip OmniAutomation."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_as:
+            # First call: safety check, second call: create tag
+            mock_as.side_effect = ["OmniFocus-TEST", "tag-new-id"]
+            with mock.patch.object(client_test_mode, '_set_tag_exclusivity') as mock_set:
+                result = client_test_mode.create_tag("TestTag", children_are_mutually_exclusive=True)
+                mock_set.assert_not_called()
+                assert result == "tag-new-id"
+
+    def test_create_tag_calls_exclusivity_in_prod_mode(self, client_prod_mode):
+        """In production mode, create_tag with exclusivity=True should call OmniAutomation."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript', return_value="tag-new-id"):
+            with mock.patch.object(client_prod_mode, '_set_tag_exclusivity') as mock_set:
+                client_prod_mode.create_tag("TestTag", children_are_mutually_exclusive=True)
+                mock_set.assert_called_once_with("tag-new-id", True)
+
+
+class TestUpdateTagSkipsOmniAutomationInTestMode:
+    """update_tag() must not call _set_tag_exclusivity() in test mode."""
+
+    def test_update_tag_skips_exclusivity_in_test_mode(self, client_test_mode):
+        """In test mode, update_tag with exclusivity should skip OmniAutomation."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_as:
+            # First call: safety check, second call: update tag
+            mock_as.side_effect = ["OmniFocus-TEST", "true"]
+            with mock.patch.object(client_test_mode, '_set_tag_exclusivity') as mock_set:
+                result = client_test_mode.update_tag("tag-1", children_are_mutually_exclusive=True)
+                mock_set.assert_not_called()
+
+    def test_update_tag_calls_exclusivity_in_prod_mode(self, client_prod_mode):
+        """In production mode, update_tag with exclusivity should call OmniAutomation."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript', return_value="true"):
+            with mock.patch.object(client_prod_mode, '_set_tag_exclusivity') as mock_set:
+                client_prod_mode.update_tag("tag-1", children_are_mutually_exclusive=False)
+                mock_set.assert_called_once_with("tag-1", False)
+
+
+class TestUpdateTaskSkipsOmniAutomationInTestMode:
+    """update_task() recurrence OmniAutomation must be skipped in test mode."""
+
+    def test_update_task_recurrence_skips_js_in_test_mode(self, client_test_mode):
+        """In test mode, update_task with recurrence should skip evaluate javascript."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_as:
+            # First call: safety check, second call: update task AppleScript
+            mock_as.side_effect = ["OmniFocus-TEST", "true"]
+            result = client_test_mode.update_task("task-1", recurrence="FREQ=DAILY;INTERVAL=1")
+            # Should only be called twice (safety + update), NOT a third time for JS
+            assert mock_as.call_count == 2
+            # Verify no call contains "evaluate javascript"
+            for call in mock_as.call_args_list:
+                script = call[0][0] if call[0] else call[1].get('script', '')
+                assert 'evaluate javascript' not in script


### PR DESCRIPTION
## Summary

- Guard all 4 OmniAutomation (`evaluate javascript`) call sites with `self._test_mode` to prevent OmniFocus crashes on headless test databases
- Add 7 unit tests verifying OmniAutomation is skipped in test mode and called in prod mode
- Move OmniAutomation-dependent recurrence test from `test_integration_real.py` to `test_prod_integration.py` (already covered there)

**Root cause:** v0.9.1 (#303) added `_get_tag_exclusivity_map()` to `get_tags()`, which calls `evaluate javascript`. This crashes OmniFocus on headless test databases (documented in `OMNIFOCUS_AUTOMATION_NOTES.md`). The crash is silent — OmniFocus restarts with the production DB, triggering `DatabaseSafetyError` on all subsequent tests.

**Before:** 112 passed, 21 errors, 9 failures (OmniFocus crash mid-suite)
**After:** 135 passed, 0 errors, 6 failures (pre-existing API signature bugs)

Closes #324

## Test plan

- [x] 713 unit tests pass (706 existing + 7 new)
- [x] `./scripts/check_client_server_parity.sh` passes
- [x] Integration tests: 135 passed, no crash, no DatabaseSafetyErrors
- [x] Remaining 6 failures are pre-existing (wrong API signatures in test code, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)