### PR TITLE
fix: convert last_reviewed from ISO to AppleScript format

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1462,7 +1462,8 @@ class OmniFocusConnector:
                 reviewed_command = 'set last review date of theProject to (current date)'
             else:
                 # Parse ISO date
-                reviewed_command = f'set last review date of theProject to date "{last_reviewed}"'
+                as_date = self._iso_to_applescript_date(last_reviewed)
+                reviewed_command = f'set last review date of theProject to date "{as_date}"'
             updated_fields.append("last_reviewed")
 
         # Build next review date command
@@ -1736,8 +1737,9 @@ class OmniFocusConnector:
                     f"set last review date of ({or_chain_target}) to (current date)"
                 )
             else:
+                as_date = self._iso_to_applescript_date(last_reviewed)
                 bulk_commands.append(
-                    f'set last review date of ({or_chain_target}) to date "{last_reviewed}"'
+                    f'set last review date of ({or_chain_target}) to date "{as_date}"'
                 )
             has_bulk = True
 

--- a/tests/test_api_redesign_update_project.py
+++ b/tests/test_api_redesign_update_project.py
@@ -131,7 +131,7 @@ class TestUpdateProjectRedesign:
             call_args = mock_run.call_args[0][0]
             assert "last review date" in call_args, "Should set 'last review date' property"
             assert "next review date" not in call_args, "Should NOT set 'next review date'"
-            assert "2025-10-18" in call_args
+            assert "October 18, 2025" in call_args
 
     def test_update_project_mark_reviewed_now(self, client):
         """NEW API: update_project() sets LAST review date to current date when 'now'."""


### PR DESCRIPTION
## Summary

- Fix `update_project` and `update_projects` to convert `last_reviewed` from ISO to AppleScript date format using `_iso_to_applescript_date()`
- Same bug pattern as #330 (which fixed `next_review_date`)

All review date fields now consistently use the date converter.

Closes #320

## Test plan

- [x] 782 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)