### PR TITLE
refactor: reduce update_task, update_tasks, get_projects complexity

### DIFF
--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -56,18 +56,22 @@ echo "========================================="
 echo ""
 
 # Check for functions with unacceptable complexity
-# Documented exceptions with higher limits due to AppleScript constraints:
-#   - get_tasks: CC ≤ 25 (24 current - orchestrator after full extraction)
-#   - _post_process_tasks: CC ≤ 29 (28 current - normalization + Python-side filtering)
-#   - _build_task_filter_checks: CC ≤ 55 (54 current - 12+ filter types × per-task + batch variants)
-#   - update_task: CC ≤ 54 (53 current - extensive property handling)
-#   - update_tasks: CC ≤ 47 (46 current - batch property handling)
+# Documented exceptions with higher limits:
+#
+# Extracted helpers (inherent complexity — CC maps 1:1 to parameter/filter count):
+#   - _build_task_filter_checks: CC ≤ 55 (54 current - 12 filter types × per-task + batch variants)
+#   - _build_update_task_commands: CC ≤ 30 (29 current - 17 updatable fields)
+#   - _post_process_tasks: CC ≤ 29 (28 current - normalization + 6 filter steps)
+#   - _filter_projects_by_conditions: CC ≤ 25 (24 current - 3 conditions × pos/neg matching)
+#   - _post_process_projects: CC ≤ 23 (22 current - projectType + 6 filter steps)
+#
+# Original functions not yet refactored:
 #   - update_projects: CC ≤ 35 (34 current)
-#   - get_projects: CC ≤ 36 (35 current - v0.9.0 added stalled_only, completedByChildren, effective dates)
-#   - update_project: CC ≤ 33 (32 current - v0.9.0 added completed_by_children, next_review_date)
-#   - _filter_projects_by_conditions: CC ≤ 25 (24 current)
-#   - create_task: CC ≤ 22 (21 current - many optional parameters with date handling)
+#   - update_project: CC ≤ 33 (32 current)
 #   - _format_task: CC ≤ 26 (25 current)
+#   - get_tasks: CC ≤ 25 (24 current - orchestrator)
+#   - create_task: CC ≤ 23 (22 current)
+#   - _validate_update_task_params: CC ≤ 19 (18 current)
 EXCESSIVE_COMPLEXITY=$($RADON cc src/omnifocus_mcp/ -n D -j | $PYTHON -c "
 import sys
 import json
@@ -80,27 +84,27 @@ try:
                 cc = item['complexity']
                 name = item['name']
                 # Documented exceptions with specific limits
-                if name == 'get_tasks' and cc <= 25:
+                # Extracted helpers (inherent complexity)
+                if name == '_build_task_filter_checks' and cc <= 55:
+                    continue
+                elif name == '_build_update_task_commands' and cc <= 30:
                     continue
                 elif name == '_post_process_tasks' and cc <= 29:
                     continue
-                elif name == '_build_task_filter_checks' and cc <= 55:
+                elif name == '_filter_projects_by_conditions' and cc <= 25:
                     continue
-                elif name == 'update_task' and cc <= 54:
+                elif name == '_post_process_projects' and cc <= 23:
                     continue
-                elif name == 'get_projects' and cc <= 36:
+                # Original functions
+                elif name == 'update_projects' and cc <= 35:
                     continue
                 elif name == 'update_project' and cc <= 33:
                     continue
-                elif name == '_filter_projects_by_conditions' and cc <= 25:
-                    continue
-                elif name == 'create_task' and cc <= 22:
-                    continue
-                elif name == 'update_tasks' and cc <= 47:
-                    continue
                 elif name == '_format_task' and cc <= 26:
                     continue
-                elif name == 'update_projects' and cc <= 35:
+                elif name == 'get_tasks' and cc <= 25:
+                    continue
+                elif name == 'create_task' and cc <= 23:
                     continue
                 # General functions: CC ≤ 20 (C rating or better)
                 elif cc <= 20:
@@ -121,12 +125,7 @@ if [ $? -ne 0 ]; then
     echo ""
     echo "Maximum acceptable complexity:"
     echo "  - General functions: CC ≤ 20 (C rating or better)"
-    echo "  - get_tasks(): CC ≤ 25 (current: 24)"
-    echo "  - _post_process_tasks(): CC ≤ 29 (current: 28)"
-    echo "  - _build_task_filter_checks(): CC ≤ 55 (current: 54)"
-    echo "  - update_task(): CC ≤ 54 (current: 53)"
-    echo "  - get_projects(): CC ≤ 36 (current: 35)"
-    echo "  - update_project(): CC ≤ 33 (current: 32)"
+    echo "  - See documented exceptions in script comments"
     echo ""
     echo "See docs/reference/HYGIENE_CHECK_CRITERIA.md for details."
     exit 1
@@ -134,13 +133,9 @@ fi
 
 echo "✅ PASS: All functions within complexity limits"
 echo ""
-echo "Documented high complexity functions (AppleScript constraints):"
-echo "  - get_tasks(): CC ≤ 25 (orchestrator after full extraction)"
-echo "  - _post_process_tasks(): CC ≤ 29 (normalization + Python-side filtering)"
-echo "  - _build_task_filter_checks(): CC ≤ 55 (12+ filter types × per-task + batch variants)"
-echo "  - update_task(): CC ≤ 54 (extensive property handling)"
-echo "  - get_projects(): CC ≤ 36 (v0.9.0: stalled_only, completedByChildren, effective dates)"
-echo "  - update_project(): CC ≤ 33 (v0.9.0: completed_by_children, next_review_date)"
+echo "Documented exceptions (see script comments for full list):"
+echo "  - Extracted helpers: _build_task_filter_checks (54), _build_update_task_commands (29), _post_process_tasks (28)"
+echo "  - Original functions: update_projects (34), update_project (32), _format_task (25), create_task (22)"
 echo "  - All other functions: CC ≤ 20"
 echo ""
 echo "See inline documentation in omnifocus_connector.py for rationale."

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -784,6 +784,100 @@ class OmniFocusConnector:
 
         return task_ops_preamble, task_ops_block, health_init, task_health_json_fields
 
+    def _validate_get_projects_params(
+        self,
+        *,
+        modified_after: Optional[str],
+        modified_before: Optional[str],
+        sort_by: Optional[str],
+        sort_order: str,
+    ) -> None:
+        """Validate get_projects parameters, raising ValueError for invalid values."""
+        from datetime import datetime
+        for date_param, date_value in [
+            ("modified_after", modified_after),
+            ("modified_before", modified_before)
+        ]:
+            if date_value:
+                try:
+                    datetime.fromisoformat(date_value.replace('Z', '+00:00'))
+                except ValueError:
+                    raise ValueError(f"Invalid date format for {date_param}: {date_value}. Use ISO format (e.g., '2025-01-15T00:00:00Z')")
+
+        valid_sort_by = ["name", None]
+        valid_sort_order = ["asc", "desc"]
+        if sort_by not in valid_sort_by:
+            raise ValueError(f"Invalid sort_by value: {sort_by}. Must be one of: {[v for v in valid_sort_by if v is not None]}")
+        if sort_order not in valid_sort_order:
+            raise ValueError(f"Invalid sort_order value: {sort_order}. Must be one of: {valid_sort_order}")
+
+    def _post_process_projects(
+        self,
+        projects: list[dict[str, Any]],
+        *,
+        modified_after: Optional[str],
+        modified_before: Optional[str],
+        min_task_count: Optional[int],
+        has_overdue_tasks: Optional[bool],
+        has_no_due_dates: Optional[bool],
+        query: Optional[str],
+        include_task_health: bool,
+        stalled_only: bool,
+        sort_by: Optional[str],
+        sort_order: str,
+    ) -> list[dict[str, Any]]:
+        """Post-process projects: compute types, apply filters, sort."""
+        # Compute projectType from singleton and sequential flags
+        for p in projects:
+            if p.get("singletonActionHolder"):
+                p["projectType"] = "single_actions"
+            elif p.get("sequential"):
+                p["projectType"] = "sequential"
+            else:
+                p["projectType"] = "parallel"
+
+        # Apply date range filtering
+        if modified_after or modified_before:
+            projects = self._filter_by_date_range(
+                projects, None, None, modified_after, modified_before
+            )
+
+        # Apply conditional filters
+        if min_task_count is not None or has_overdue_tasks is not None or has_no_due_dates is not None:
+            projects = self._filter_projects_by_conditions(
+                projects, min_task_count, has_overdue_tasks, has_no_due_dates
+            )
+
+        # Apply query filter
+        if query:
+            query_lower = query.lower()
+            projects = [
+                p for p in projects
+                if query_lower in p.get('name', '').lower()
+                or query_lower in p.get('note', '').lower()
+                or query_lower in p.get('folderPath', '').lower()
+            ]
+
+        # Compute stalled field when task health is available
+        if include_task_health:
+            for p in projects:
+                p["stalled"] = (
+                    p.get("status") == "active status"
+                    and p.get("availableCount", 1) == 0
+                    and not p.get("hasDeferredOnly", False)
+                )
+
+        # Filter to stalled projects only
+        if stalled_only:
+            projects = [p for p in projects if p.get("stalled", False)]
+
+        # Apply sorting
+        if sort_by:
+            reverse = (sort_order == "desc")
+            projects = sorted(projects, key=lambda p: p.get("name", "").lower(), reverse=reverse)
+
+        return projects
+
     def get_projects(
         self,
         project_id: Optional[str] = None,  # NEW (Phase 3.2): Filter to specific project
@@ -803,12 +897,6 @@ class OmniFocusConnector:
         timeout: int = 90
     ) -> list[dict[str, Any]]:
         """Get projects with their folder/hierarchy information using AppleScript.
-
-        NOTE: This method is intentionally long (251 lines) because:
-        1. AppleScript must be a single self-contained string with embedded JSON helpers
-        2. Comprehensive property extraction (timestamps, stats, hierarchy, etc.)
-        3. Multiple filter conditions and post-processing logic
-        4. AppleScript is verbose for JSON generation and error handling
 
         Args:
             project_id: NEW (Phase 3.2) - Filter to specific project by ID (consolidates get_project())
@@ -831,26 +919,10 @@ class OmniFocusConnector:
             ValueError: If date format or sort parameters are invalid
             subprocess.TimeoutExpired: If AppleScript execution exceeds timeout
         """
-        # Validate date formats
-        from datetime import datetime
-        for date_param, date_value in [
-            ("modified_after", modified_after),
-            ("modified_before", modified_before)
-        ]:
-            if date_value:
-                try:
-                    datetime.fromisoformat(date_value.replace('Z', '+00:00'))
-                except ValueError:
-                    raise ValueError(f"Invalid date format for {date_param}: {date_value}. Use ISO format (e.g., '2025-01-15T00:00:00Z')")
-
-        # Validate sort parameters
-        valid_sort_by = ["name", None]
-        valid_sort_order = ["asc", "desc"]
-
-        if sort_by not in valid_sort_by:
-            raise ValueError(f"Invalid sort_by value: {sort_by}. Must be one of: {[v for v in valid_sort_by if v is not None]}")
-        if sort_order not in valid_sort_order:
-            raise ValueError(f"Invalid sort_order value: {sort_order}. Must be one of: {valid_sort_order}")
+        self._validate_get_projects_params(
+            modified_after=modified_after, modified_before=modified_before,
+            sort_by=sort_by, sort_order=sort_order,
+        )
 
         # Build project source (specific project or all projects)
         # NEW (Phase 3.2): project_id parameter
@@ -1054,63 +1126,19 @@ class OmniFocusConnector:
             if result:
                 projects = json.loads(result)
 
-                # Compute projectType from singleton and sequential flags
-                for p in projects:
-                    if p.get("singletonActionHolder"):
-                        p["projectType"] = "single_actions"
-                    elif p.get("sequential"):
-                        p["projectType"] = "sequential"
-                    else:
-                        p["projectType"] = "parallel"
-
-                # Apply date range filtering
-                if modified_after or modified_before:
-                    projects = self._filter_by_date_range(
-                        projects,
-                        None,  # created_after (not applicable to projects)
-                        None,  # created_before
-                        modified_after,
-                        modified_before
-                    )
-
-                # Apply conditional filters
-                if min_task_count is not None or has_overdue_tasks is not None or has_no_due_dates is not None:
-                    projects = self._filter_projects_by_conditions(
-                        projects,
-                        min_task_count,
-                        has_overdue_tasks,
-                        has_no_due_dates
-                    )
-
-                # Apply query filter if provided
-                if query:
-                    query_lower = query.lower()
-                    projects = [
-                        p for p in projects
-                        if query_lower in p.get('name', '').lower()
-                        or query_lower in p.get('note', '').lower()
-                        or query_lower in p.get('folderPath', '').lower()
-                    ]
-
-                # Compute stalled field when task health is available
-                if include_task_health:
-                    for p in projects:
-                        p["stalled"] = (
-                            p.get("status") == "active status"
-                            and p.get("availableCount", 1) == 0
-                            and not p.get("hasDeferredOnly", False)
-                        )
-
-                # Filter to stalled projects only
-                if stalled_only:
-                    projects = [p for p in projects if p.get("stalled", False)]
-
-                # Apply sorting if requested
-                if sort_by:
-                    reverse = (sort_order == "desc")
-                    projects = sorted(projects, key=lambda p: p.get("name", "").lower(), reverse=reverse)
-
-                return projects
+                return self._post_process_projects(
+                    projects,
+                    modified_after=modified_after,
+                    modified_before=modified_before,
+                    min_task_count=min_task_count,
+                    has_overdue_tasks=has_overdue_tasks,
+                    has_no_due_dates=has_no_due_dates,
+                    query=query,
+                    include_task_health=include_task_health,
+                    stalled_only=stalled_only,
+                    sort_by=sort_by,
+                    sort_order=sort_order,
+                )
             else:
                 raise Exception("No output from OmniFocus AppleScript")
         except subprocess.CalledProcessError as e:
@@ -3527,6 +3555,282 @@ class OmniFocusConnector:
             raise Exception(f"Error parsing OmniFocus task output: {e}")
 
 
+    def _validate_update_task_params(
+        self,
+        *,
+        task_id: str,
+        task_name: Optional[str],
+        name: Optional[str],
+        project_id: Optional[str],
+        parent_task_id: Optional[str],
+        tags: Optional[list[str]],
+        add_tags: Optional[list[str]],
+        remove_tags: Optional[list[str]],
+        status: Optional[Union[TaskStatus, str]],
+        repetition_method: Optional[str],
+        note: Optional[str],
+        due_date: Optional[str],
+        defer_date: Optional[str],
+        planned_date: Optional[str],
+        flagged: Optional[bool],
+        sequential: Optional[bool],
+        estimated_minutes: Optional[int],
+        completed: Optional[bool],
+        recurrence: Optional[str],
+    ) -> tuple[Optional[str], Optional[TaskStatus]]:
+        """Validate update_task parameters, raising ValueError for invalid values.
+
+        Returns (resolved_task_name, resolved_status) after legacy name support
+        and status enum normalization.
+        """
+        if not task_id:
+            raise ValueError("task_id is required")
+
+        # Support legacy 'name' parameter
+        if name is not None and task_name is None:
+            task_name = name
+
+        if project_id is not None and parent_task_id is not None:
+            raise ValueError("Cannot specify both parent_task_id and project_id - parent task already determines the project.")
+
+        if tags is not None and add_tags is not None:
+            raise ValueError("Cannot specify both tags and add_tags/remove_tags - use tags for full replacement or add_tags/remove_tags for incremental changes.")
+        if tags is not None and remove_tags is not None:
+            raise ValueError("Cannot specify both tags and remove_tags - use tags for full replacement or add_tags/remove_tags for incremental changes.")
+
+        if status is not None:
+            if isinstance(status, str):
+                try:
+                    status = TaskStatus(status)
+                except ValueError:
+                    raise ValueError(f"Invalid status: {status}. Must be one of: {', '.join([s.value for s in TaskStatus])}")
+
+        if repetition_method:
+            valid_methods = ["fixed", "start_after_completion", "due_after_completion"]
+            if repetition_method not in valid_methods:
+                raise ValueError(f"Invalid repetition_method: {repetition_method}. Must be one of: {', '.join(valid_methods)}")
+
+        all_params = [
+            task_name, project_id, parent_task_id, note, due_date, defer_date,
+            planned_date, flagged, sequential, tags, add_tags, remove_tags,
+            estimated_minutes, completed, status, recurrence, repetition_method
+        ]
+        if all(v is None for v in all_params):
+            raise ValueError("At least one field must be provided to update")
+
+        return task_name, status
+
+    def _build_update_task_commands(
+        self,
+        *,
+        task_name: Optional[str],
+        note: Optional[str],
+        flagged: Optional[bool],
+        sequential: Optional[bool],
+        due_date: Optional[str],
+        defer_date: Optional[str],
+        planned_date: Optional[str],
+        estimated_minutes: Optional[int],
+        completed: Optional[bool],
+        status: Optional[TaskStatus],
+        project_id: Optional[str],
+        parent_task_id: Optional[str],
+        tags: Optional[list[str]],
+        add_tags: Optional[list[str]],
+        remove_tags: Optional[list[str]],
+        recurrence: Optional[str],
+        repetition_method: Optional[str],
+    ) -> tuple[list[str], list[str], list[str], bool]:
+        """Build AppleScript property and command strings for update_task.
+
+        Returns (properties, separate_commands, updated_fields, recurrence_js_needed).
+        """
+        properties: list[str] = []
+        separate_commands: list[str] = []
+        updated_fields: list[str] = []
+
+        # Simple properties (set via 'set properties of theTask')
+        if task_name is not None:
+            escaped_name = self._escape_applescript_string(task_name)
+            properties.append(f'name:"{escaped_name}"')
+            updated_fields.append("task_name")
+
+        if note is not None:
+            escaped_note = self._escape_applescript_string(note)
+            properties.append(f'note:"{escaped_note}"')
+            updated_fields.append("note")
+
+        if flagged is not None:
+            properties.append(f'flagged:{str(flagged).lower()}')
+            updated_fields.append("flagged")
+
+        if sequential is not None:
+            properties.append(f'sequential:{str(sequential).lower()}')
+            updated_fields.append("sequential")
+
+        # Dates (clear vs set)
+        if due_date is not None:
+            if due_date == "":
+                separate_commands.append("set due date of theTask to missing value")
+            else:
+                as_date = self._iso_to_applescript_date(due_date)
+                separate_commands.append(f'set due date of theTask to date "{as_date}"')
+            updated_fields.append("due_date")
+
+        if defer_date is not None:
+            if defer_date == "":
+                separate_commands.append("set defer date of theTask to missing value")
+            else:
+                as_date = self._iso_to_applescript_date(defer_date)
+                separate_commands.append(f'set defer date of theTask to date "{as_date}"')
+            updated_fields.append("defer_date")
+
+        if planned_date is not None:
+            if planned_date == "":
+                separate_commands.append("set planned date of theTask to missing value")
+            else:
+                as_date = self._iso_to_applescript_date(planned_date)
+                separate_commands.append(f'set planned date of theTask to date "{as_date}"')
+            updated_fields.append("planned_date")
+
+        # Estimated minutes
+        if estimated_minutes is not None:
+            separate_commands.append(f'set estimated minutes of theTask to {estimated_minutes}')
+            updated_fields.append("estimated_minutes")
+
+        # Completion (use "mark complete" for recurring task safety)
+        if completed is not None:
+            if completed:
+                separate_commands.append("mark complete theTask")
+            else:
+                separate_commands.append("set completed of theTask to false")
+            updated_fields.append("completed")
+
+        # Status (use "mark dropped" command)
+        if status is not None:
+            if status == TaskStatus.DROPPED:
+                separate_commands.append("mark dropped theTask")
+            elif status == TaskStatus.ACTIVE:
+                separate_commands.append("set dropped of theTask to false")
+            updated_fields.append("status")
+
+        # Hierarchy changes
+        if project_id is not None:
+            project_id_escaped = self._escape_applescript_string(project_id)
+            separate_commands.append(f'''
+                    set theProject to first flattened project whose id is "{project_id_escaped}"
+                    move theTask to end of tasks of theProject''')
+            updated_fields.append("project_id")
+
+        if parent_task_id is not None:
+            parent_id_escaped = self._escape_applescript_string(parent_task_id)
+            separate_commands.append(f'''
+                    set theParent to first flattened task whose id is "{parent_id_escaped}"
+                    if id of theTask is id of theParent then
+                        error "Cannot set task as its own parent"
+                    end if
+                    move theTask to end of tasks of theParent''')
+            updated_fields.append("parent_task_id")
+
+        # Tags
+        if tags is not None:
+            if len(tags) > 0:
+                tag_adds = []
+                for tag in tags:
+                    tag_escaped = self._escape_applescript_string(tag)
+                    tag_adds.append(f'''
+                        set tagObj to first flattened tag whose name is "{tag_escaped}"
+                        copy tagObj to end of newTags''')
+                tag_adds_str = "\n                    ".join(tag_adds)
+                separate_commands.append(f'''
+                    set newTags to {{}}
+                    {tag_adds_str}
+                    set tags of theTask to newTags''')
+            else:
+                separate_commands.append("set tags of theTask to {}")
+            updated_fields.append("tags")
+
+        if add_tags is not None:
+            for tag in add_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                separate_commands.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of theTask''')
+            updated_fields.append("add_tags")
+
+        if remove_tags is not None:
+            for tag in remove_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                separate_commands.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    remove tagObj from tags of theTask''')
+            updated_fields.append("remove_tags")
+
+        # Recurrence
+        _recurrence_js_needed = False
+        if recurrence is not None:
+            if recurrence == "":
+                separate_commands.append("set repetition rule of theTask to missing value")
+            else:
+                _recurrence_js_needed = True
+            updated_fields.append("recurrence")
+        elif repetition_method is not None:
+            _recurrence_js_needed = True
+            updated_fields.append("repetition_method")
+
+        return properties, separate_commands, updated_fields, _recurrence_js_needed
+
+    def _execute_recurrence_update(
+        self,
+        task_id_escaped: str,
+        recurrence: Optional[str],
+        repetition_method: Optional[str],
+    ) -> None:
+        """Execute OmniAutomation recurrence update (post-AppleScript).
+
+        Skipped in test mode — OmniAutomation crashes on headless test databases (#324).
+        """
+        if self._test_mode:
+            return
+
+        js_method_map = {
+            "fixed": "Task.RepetitionMethod.Fixed",
+            "due_after_completion": "Task.RepetitionMethod.DueDate",
+            "start_after_completion": "Task.RepetitionMethod.DeferUntilDate",
+        }
+        js_method = js_method_map.get(
+            repetition_method or "fixed",
+            "Task.RepetitionMethod.Fixed"
+        )
+        task_id_js = task_id_escaped.replace("'", "\\'")
+
+        if recurrence is not None:
+            recurrence_js = self._escape_applescript_string(
+                recurrence
+            ).replace("'", "\\'")
+            js_code = (
+                f"var t = Task.byIdentifier('{task_id_js}');"
+                f" if (t) {{ t.repetitionRule = new Task.RepetitionRule("
+                f"'{recurrence_js}', {js_method}); 'ok'; }}"
+                f" else {{ 'not found'; }}"
+            )
+        else:
+            js_code = (
+                f"var t = Task.byIdentifier('{task_id_js}');"
+                f" if (t && t.repetitionRule) {{"
+                f" var rr = t.repetitionRule.ruleString;"
+                f" t.repetitionRule = new Task.RepetitionRule("
+                f"rr, {js_method}); 'ok'; }}"
+                f" else {{ 'no rule'; }}"
+            )
+
+        js_script = (
+            'tell application "OmniFocus"\n'
+            f'    evaluate javascript "{js_code}"\n'
+            'end tell'
+        )
+        run_applescript(js_script)
+
     def update_task(
         self,
         task_id: str,
@@ -3596,202 +3900,35 @@ class OmniFocusConnector:
             - OmniFocus errors (task not found, etc.) → Returns dict with success=False
             - Never raises exceptions for runtime OmniFocus errors
         """
-        # NEW API (Redesign)
-
         # SAFETY: Verify database before modifying
         self._verify_database_safety('update_task')
 
-        if not task_id:
-            raise ValueError("task_id is required")
+        # Validate parameters
+        task_name, status = self._validate_update_task_params(
+            task_id=task_id, task_name=task_name, name=name,
+            project_id=project_id, parent_task_id=parent_task_id,
+            tags=tags, add_tags=add_tags, remove_tags=remove_tags,
+            status=status, repetition_method=repetition_method,
+            note=note, due_date=due_date, defer_date=defer_date,
+            planned_date=planned_date, flagged=flagged, sequential=sequential,
+            estimated_minutes=estimated_minutes, completed=completed,
+            recurrence=recurrence,
+        )
 
-        # Support legacy 'name' parameter
-        if name is not None and task_name is None:
-            task_name = name
+        # Build AppleScript properties and commands
+        properties, separate_commands, updated_fields, _recurrence_js_needed = \
+            self._build_update_task_commands(
+                task_name=task_name, note=note, flagged=flagged,
+                sequential=sequential, due_date=due_date, defer_date=defer_date,
+                planned_date=planned_date, estimated_minutes=estimated_minutes,
+                completed=completed, status=status, project_id=project_id,
+                parent_task_id=parent_task_id, tags=tags, add_tags=add_tags,
+                remove_tags=remove_tags, recurrence=recurrence,
+                repetition_method=repetition_method,
+            )
 
-        # Validate conflict: project_id vs parent_task_id
-        if project_id is not None and parent_task_id is not None:
-            raise ValueError("Cannot specify both parent_task_id and project_id - parent task already determines the project.")
-
-        # Validate conflict: tags vs add_tags/remove_tags
-        if tags is not None and add_tags is not None:
-            raise ValueError("Cannot specify both tags and add_tags/remove_tags - use tags for full replacement or add_tags/remove_tags for incremental changes.")
-        if tags is not None and remove_tags is not None:
-            raise ValueError("Cannot specify both tags and remove_tags - use tags for full replacement or add_tags/remove_tags for incremental changes.")
-
-        # Validate status parameter (accept enum or string)
-        if status is not None:
-            if isinstance(status, str):
-                try:
-                    status = TaskStatus(status)
-                except ValueError:
-                    raise ValueError(f"Invalid status: {status}. Must be one of: {', '.join([s.value for s in TaskStatus])}")
-
-        # Validate repetition parameters (legacy)
-        if repetition_method:
-            valid_methods = ["fixed", "start_after_completion", "due_after_completion"]
-            if repetition_method not in valid_methods:
-                raise ValueError(f"Invalid repetition_method: {repetition_method}. Must be one of: {', '.join(valid_methods)}")
-
-        # Track which fields are being updated
-        updated_fields = []
-
-        # Check if at least one field is provided
-        all_params = [
-            task_name, project_id, parent_task_id, note, due_date, defer_date,
-            planned_date, flagged, sequential, tags, add_tags, remove_tags,
-            estimated_minutes, completed, status, recurrence, repetition_method
-        ]
-        if all(v is None for v in all_params):
-            raise ValueError("At least one field must be provided to update")
-
-        # Build AppleScript
+        # Build and execute AppleScript
         try:
-            # Build properties to update (for set properties of theTask)
-            properties = []
-
-            if task_name is not None:
-                escaped_name = self._escape_applescript_string(task_name)
-                properties.append(f'name:"{escaped_name}"')
-                updated_fields.append("task_name")
-
-            if note is not None:
-                escaped_note = self._escape_applescript_string(note)
-                properties.append(f'note:"{escaped_note}"')
-                updated_fields.append("note")
-
-            if flagged is not None:
-                properties.append(f'flagged:{str(flagged).lower()}')
-                updated_fields.append("flagged")
-
-            if sequential is not None:
-                properties.append(f'sequential:{str(sequential).lower()}')
-                updated_fields.append("sequential")
-
-            # Build separate commands (can't use set properties for these)
-            separate_commands = []
-
-            # Handle dates
-            if due_date is not None:
-                if due_date == "":
-                    separate_commands.append("set due date of theTask to missing value")
-                else:
-                    as_date = self._iso_to_applescript_date(due_date)
-                    separate_commands.append(f'set due date of theTask to date "{as_date}"')
-                updated_fields.append("due_date")
-
-            if defer_date is not None:
-                if defer_date == "":
-                    separate_commands.append("set defer date of theTask to missing value")
-                else:
-                    as_date = self._iso_to_applescript_date(defer_date)
-                    separate_commands.append(f'set defer date of theTask to date "{as_date}"')
-                updated_fields.append("defer_date")
-
-            if planned_date is not None:
-                if planned_date == "":
-                    separate_commands.append("set planned date of theTask to missing value")
-                else:
-                    as_date = self._iso_to_applescript_date(planned_date)
-                    separate_commands.append(f'set planned date of theTask to date "{as_date}"')
-                updated_fields.append("planned_date")
-
-            # Handle estimated minutes
-            if estimated_minutes is not None:
-                separate_commands.append(f'set estimated minutes of theTask to {estimated_minutes}')
-                updated_fields.append("estimated_minutes")
-
-            # Handle completion (use "mark complete" for recurring task safety)
-            if completed is not None:
-                if completed:
-                    separate_commands.append("mark complete theTask")
-                else:
-                    # Uncomplete task
-                    separate_commands.append("set completed of theTask to false")
-                updated_fields.append("completed")
-
-            # Handle status (use "mark dropped" command)
-            if status is not None:
-                if status == TaskStatus.DROPPED:
-                    separate_commands.append("mark dropped theTask")
-                elif status == TaskStatus.ACTIVE:
-                    # Reactivate dropped task
-                    separate_commands.append("set dropped of theTask to false")
-                updated_fields.append("status")
-
-            # Handle hierarchy changes (project_id or parent_task_id)
-            if project_id is not None:
-                # Move to project
-                project_id_escaped = self._escape_applescript_string(project_id)
-                separate_commands.append(f'''
-                    set theProject to first flattened project whose id is "{project_id_escaped}"
-                    move theTask to end of tasks of theProject''')
-                updated_fields.append("project_id")
-
-            if parent_task_id is not None:
-                # Make subtask
-                parent_id_escaped = self._escape_applescript_string(parent_task_id)
-                separate_commands.append(f'''
-                    set theParent to first flattened task whose id is "{parent_id_escaped}"
-                    if id of theTask is id of theParent then
-                        error "Cannot set task as its own parent"
-                    end if
-                    move theTask to end of tasks of theParent''')
-                updated_fields.append("parent_task_id")
-
-            # Handle tags
-            if tags is not None:
-                # Full replacement: remove all tags, then add new ones
-                if len(tags) > 0:
-                    tag_adds = []
-                    for tag in tags:
-                        tag_escaped = self._escape_applescript_string(tag)
-                        tag_adds.append(f'''
-                        set tagObj to first flattened tag whose name is "{tag_escaped}"
-                        copy tagObj to end of newTags''')
-                    tag_adds_str = "\n                    ".join(tag_adds)
-                    separate_commands.append(f'''
-                    set newTags to {{}}
-                    {tag_adds_str}
-                    set tags of theTask to newTags''')
-                else:
-                    # Empty list = remove all tags
-                    separate_commands.append("set tags of theTask to {}")
-                updated_fields.append("tags")
-
-            if add_tags is not None:
-                # Add tags incrementally
-                for tag in add_tags:
-                    tag_escaped = self._escape_applescript_string(tag)
-                    separate_commands.append(f'''
-                    set tagObj to first flattened tag whose name is "{tag_escaped}"
-                    add tagObj to tags of theTask''')
-                updated_fields.append("add_tags")
-
-            if remove_tags is not None:
-                # Remove tags
-                for tag in remove_tags:
-                    tag_escaped = self._escape_applescript_string(tag)
-                    separate_commands.append(f'''
-                    set tagObj to first flattened tag whose name is "{tag_escaped}"
-                    remove tagObj from tags of theTask''')
-                updated_fields.append("remove_tags")
-
-            # Handle recurrence
-            # Note: AppleScript property writes on repetition rules don't persist in
-            # OmniFocus 4.x. Remove works via AppleScript, but set/modify requires
-            # OmniAutomation (evaluate javascript) — handled as a post-update call below.
-            _recurrence_js_needed = False
-            if recurrence is not None:
-                if recurrence == "":
-                    separate_commands.append("set repetition rule of theTask to missing value")
-                else:
-                    _recurrence_js_needed = True
-                updated_fields.append("recurrence")
-            elif repetition_method is not None:
-                _recurrence_js_needed = True
-                updated_fields.append("repetition_method")
-
-            # Build final AppleScript
             task_id_escaped = self._escape_applescript_string(task_id)
             script = f'''
             tell application "OmniFocus"
@@ -3799,12 +3936,10 @@ class OmniFocusConnector:
                     set theTask to first flattened task whose id is "{task_id_escaped}"
                     '''
 
-            # Apply property updates
             if properties:
                 props_str = ", ".join(properties)
                 script += f'\n                    set properties of theTask to {{{props_str}}}'
 
-            # Apply separate commands
             if separate_commands:
                 cmds_str = "\n                    ".join(separate_commands)
                 script += f'\n                    {cmds_str}'
@@ -3817,52 +3952,10 @@ class OmniFocusConnector:
 
             result = run_applescript(script)
             if result.strip() == "true":
-                # Post-update: set/modify recurrence via OmniAutomation
-                # AppleScript property writes on repetition rules don't persist
-                # in OmniFocus 4.x, so we use evaluate javascript instead.
-                # OmniAutomation crashes on headless test databases (#324)
-                if _recurrence_js_needed and not self._test_mode:
-                    js_method_map = {
-                        "fixed": "Task.RepetitionMethod.Fixed",
-                        "due_after_completion": "Task.RepetitionMethod.DueDate",
-                        "start_after_completion": "Task.RepetitionMethod.DeferUntilDate",
-                    }
-                    js_method = js_method_map.get(
-                        repetition_method or "fixed",
-                        "Task.RepetitionMethod.Fixed"
+                if _recurrence_js_needed:
+                    self._execute_recurrence_update(
+                        task_id_escaped, recurrence, repetition_method
                     )
-                    task_id_js = task_id_escaped.replace("'", "\\'")
-
-                    if recurrence is not None:
-                        # Set/modify: create new rule with given RRULE and method
-                        recurrence_js = self._escape_applescript_string(
-                            recurrence
-                        ).replace("'", "\\'")
-                        js_code = (
-                            f"var t = Task.byIdentifier('{task_id_js}');"
-                            f" if (t) {{ t.repetitionRule = new Task.RepetitionRule("
-                            f"'{recurrence_js}', {js_method}); 'ok'; }}"
-                            f" else {{ 'not found'; }}"
-                        )
-                    else:
-                        # Change method only: read current RRULE, create new rule
-                        # with same RRULE but different method
-                        js_code = (
-                            f"var t = Task.byIdentifier('{task_id_js}');"
-                            f" if (t && t.repetitionRule) {{"
-                            f" var rr = t.repetitionRule.ruleString;"
-                            f" t.repetitionRule = new Task.RepetitionRule("
-                            f"rr, {js_method}); 'ok'; }}"
-                            f" else {{ 'no rule'; }}"
-                        )
-
-                    js_script = (
-                        'tell application "OmniFocus"\n'
-                        f'    evaluate javascript "{js_code}"\n'
-                        'end tell'
-                    )
-                    run_applescript(js_script)
-
                 return {
                     "success": True,
                     "task_id": task_id,
@@ -3877,7 +3970,6 @@ class OmniFocusConnector:
                     "error": f"Unexpected result: {result}"
                 }
         except subprocess.CalledProcessError as e:
-            # OmniFocus error (task not found, etc.) - return error dict
             return {
                 "success": False,
                 "task_id": task_id,
@@ -3885,13 +3977,182 @@ class OmniFocusConnector:
                 "error": f"AppleScript error: {e.stderr}"
             }
         except Exception as e:
-            # Other runtime errors - return error dict
             return {
                 "success": False,
                 "task_id": task_id,
                 "updated_fields": [],
                 "error": str(e)
             }
+
+    def _validate_update_tasks_params(
+        self,
+        *,
+        task_ids: Union[str, list[str]],
+        flagged: Optional[bool],
+        sequential: Optional[bool],
+        status: Optional[Union[TaskStatus, str]],
+        completed: Optional[bool],
+        project_id: Optional[str],
+        parent_task_id: Optional[str],
+        tags: Optional[list[str]],
+        add_tags: Optional[list[str]],
+        remove_tags: Optional[list[str]],
+        due_date: Optional[str],
+        defer_date: Optional[str],
+        planned_date: Optional[str],
+        estimated_minutes: Optional[int],
+        kwargs: dict,
+    ) -> list[str]:
+        """Validate update_tasks parameters. Returns normalized ids_list."""
+        if 'task_name' in kwargs or 'name' in kwargs:
+            raise ValueError("task_name is not allowed in batch updates (requires unique values per task)")
+        if 'note' in kwargs:
+            raise ValueError("note is not allowed in batch updates (requires unique values per task)")
+        if kwargs:
+            unexpected = ', '.join(kwargs.keys())
+            raise ValueError(f"Unexpected arguments: {unexpected}")
+
+        ids_list = [task_ids] if isinstance(task_ids, str) else task_ids
+        if not ids_list:
+            raise ValueError("task_ids cannot be empty")
+
+        provided_fields = [
+            flagged, sequential, status, completed, project_id, parent_task_id,
+            tags, add_tags, remove_tags, due_date, defer_date, planned_date,
+            estimated_minutes
+        ]
+        if all(f is None for f in provided_fields):
+            raise ValueError("Must provide at least one field to update")
+
+        if project_id is not None and parent_task_id is not None:
+            raise ValueError("Cannot specify both project_id and parent_task_id")
+        if tags is not None and add_tags is not None:
+            raise ValueError("Cannot specify both tags and add_tags (use one or the other)")
+
+        return ids_list
+
+    def _build_bulk_update_commands(
+        self,
+        *,
+        or_chain_target: str,
+        flagged: Optional[bool],
+        sequential: Optional[bool],
+        due_date: Optional[str],
+        defer_date: Optional[str],
+        planned_date: Optional[str],
+        estimated_minutes: Optional[int],
+        completed: Optional[bool],
+    ) -> tuple[list[str], bool]:
+        """Build bulk-settable OR-chain commands for update_tasks.
+
+        Returns (bulk_commands, has_bulk).
+        """
+        bulk_commands: list[str] = []
+
+        if flagged is not None:
+            bulk_commands.append(
+                f"set flagged of ({or_chain_target}) to {str(flagged).lower()}"
+            )
+        if sequential is not None:
+            bulk_commands.append(
+                f"set sequential of ({or_chain_target}) to {str(sequential).lower()}"
+            )
+        if estimated_minutes is not None:
+            bulk_commands.append(
+                f"set estimated minutes of ({or_chain_target}) to {estimated_minutes}"
+            )
+
+        for field_name, field_val in [("due date", due_date), ("defer date", defer_date), ("planned date", planned_date)]:
+            if field_val is not None:
+                if field_val == "":
+                    bulk_commands.append(
+                        f"set {field_name} of ({or_chain_target}) to missing value"
+                    )
+                else:
+                    as_date = self._iso_to_applescript_date(field_val)
+                    bulk_commands.append(
+                        f'set {field_name} of ({or_chain_target}) to date "{as_date}"'
+                    )
+
+        if completed is True:
+            bulk_commands.append(f"mark complete ({or_chain_target})")
+
+        return bulk_commands, len(bulk_commands) > 0
+
+    def _build_per_task_update_commands(
+        self,
+        *,
+        completed: Optional[bool],
+        status: Optional[Union[TaskStatus, str]],
+        project_id: Optional[str],
+        parent_task_id: Optional[str],
+        tags: Optional[list[str]],
+        add_tags: Optional[list[str]],
+        remove_tags: Optional[list[str]],
+    ) -> tuple[list[str], bool]:
+        """Build per-task repeat-loop commands for update_tasks.
+
+        Returns (per_task_commands, has_per_task).
+        """
+        per_task_commands: list[str] = []
+
+        if completed is False:
+            per_task_commands.append("set completed of theTask to false")
+
+        if status is not None:
+            if isinstance(status, str):
+                status = TaskStatus(status)
+            if status == TaskStatus.DROPPED:
+                per_task_commands.append("mark dropped theTask")
+            elif status == TaskStatus.ACTIVE:
+                per_task_commands.append("set dropped of theTask to false")
+
+        if project_id is not None:
+            project_id_escaped = self._escape_applescript_string(project_id)
+            per_task_commands.append(f'''
+                    set theProject to first flattened project whose id is "{project_id_escaped}"
+                    move theTask to end of tasks of theProject''')
+
+        if parent_task_id is not None:
+            parent_id_escaped = self._escape_applescript_string(parent_task_id)
+            per_task_commands.append(f'''
+                    set theParent to first flattened task whose id is "{parent_id_escaped}"
+                    if id of theTask is id of theParent then
+                        error "Cannot set task as its own parent"
+                    end if
+                    move theTask to end of tasks of theParent''')
+
+        if tags is not None:
+            if len(tags) > 0:
+                tag_adds = []
+                for tag in tags:
+                    tag_escaped = self._escape_applescript_string(tag)
+                    tag_adds.append(f'''
+                        set tagObj to first flattened tag whose name is "{tag_escaped}"
+                        copy tagObj to end of newTags''')
+                tag_adds_str = "\n                    ".join(tag_adds)
+                per_task_commands.append(f'''
+                    set newTags to {{}}
+                    {tag_adds_str}
+                    set tags of theTask to newTags''')
+            else:
+                per_task_commands.append("set tags of theTask to {}")
+
+        if add_tags is not None:
+            for tag in add_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                per_task_commands.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of theTask''')
+
+        if remove_tags is not None:
+            for tag in remove_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                per_task_commands.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    remove tagObj from tags of theTask''')
+
+        return per_task_commands, len(per_task_commands) > 0
 
     def update_tasks(
         self,
@@ -3962,180 +4223,31 @@ class OmniFocusConnector:
         # SAFETY: Verify database before modifying
         self._verify_database_safety('update_tasks')
 
-        # Validation: task_name and note are NOT allowed (require unique values)
-        if 'task_name' in kwargs or 'name' in kwargs:
-            raise ValueError("task_name is not allowed in batch updates (requires unique values per task)")
-        if 'note' in kwargs:
-            raise ValueError("note is not allowed in batch updates (requires unique values per task)")
+        # Validate and normalize parameters
+        ids_list = self._validate_update_tasks_params(
+            task_ids=task_ids, flagged=flagged, sequential=sequential,
+            status=status, completed=completed, project_id=project_id,
+            parent_task_id=parent_task_id, tags=tags, add_tags=add_tags,
+            remove_tags=remove_tags, due_date=due_date, defer_date=defer_date,
+            planned_date=planned_date, estimated_minutes=estimated_minutes,
+            kwargs=kwargs,
+        )
 
-        # Reject any other unexpected arguments
-        if kwargs:
-            unexpected = ', '.join(kwargs.keys())
-            raise ValueError(f"Unexpected arguments: {unexpected}")
-
-        # Normalize task_ids to list
-        if isinstance(task_ids, str):
-            ids_list = [task_ids]
-        else:
-            ids_list = task_ids
-
-        # Validation: task_ids must not be empty
-        if not ids_list:
-            raise ValueError("task_ids cannot be empty")
-
-        # Validation: Must provide at least one field to update
-        provided_fields = [
-            flagged, sequential, status, completed, project_id, parent_task_id,
-            tags, add_tags, remove_tags, due_date, defer_date, planned_date,
-            estimated_minutes
-        ]
-        if all(f is None for f in provided_fields):
-            raise ValueError("Must provide at least one field to update")
-
-        # Validation: Conflicting parameters
-        if project_id is not None and parent_task_id is not None:
-            raise ValueError("Cannot specify both project_id and parent_task_id")
-
-        if tags is not None and add_tags is not None:
-            raise ValueError("Cannot specify both tags and add_tags (use one or the other)")
-
-        # Classify fields into bulk-settable (or-chain) vs per-task (repeat loop)
-        # Bulk: flagged, estimated_minutes, due_date, defer_date, completed=True
-        # Per-task: completed=False, status, project_id, parent_task_id, tags, add_tags, remove_tags
-        has_bulk = False
-        has_per_task = False
-
-        bulk_commands = []
         or_chain_target = self._build_whose_or_chain(ids_list, "flattened task")
 
-        # --- Bulk-settable fields ---
+        # Build bulk-settable and per-task commands
+        bulk_commands, has_bulk = self._build_bulk_update_commands(
+            or_chain_target=or_chain_target, flagged=flagged,
+            sequential=sequential, due_date=due_date, defer_date=defer_date,
+            planned_date=planned_date, estimated_minutes=estimated_minutes,
+            completed=completed,
+        )
 
-        if flagged is not None:
-            bulk_commands.append(
-                f"set flagged of ({or_chain_target}) to {str(flagged).lower()}"
-            )
-            has_bulk = True
-
-        if sequential is not None:
-            bulk_commands.append(
-                f"set sequential of ({or_chain_target}) to {str(sequential).lower()}"
-            )
-            has_bulk = True
-
-        if estimated_minutes is not None:
-            bulk_commands.append(
-                f"set estimated minutes of ({or_chain_target}) to {estimated_minutes}"
-            )
-            has_bulk = True
-
-        if due_date is not None:
-            if due_date == "":
-                bulk_commands.append(
-                    f"set due date of ({or_chain_target}) to missing value"
-                )
-            else:
-                as_date = self._iso_to_applescript_date(due_date)
-                bulk_commands.append(
-                    f'set due date of ({or_chain_target}) to date "{as_date}"'
-                )
-            has_bulk = True
-
-        if defer_date is not None:
-            if defer_date == "":
-                bulk_commands.append(
-                    f"set defer date of ({or_chain_target}) to missing value"
-                )
-            else:
-                as_date = self._iso_to_applescript_date(defer_date)
-                bulk_commands.append(
-                    f'set defer date of ({or_chain_target}) to date "{as_date}"'
-                )
-            has_bulk = True
-
-        if planned_date is not None:
-            if planned_date == "":
-                bulk_commands.append(
-                    f"set planned date of ({or_chain_target}) to missing value"
-                )
-            else:
-                as_date = self._iso_to_applescript_date(planned_date)
-                bulk_commands.append(
-                    f'set planned date of ({or_chain_target}) to date "{as_date}"'
-                )
-            has_bulk = True
-
-        if completed is True:
-            bulk_commands.append(f"mark complete ({or_chain_target})")
-            has_bulk = True
-
-        # --- Per-task fields (need repeat loop) ---
-
-        per_task_properties = []
-        per_task_commands = []
-
-        if completed is False:
-            per_task_commands.append("set completed of theTask to false")
-            has_per_task = True
-
-        # Validate and normalize status
-        if status is not None:
-            if isinstance(status, str):
-                status = TaskStatus(status)
-            if status == TaskStatus.DROPPED:
-                per_task_commands.append("mark dropped theTask")
-            elif status == TaskStatus.ACTIVE:
-                per_task_commands.append("set dropped of theTask to false")
-            has_per_task = True
-
-        if project_id is not None:
-            project_id_escaped = self._escape_applescript_string(project_id)
-            per_task_commands.append(f'''
-                    set theProject to first flattened project whose id is "{project_id_escaped}"
-                    move theTask to end of tasks of theProject''')
-            has_per_task = True
-
-        if parent_task_id is not None:
-            parent_id_escaped = self._escape_applescript_string(parent_task_id)
-            per_task_commands.append(f'''
-                    set theParent to first flattened task whose id is "{parent_id_escaped}"
-                    if id of theTask is id of theParent then
-                        error "Cannot set task as its own parent"
-                    end if
-                    move theTask to end of tasks of theParent''')
-            has_per_task = True
-
-        if tags is not None:
-            if len(tags) > 0:
-                tag_adds = []
-                for tag in tags:
-                    tag_escaped = self._escape_applescript_string(tag)
-                    tag_adds.append(f'''
-                        set tagObj to first flattened tag whose name is "{tag_escaped}"
-                        copy tagObj to end of newTags''')
-                tag_adds_str = "\n                    ".join(tag_adds)
-                per_task_commands.append(f'''
-                    set newTags to {{}}
-                    {tag_adds_str}
-                    set tags of theTask to newTags''')
-            else:
-                per_task_commands.append("set tags of theTask to {}")
-            has_per_task = True
-
-        if add_tags is not None:
-            for tag in add_tags:
-                tag_escaped = self._escape_applescript_string(tag)
-                per_task_commands.append(f'''
-                    set tagObj to first flattened tag whose name is "{tag_escaped}"
-                    add tagObj to tags of theTask''')
-            has_per_task = True
-
-        if remove_tags is not None:
-            for tag in remove_tags:
-                tag_escaped = self._escape_applescript_string(tag)
-                per_task_commands.append(f'''
-                    set tagObj to first flattened tag whose name is "{tag_escaped}"
-                    remove tagObj from tags of theTask''')
-            has_per_task = True
+        per_task_commands, has_per_task = self._build_per_task_update_commands(
+            completed=completed, status=status, project_id=project_id,
+            parent_task_id=parent_task_id, tags=tags, add_tags=add_tags,
+            remove_tags=remove_tags,
+        )
 
         # --- Build AppleScript ---
 

--- a/tests/test_get_projects_helpers.py
+++ b/tests/test_get_projects_helpers.py
@@ -1,0 +1,154 @@
+"""Tests for get_projects helper methods.
+
+Tests _validate_get_projects_params and _post_process_projects.
+"""
+import pytest
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+
+
+@pytest.fixture
+def client():
+    return OmniFocusConnector()
+
+
+# ── _validate_get_projects_params ───────────────────────────────────────────
+
+
+class TestValidateGetProjectsParams:
+
+    def test_valid_params_no_error(self, client):
+        client._validate_get_projects_params(
+            modified_after=None, modified_before=None,
+            sort_by=None, sort_order="asc",
+        )
+
+    def test_invalid_date_raises(self, client):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            client._validate_get_projects_params(
+                modified_after="not-a-date", modified_before=None,
+                sort_by=None, sort_order="asc",
+            )
+
+    def test_invalid_sort_by_raises(self, client):
+        with pytest.raises(ValueError, match="sort_by"):
+            client._validate_get_projects_params(
+                modified_after=None, modified_before=None,
+                sort_by="date", sort_order="asc",
+            )
+
+    def test_invalid_sort_order_raises(self, client):
+        with pytest.raises(ValueError, match="sort_order"):
+            client._validate_get_projects_params(
+                modified_after=None, modified_before=None,
+                sort_by=None, sort_order="sideways",
+            )
+
+    def test_valid_iso_date_accepted(self, client):
+        client._validate_get_projects_params(
+            modified_after="2025-01-15T00:00:00Z", modified_before=None,
+            sort_by=None, sort_order="asc",
+        )
+
+
+# ── _post_process_projects ──────────────────────────────────────────────────
+
+
+class TestPostProcessProjects:
+
+    def _default_params(self, **overrides):
+        defaults = dict(
+            modified_after=None, modified_before=None,
+            min_task_count=None, has_overdue_tasks=None,
+            has_no_due_dates=None, query=None,
+            include_task_health=False, stalled_only=False,
+            sort_by=None, sort_order="asc",
+        )
+        defaults.update(overrides)
+        return defaults
+
+    def _sample_project(self, **overrides):
+        p = {
+            "id": "p1", "name": "Project", "note": "",
+            "status": "active status", "singletonActionHolder": False,
+            "sequential": False, "folderPath": "Work",
+        }
+        p.update(overrides)
+        return p
+
+    def test_computes_parallel_project_type(self, client):
+        projects = [self._sample_project()]
+        result = client._post_process_projects(projects, **self._default_params())
+        assert result[0]["projectType"] == "parallel"
+
+    def test_computes_sequential_project_type(self, client):
+        projects = [self._sample_project(sequential=True)]
+        result = client._post_process_projects(projects, **self._default_params())
+        assert result[0]["projectType"] == "sequential"
+
+    def test_computes_single_actions_project_type(self, client):
+        projects = [self._sample_project(singletonActionHolder=True)]
+        result = client._post_process_projects(projects, **self._default_params())
+        assert result[0]["projectType"] == "single_actions"
+
+    def test_query_filters_by_name(self, client):
+        projects = [
+            self._sample_project(id="p1", name="Marketing Plan"),
+            self._sample_project(id="p2", name="Engineering"),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(query="marketing"))
+        assert len(result) == 1
+        assert result[0]["id"] == "p1"
+
+    def test_query_filters_by_folder_path(self, client):
+        projects = [
+            self._sample_project(id="p1", folderPath="Work/Marketing"),
+            self._sample_project(id="p2", folderPath="Personal"),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(query="marketing"))
+        assert len(result) == 1
+
+    def test_sort_by_name(self, client):
+        projects = [
+            self._sample_project(name="Zebra"),
+            self._sample_project(name="Apple"),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(sort_by="name"))
+        assert result[0]["name"] == "Apple"
+
+    def test_sort_by_name_desc(self, client):
+        projects = [
+            self._sample_project(name="Apple"),
+            self._sample_project(name="Zebra"),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(sort_by="name", sort_order="desc"))
+        assert result[0]["name"] == "Zebra"
+
+    def test_stalled_computed_when_task_health(self, client):
+        projects = [
+            self._sample_project(status="active status", availableCount=0, hasDeferredOnly=False),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(include_task_health=True))
+        assert result[0]["stalled"] is True
+
+    def test_not_stalled_when_has_available(self, client):
+        projects = [
+            self._sample_project(status="active status", availableCount=5, hasDeferredOnly=False),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(include_task_health=True))
+        assert result[0]["stalled"] is False
+
+    def test_stalled_only_filters(self, client):
+        projects = [
+            self._sample_project(id="p1", status="active status", availableCount=0, hasDeferredOnly=False),
+            self._sample_project(id="p2", status="active status", availableCount=5, hasDeferredOnly=False),
+        ]
+        result = client._post_process_projects(projects, **self._default_params(
+            include_task_health=True, stalled_only=True
+        ))
+        assert len(result) == 1
+        assert result[0]["id"] == "p1"
+
+    def test_passthrough_when_no_filters(self, client):
+        projects = [self._sample_project()]
+        result = client._post_process_projects(projects, **self._default_params())
+        assert len(result) == 1

--- a/tests/test_update_task_helpers.py
+++ b/tests/test_update_task_helpers.py
@@ -1,0 +1,294 @@
+"""Tests for update_task and update_tasks helper methods.
+
+Tests _validate_update_task_params, _build_update_task_commands,
+_execute_recurrence_update, _validate_update_tasks_params,
+_build_bulk_update_commands, and _build_per_task_update_commands.
+"""
+import pytest
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector, TaskStatus
+
+
+@pytest.fixture
+def client():
+    return OmniFocusConnector()
+
+
+# ── _validate_update_task_params ────────────────────────────────────────────
+
+
+class TestValidateUpdateTaskParams:
+
+    def _call(self, client, **overrides):
+        defaults = dict(
+            task_id="t1", task_name=None, name=None,
+            project_id=None, parent_task_id=None,
+            tags=None, add_tags=None, remove_tags=None,
+            status=None, repetition_method=None,
+            note=None, due_date=None, defer_date=None,
+            planned_date=None, flagged=None, sequential=None,
+            estimated_minutes=None, completed=None, recurrence=None,
+        )
+        defaults.update(overrides)
+        return client._validate_update_task_params(**defaults)
+
+    def test_empty_task_id_raises(self, client):
+        with pytest.raises(ValueError, match="task_id is required"):
+            self._call(client, task_id="", flagged=True)
+
+    def test_legacy_name_resolved(self, client):
+        task_name, _ = self._call(client, name="legacy", task_name=None, flagged=True)
+        assert task_name == "legacy"
+
+    def test_task_name_takes_precedence_over_name(self, client):
+        task_name, _ = self._call(client, name="legacy", task_name="new", flagged=True)
+        assert task_name == "new"
+
+    def test_project_and_parent_conflict(self, client):
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            self._call(client, project_id="p1", parent_task_id="t2", flagged=True)
+
+    def test_tags_and_add_tags_conflict(self, client):
+        with pytest.raises(ValueError, match="Cannot specify both tags"):
+            self._call(client, tags=["a"], add_tags=["b"])
+
+    def test_tags_and_remove_tags_conflict(self, client):
+        with pytest.raises(ValueError, match="Cannot specify both tags"):
+            self._call(client, tags=["a"], remove_tags=["b"])
+
+    def test_invalid_status_string_raises(self, client):
+        with pytest.raises(ValueError, match="Invalid status"):
+            self._call(client, status="invalid")
+
+    def test_valid_status_string_normalized(self, client):
+        _, status = self._call(client, status="dropped")
+        assert status == TaskStatus.DROPPED
+
+    def test_invalid_repetition_method_raises(self, client):
+        with pytest.raises(ValueError, match="Invalid repetition_method"):
+            self._call(client, repetition_method="bogus", recurrence="FREQ=DAILY")
+
+    def test_no_fields_raises(self, client):
+        with pytest.raises(ValueError, match="At least one field"):
+            self._call(client)
+
+
+# ── _build_update_task_commands ─────────────────────────────────────────────
+
+
+class TestBuildUpdateTaskCommands:
+
+    def _call(self, client, **overrides):
+        defaults = dict(
+            task_name=None, note=None, flagged=None, sequential=None,
+            due_date=None, defer_date=None, planned_date=None,
+            estimated_minutes=None, completed=None, status=None,
+            project_id=None, parent_task_id=None,
+            tags=None, add_tags=None, remove_tags=None,
+            recurrence=None, repetition_method=None,
+        )
+        defaults.update(overrides)
+        return client._build_update_task_commands(**defaults)
+
+    def test_task_name_adds_property(self, client):
+        props, cmds, fields, _ = self._call(client, task_name="New Name")
+        assert any('name:' in p for p in props)
+        assert "task_name" in fields
+
+    def test_flagged_adds_property(self, client):
+        props, _, fields, _ = self._call(client, flagged=True)
+        assert any('flagged:true' in p for p in props)
+        assert "flagged" in fields
+
+    def test_due_date_set(self, client):
+        _, cmds, fields, _ = self._call(client, due_date="2026-04-01")
+        assert any('due date' in c for c in cmds)
+        assert "due_date" in fields
+
+    def test_due_date_clear(self, client):
+        _, cmds, _, _ = self._call(client, due_date="")
+        assert any('missing value' in c for c in cmds)
+
+    def test_completed_true_uses_mark_complete(self, client):
+        _, cmds, _, _ = self._call(client, completed=True)
+        assert any('mark complete' in c for c in cmds)
+
+    def test_completed_false_uses_set(self, client):
+        _, cmds, _, _ = self._call(client, completed=False)
+        assert any('set completed' in c for c in cmds)
+
+    def test_status_dropped(self, client):
+        _, cmds, _, _ = self._call(client, status=TaskStatus.DROPPED)
+        assert any('mark dropped' in c for c in cmds)
+
+    def test_tags_full_replacement(self, client):
+        _, cmds, fields, _ = self._call(client, tags=["urgent", "home"])
+        assert any('newTags' in c for c in cmds)
+        assert "tags" in fields
+
+    def test_tags_empty_clears(self, client):
+        _, cmds, _, _ = self._call(client, tags=[])
+        assert any('set tags of theTask to {}' in c for c in cmds)
+
+    def test_add_tags(self, client):
+        _, cmds, fields, _ = self._call(client, add_tags=["urgent"])
+        assert any('add tagObj' in c for c in cmds)
+        assert "add_tags" in fields
+
+    def test_recurrence_set_flags_js(self, client):
+        _, _, _, js_needed = self._call(client, recurrence="FREQ=DAILY")
+        assert js_needed is True
+
+    def test_recurrence_clear_no_js(self, client):
+        _, cmds, _, js_needed = self._call(client, recurrence="")
+        assert js_needed is False
+        assert any('missing value' in c for c in cmds)
+
+    def test_repetition_method_only_flags_js(self, client):
+        _, _, _, js_needed = self._call(client, repetition_method="fixed")
+        assert js_needed is True
+
+
+# ── _execute_recurrence_update ──────────────────────────────────────────────
+
+
+class TestExecuteRecurrenceUpdate:
+
+    def test_skipped_in_test_mode(self, client):
+        """In test mode, should not call run_applescript."""
+        import os
+        from unittest import mock
+        os.environ['OMNIFOCUS_TEST_MODE'] = 'true'
+        os.environ['OMNIFOCUS_TEST_DATABASE'] = 'OmniFocus-TEST.ofocus'
+        test_client = OmniFocusConnector(enable_safety_checks=True)
+        try:
+            with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_as:
+                test_client._execute_recurrence_update("task-1", "FREQ=DAILY", "fixed")
+                mock_as.assert_not_called()
+        finally:
+            os.environ.pop('OMNIFOCUS_TEST_MODE', None)
+            os.environ.pop('OMNIFOCUS_TEST_DATABASE', None)
+
+
+# ── _validate_update_tasks_params ───────────────────────────────────────────
+
+
+class TestValidateUpdateTasksParams:
+
+    def _call(self, client, **overrides):
+        defaults = dict(
+            task_ids=["t1"], flagged=None, sequential=None, status=None,
+            completed=None, project_id=None, parent_task_id=None,
+            tags=None, add_tags=None, remove_tags=None,
+            due_date=None, defer_date=None, planned_date=None,
+            estimated_minutes=None, kwargs={},
+        )
+        defaults.update(overrides)
+        return client._validate_update_tasks_params(**defaults)
+
+    def test_task_name_rejected(self, client):
+        with pytest.raises(ValueError, match="task_name is not allowed"):
+            self._call(client, kwargs={"task_name": "x"}, flagged=True)
+
+    def test_note_rejected(self, client):
+        with pytest.raises(ValueError, match="note is not allowed"):
+            self._call(client, kwargs={"note": "x"}, flagged=True)
+
+    def test_unexpected_kwargs_rejected(self, client):
+        with pytest.raises(ValueError, match="Unexpected"):
+            self._call(client, kwargs={"foo": "bar"}, flagged=True)
+
+    def test_empty_ids_raises(self, client):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            self._call(client, task_ids=[], flagged=True)
+
+    def test_no_fields_raises(self, client):
+        with pytest.raises(ValueError, match="Must provide"):
+            self._call(client)
+
+    def test_string_id_normalized(self, client):
+        ids = self._call(client, task_ids="single-id", flagged=True)
+        assert ids == ["single-id"]
+
+    def test_conflict_project_parent(self, client):
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            self._call(client, project_id="p1", parent_task_id="t2", flagged=True)
+
+
+# ── _build_bulk_update_commands ─────────────────────────────────────────────
+
+
+class TestBuildBulkUpdateCommands:
+
+    def _call(self, client, **overrides):
+        defaults = dict(
+            or_chain_target="(flattened task whose id is \"t1\")",
+            flagged=None, sequential=None, due_date=None,
+            defer_date=None, planned_date=None,
+            estimated_minutes=None, completed=None,
+        )
+        defaults.update(overrides)
+        return client._build_bulk_update_commands(**defaults)
+
+    def test_flagged(self, client):
+        cmds, has_bulk = self._call(client, flagged=True)
+        assert has_bulk is True
+        assert any('flagged' in c for c in cmds)
+
+    def test_due_date_set(self, client):
+        cmds, has_bulk = self._call(client, due_date="2026-04-01")
+        assert has_bulk is True
+        assert any('due date' in c for c in cmds)
+
+    def test_due_date_clear(self, client):
+        cmds, _ = self._call(client, due_date="")
+        assert any('missing value' in c for c in cmds)
+
+    def test_completed_true(self, client):
+        cmds, _ = self._call(client, completed=True)
+        assert any('mark complete' in c for c in cmds)
+
+    def test_no_fields_empty(self, client):
+        cmds, has_bulk = self._call(client)
+        assert cmds == []
+        assert has_bulk is False
+
+
+# ── _build_per_task_update_commands ─────────────────────────────────────────
+
+
+class TestBuildPerTaskUpdateCommands:
+
+    def _call(self, client, **overrides):
+        defaults = dict(
+            completed=None, status=None, project_id=None,
+            parent_task_id=None, tags=None, add_tags=None,
+            remove_tags=None,
+        )
+        defaults.update(overrides)
+        return client._build_per_task_update_commands(**defaults)
+
+    def test_completed_false(self, client):
+        cmds, has = self._call(client, completed=False)
+        assert has is True
+        assert any('set completed' in c for c in cmds)
+
+    def test_status_dropped(self, client):
+        cmds, _ = self._call(client, status="dropped")
+        assert any('mark dropped' in c for c in cmds)
+
+    def test_tags_replacement(self, client):
+        cmds, _ = self._call(client, tags=["work"])
+        assert any('newTags' in c for c in cmds)
+
+    def test_add_tags(self, client):
+        cmds, _ = self._call(client, add_tags=["urgent"])
+        assert any('add tagObj' in c for c in cmds)
+
+    def test_remove_tags(self, client):
+        cmds, _ = self._call(client, remove_tags=["old"])
+        assert any('remove tagObj' in c for c in cmds)
+
+    def test_no_fields_empty(self, client):
+        cmds, has = self._call(client)
+        assert cmds == []
+        assert has is False


### PR DESCRIPTION
## Summary

- Extract 8 helpers from `update_task` (CC 55→7), `update_tasks` (CC 46→10), and `get_projects` (CC 35→7)
- Add 58 unit tests for extracted helpers
- Move OmniAutomation-dependent recurrence test to `test_prod_integration.py`
- Update complexity thresholds with documented exceptions for inherent helper complexity

Continues #265 after PR #325 (get_tasks 135→24). Remaining functions (`update_project` 32, `update_projects` 34, `create_task` 22) have documented exceptions — their complexity is close to the general limit and maps to parameter count.

### Complexity reductions

| Function | Before | After |
|----------|--------|-------|
| `update_task()` | 55 | 7 |
| `update_tasks()` | 46 | 10 |
| `get_projects()` | 35 | 7 |

## Test plan

- [x] 771 unit tests pass (713 existing + 58 new)
- [x] `./scripts/check_complexity.sh` passes
- [x] `./scripts/check_client_server_parity.sh` passes — all 22 tools
- [x] Integration tests: 135 passed, no crash, 6 pre-existing failures (tracked in #327)

🤖 Generated with [Claude Code](https://claude.com/claude-code)