### PR TITLE
release: v0.9.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.9.1 | **Tests:** 641 unit, 137 integration/E2E, 25 benchmark/profiling | **Coverage:** 89%
+**Version:** v0.9.2 | **Tests:** 782 unit, 138 integration/E2E, 25 benchmark/profiling | **Coverage:** 89%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-03-16
+
+### Changed
+
+- **Major complexity reduction across core functions** (#265, #325, #328)
+  - `get_tasks`: CC 135 → 24 (82% reduction, 8 helper methods extracted)
+  - `update_task`: CC 55 → 7 (87% reduction, 3 helpers)
+  - `update_tasks`: CC 46 → 10 (78% reduction, 3 helpers)
+  - `get_projects`: CC 35 → 7 (80% reduction, 2 helpers)
+  - 130 new unit tests for extracted helpers
+
+### Fixed
+
+- **OmniFocus crashes during integration tests** (#324, #326)
+  - OmniAutomation (`evaluate javascript`) calls now skipped on headless test databases
+  - Root cause: `get_tags()` exclusivity enrichment triggered silent OmniFocus crash
+
+- **Review date conversion bugs** (#320, #330, #332, #334)
+  - `update_project` `next_review_date` passed raw ISO to AppleScript (produced year 12169)
+  - `update_project` `last_reviewed` had the same raw ISO bug
+  - Both now use `_iso_to_applescript_date()` like all other date fields
+
+- **JavaScript string escaping for OmniAutomation** (#318, #333)
+  - New `_escape_js_string()` for proper JS escaping in `evaluate javascript` contexts
+  - Replaces fragile `_escape_applescript_string() + .replace("'", "\\'")` pattern
+
+- **6 integration tests with wrong API signatures** (#327, #331)
+  - Fixed `update_tag(active=False)` → `update_tag(status="on_hold")`
+  - Skipped tests blocked by missing project date params (#329) and date bug (#330)
+
+### Maintenance
+
+- Performance benchmarks for v0.9.1 baseline (#282, #323)
+- Fixed stochastic blind eval failures (#314, #317)
+- Split issue templates and updated contributing guide (#283, #316)
+- Removed redundant /release-validate command (#321, #322)
+
 ## [0.9.1] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MCP (Model Context Protocol) server that provides tools for interacting with 
 
 ## Features
 
-This server provides **21 comprehensive tools** for managing OmniFocus (v0.9.1 API):
+This server provides **21 comprehensive tools** for managing OmniFocus (v0.9.2 API):
 
 ### Project Management (5 tools)
 - **get_projects** - Get all projects with filtering (by ID, query, status) and optional full notes
@@ -41,8 +41,8 @@ This server provides **21 comprehensive tools** for managing OmniFocus (v0.9.1 A
 - **set_focus** - Focus on one or more projects/folders, or clear focus
 - **get_focus** - Get the currently focused items
 
-**Key Changes in v0.9.1:**
-- v0.9.1: Planned date, recurrence write, repeatSummary, tag/folder dropped status, single actions list, stalled projects, completedByChildren, effective dates, next_review_date write, stalled project detection
+**Key Changes in v0.9.2:**
+- v0.9.2: Planned date, recurrence write, repeatSummary, tag/folder dropped status, single actions list, stalled projects, completedByChildren, effective dates, next_review_date write, stalled project detection
 - v0.8.4: Fixed create_task silent On Hold tag failure, perspectives type detection, tag status reporting, documentation gaps
 - v0.8.3: Enhanced focus (multi-item, get_focus), enriched perspectives, tag CRUD, blind agent eval (36/36), docstring improvements
 - v0.8.2: AppleScript injection hardening, consistent server error handling, dead code removal, complexity refactoring
@@ -77,7 +77,7 @@ git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
 
 # Checkout latest stable release
-git checkout v0.9.1  # Or latest version from releases
+git checkout v0.9.2  # Or latest version from releases
 
 # Option 1: Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.9.1"
+version = "0.9.2"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Release v0.9.2

### Highlights

- **82% complexity reduction** on `get_tasks` (CC 135→24) and similar reductions on `update_task`, `update_tasks`, `get_projects`
- **Fixed OmniFocus crash** during integration tests (OmniAutomation on headless test DB)
- **Fixed review date bugs** — `last_reviewed` and `next_review_date` now properly convert ISO dates
- **New JS string escaper** for OmniAutomation `evaluate javascript` contexts

### Validation

- [x] Version sync
- [x] Client-server parity (22 tools)
- [x] Complexity check
- [x] 782 unit tests pass
- [x] Dependency audit
- [x] AppleScript safety audit

See CHANGELOG.md for full details.