### PR TITLE
fix: create dedicated JavaScript string escaper for OmniAutomation

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -192,6 +192,22 @@ class OmniFocusConnector:
         text = text.replace('"', '\\"')
         return text
 
+    def _escape_js_string(self, text: str) -> str:
+        """Escape a string for use in a JS single-quoted literal inside AppleScript.
+
+        Handles the double-context: JS '...' inside AppleScript "..." via
+        `evaluate javascript "..."`. Order matters — backslashes first.
+        """
+        if not text:
+            return ""
+        text = text.replace("\\", "\\\\")   # \ → \\ (must be first)
+        text = text.replace("'", "\\'")      # ' → \' (JS string delimiter)
+        text = text.replace('"', '\\"')      # " → \" (AppleScript string delimiter)
+        text = text.replace("\n", "\\n")     # newline → \n
+        text = text.replace("\r", "\\r")     # carriage return → \r
+        text = text.replace("\t", "\\t")     # tab → \t
+        return text
+
     def _build_whose_or_chain(self, ids_list: list[str], entity_type: str) -> str:
         """Build a 'whose' or-chain clause for targeting multiple items by ID.
 
@@ -3783,7 +3799,7 @@ class OmniFocusConnector:
 
     def _execute_recurrence_update(
         self,
-        task_id_escaped: str,
+        task_id: str,
         recurrence: Optional[str],
         repetition_method: Optional[str],
     ) -> None:
@@ -3803,12 +3819,10 @@ class OmniFocusConnector:
             repetition_method or "fixed",
             "Task.RepetitionMethod.Fixed"
         )
-        task_id_js = task_id_escaped.replace("'", "\\'")
+        task_id_js = self._escape_js_string(task_id)
 
         if recurrence is not None:
-            recurrence_js = self._escape_applescript_string(
-                recurrence
-            ).replace("'", "\\'")
+            recurrence_js = self._escape_js_string(recurrence)
             js_code = (
                 f"var t = Task.byIdentifier('{task_id_js}');"
                 f" if (t) {{ t.repetitionRule = new Task.RepetitionRule("
@@ -3955,7 +3969,7 @@ class OmniFocusConnector:
             if result.strip() == "true":
                 if _recurrence_js_needed:
                     self._execute_recurrence_update(
-                        task_id_escaped, recurrence, repetition_method
+                        task_id, recurrence, repetition_method
                     )
                 return {
                     "success": True,
@@ -4359,7 +4373,7 @@ class OmniFocusConnector:
             tag_id: The tag ID
             value: True to make children mutually exclusive, False otherwise
         """
-        tag_id_js = self._escape_applescript_string(tag_id).replace("'", "\\'")
+        tag_id_js = self._escape_js_string(tag_id)
         value_js = "true" if value else "false"
         js_code = (
             f"var tag = Tag.byIdentifier('{tag_id_js}');"

--- a/tests/test_js_string_escaper.py
+++ b/tests/test_js_string_escaper.py
@@ -1,0 +1,59 @@
+"""Tests for _escape_js_string — JavaScript escaping for OmniAutomation.
+
+The escaper handles the double-context problem: JS single-quoted strings
+embedded inside AppleScript double-quoted strings via `evaluate javascript "..."`.
+
+See #318.
+"""
+import pytest
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector
+
+
+@pytest.fixture
+def client():
+    return OmniFocusConnector()
+
+
+class TestEscapeJsString:
+
+    def test_plain_string_unchanged(self, client):
+        assert client._escape_js_string("hello") == "hello"
+
+    def test_empty_string(self, client):
+        assert client._escape_js_string("") == ""
+
+    def test_single_quote_escaped(self, client):
+        assert client._escape_js_string("it's") == "it\\'s"
+
+    def test_backslash_escaped(self, client):
+        assert client._escape_js_string("a\\b") == "a\\\\b"
+
+    def test_double_quote_escaped_for_applescript(self, client):
+        """Double quotes must be escaped because the JS lives inside AppleScript \"...\"."""
+        assert client._escape_js_string('say "hi"') == 'say \\"hi\\"'
+
+    def test_newline_escaped(self, client):
+        assert client._escape_js_string("line1\nline2") == "line1\\nline2"
+
+    def test_carriage_return_escaped(self, client):
+        assert client._escape_js_string("a\rb") == "a\\rb"
+
+    def test_tab_escaped(self, client):
+        assert client._escape_js_string("a\tb") == "a\\tb"
+
+    def test_combined_special_chars(self, client):
+        result = client._escape_js_string("it's a \"test\"\nwith\\stuff")
+        assert "\\'" in result      # single quote
+        assert '\\"' in result      # double quote
+        assert "\\n" in result      # newline
+        assert "\\\\" in result     # backslash
+
+    def test_rrule_string_safe(self, client):
+        """Typical RRULE strings should pass through safely."""
+        rrule = "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"
+        assert client._escape_js_string(rrule) == rrule
+
+    def test_backslash_before_quote(self, client):
+        """Backslash before quote: both must be escaped independently."""
+        result = client._escape_js_string("\\'")
+        assert result == "\\\\\\'"


### PR DESCRIPTION
## Summary

- Add `_escape_js_string()` method for proper JS escaping in `evaluate javascript` contexts
- Replace fragile `_escape_applescript_string() + .replace("'", "\\'")` at 2 call sites
- Add 11 unit tests for the escaper covering quotes, backslashes, newlines, and combined edge cases

**Problem:** OmniAutomation JS code is embedded inside AppleScript strings (`evaluate javascript "..."`), creating a double-context escaping requirement. The old approach used the AppleScript escaper plus manual single-quote replacement, which missed newlines, tabs, and carriage returns.

Closes #318

## Test plan

- [x] 782 unit tests pass (771 existing + 11 new)
- [x] No remaining ad-hoc `.replace("'", "\\'")` patterns at call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)