### PR TITLE
fix: convert next_review_date from ISO to AppleScript format

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1452,8 +1452,8 @@ class OmniFocusConnector:
         # Build next review date command
         next_review_command = ""
         if next_review_date is not None:
-            # Parse ISO date
-            next_review_command = f'set next review date of theProject to date "{next_review_date}"'
+            as_date = self._iso_to_applescript_date(next_review_date)
+            next_review_command = f'set next review date of theProject to date "{as_date}"'
             updated_fields.append("next_review_date")
 
         # Build completed by children command
@@ -1726,8 +1726,9 @@ class OmniFocusConnector:
             has_bulk = True
 
         if next_review_date is not None:
+            as_date = self._iso_to_applescript_date(next_review_date)
             bulk_commands.append(
-                f'set next review date of ({or_chain_target}) to date "{next_review_date}"'
+                f'set next review date of ({or_chain_target}) to date "{as_date}"'
             )
             has_bulk = True
 

--- a/tests/test_api_redesign_update_project.py
+++ b/tests/test_api_redesign_update_project.py
@@ -162,7 +162,7 @@ class TestUpdateProjectRedesign:
             # Should set "next review date" for explicit override
             call_args = mock_run.call_args[0][0]
             assert "next review date" in call_args, "Should set 'next review date' property"
-            assert "2025-12-01" in call_args
+            assert "December 01, 2025" in call_args
 
     def test_update_project_both_review_dates(self, client):
         """NEW API: update_project() can set both last reviewed and next review date."""
@@ -179,7 +179,7 @@ class TestUpdateProjectRedesign:
             call_args = mock_run.call_args[0][0]
             assert "last review date" in call_args
             assert "next review date" in call_args
-            assert "2025-12-15" in call_args
+            assert "December 15, 2025" in call_args
 
     # ========================================================================
     # Existing Fields (Regression)

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -659,7 +659,6 @@ class TestProjectCRUD:
         # TODO: Fix get_projects() to parse review interval correctly
         # assert projects[0]['reviewInterval'] == "2 weeks"
 
-    @pytest.mark.skip(reason="Blocked by #330: next_review_date passes raw ISO to AppleScript")
     def test_update_project_next_review_date_integration(self, client, test_project):
         """Integration: update_project() can set next_review_date explicitly."""
         next_review = "2026-06-01"


### PR DESCRIPTION
## Summary

- Fix `update_project` and `update_projects` to convert `next_review_date` from ISO to AppleScript date format using `_iso_to_applescript_date()`
- Unskip `test_update_project_next_review_date_integration` (now passes)
- Update 2 unit test assertions to expect converted date format

**Bug:** `update_project(next_review_date="2026-06-01")` produced year 12169 because the raw ISO string was passed directly to AppleScript's `date` command. All other date fields already used the conversion helper.

Closes #330

## Test plan

- [x] 771 unit tests pass
- [x] Integration test `test_update_project_next_review_date_integration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)