### PR TITLE
feat: add due_date, defer_date, planned_date to project operations

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1172,7 +1172,10 @@ class OmniFocusConnector:
         sequential: bool = False,
         project_type: Optional[str] = None,
         review_interval_weeks: Optional[int] = None,
-        completed_by_children: Optional[bool] = None
+        completed_by_children: Optional[bool] = None,
+        due_date: Optional[str] = None,
+        defer_date: Optional[str] = None,
+        planned_date: Optional[str] = None,
     ) -> str:
         """Create a new project in OmniFocus.
 
@@ -1185,6 +1188,9 @@ class OmniFocusConnector:
             project_type: Project type: "parallel", "sequential", or "single_actions".
                 Overrides sequential when provided.
             review_interval_weeks: Optional review interval in weeks for GTD review cycle
+            due_date: Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00")
+            defer_date: Defer date in ISO 8601 format (when project becomes available)
+            planned_date: Planned date in ISO 8601 format (when you plan to work on the project)
 
         Returns:
             str: The ID of the created project
@@ -1226,6 +1232,16 @@ class OmniFocusConnector:
             properties.append(f'completed by children:{str(completed_by_children).lower()}')
 
         properties_str = ", ".join(properties)
+
+        # Build date commands (set after creation, like create_task)
+        date_commands = []
+        if due_date:
+            date_commands.append(f'set due date of newProject to date "{self._iso_to_applescript_date(due_date)}"')
+        if defer_date:
+            date_commands.append(f'set defer date of newProject to date "{self._iso_to_applescript_date(defer_date)}"')
+        if planned_date:
+            date_commands.append(f'set planned date of newProject to date "{self._iso_to_applescript_date(planned_date)}"')
+        date_commands_str = "\n                    ".join(date_commands) if date_commands else ""
 
         # Build script with optional folder placement
         if folder_path:
@@ -1286,6 +1302,7 @@ class OmniFocusConnector:
                 tell front document
                     {folder_finder}
                     set newProject to make new project at end of projects of targetFolder with properties {{{properties_str}}}
+                    {date_commands_str}
                     return id of newProject
                 end tell
             end tell
@@ -1296,6 +1313,7 @@ class OmniFocusConnector:
             tell application "OmniFocus"
                 tell front document
                     set newProject to make new project with properties {{{properties_str}}}
+                    {date_commands_str}
                     return id of newProject
                 end tell
             end tell
@@ -1322,18 +1340,12 @@ class OmniFocusConnector:
         review_interval_weeks: Optional[int] = None,
         last_reviewed: Optional[str] = None,
         next_review_date: Optional[str] = None,
-        completed_by_children: Optional[bool] = None
+        completed_by_children: Optional[bool] = None,
+        due_date: Optional[str] = None,
+        defer_date: Optional[str] = None,
+        planned_date: Optional[str] = None,
     ) -> dict:
         """Update properties of an existing project (NEW API - Phase 2).
-
-        NEW API changes:
-        - Renamed 'name' parameter to 'project_name' for consistency
-        - Added status parameter (ProjectStatus enum or string)
-        - Added review_interval_weeks parameter
-        - Added last_reviewed parameter
-        - Added folder_path parameter
-        - Returns dict instead of bool
-        - Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_project_reviewed()
 
         Args:
             project_id: The ID of the project to update
@@ -1345,6 +1357,9 @@ class OmniFocusConnector:
             review_interval_weeks: Review interval in weeks (0 to clear)
             last_reviewed: Last reviewed date in ISO format or "now" - OmniFocus calculates next review automatically (optional)
             next_review_date: Next review date in ISO format - Explicit override of calculated date (optional)
+            due_date: Due date in ISO 8601 format, or "" to clear (optional)
+            defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
+            planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
 
         Returns:
             dict: {
@@ -1374,7 +1389,10 @@ class OmniFocusConnector:
             "review_interval_weeks": review_interval_weeks,
             "last_reviewed": last_reviewed,
             "next_review_date": next_review_date,
-            "completed_by_children": completed_by_children
+            "completed_by_children": completed_by_children,
+            "due_date": due_date,
+            "defer_date": defer_date,
+            "planned_date": planned_date,
         }
 
         # Check if at least one field is provided
@@ -1473,6 +1491,22 @@ class OmniFocusConnector:
             next_review_command = f'set next review date of theProject to date "{as_date}"'
             updated_fields.append("next_review_date")
 
+        # Build date commands (due, defer, planned)
+        date_commands_list = []
+        for field_name, field_val, field_key in [
+            ("due date", due_date, "due_date"),
+            ("defer date", defer_date, "defer_date"),
+            ("planned date", planned_date, "planned_date"),
+        ]:
+            if field_val is not None:
+                if field_val == "":
+                    date_commands_list.append(f"set {field_name} of theProject to missing value")
+                else:
+                    as_date = self._iso_to_applescript_date(field_val)
+                    date_commands_list.append(f'set {field_name} of theProject to date "{as_date}"')
+                updated_fields.append(field_key)
+        date_commands_str = "\n                    ".join(date_commands_list) if date_commands_list else ""
+
         # Build completed by children command
         completed_by_children_command = ""
         if completed_by_children is not None:
@@ -1557,6 +1591,7 @@ class OmniFocusConnector:
                     {review_command}
                     {reviewed_command}
                     {next_review_command}
+                    {date_commands_str}
                     {completed_by_children_command}
                     {folder_command}
 
@@ -1604,6 +1639,9 @@ class OmniFocusConnector:
         review_interval_weeks: Optional[int] = None,
         last_reviewed: Optional[str] = None,
         next_review_date: Optional[str] = None,
+        due_date: Optional[str] = None,
+        defer_date: Optional[str] = None,
+        planned_date: Optional[str] = None,
         **kwargs  # Catch invalid parameters like project_name, note
     ) -> dict:
         """Update properties of multiple projects (NEW API - Phase 2, Batch Function).
@@ -1615,13 +1653,6 @@ class OmniFocusConnector:
         because those require unique values for each project. Use update_project()
         for those fields.
 
-        NEW API changes:
-        - Accepts Union[str, list[str]] for project_ids (single or batch)
-        - EXCLUDES project_name and note (require unique values)
-        - Returns dict with counts instead of success bool
-        - Continues processing even if some projects fail
-        - Consolidates: drop_projects() legacy function
-
         Args:
             project_ids: Single project ID (str) or list of project IDs
             folder_path: Folder path to move projects to (e.g., "Work > Projects")
@@ -1630,6 +1661,9 @@ class OmniFocusConnector:
             review_interval_weeks: Review interval in weeks (0 to clear)
             last_reviewed: Last reviewed date in ISO format or "now" - OmniFocus calculates next review automatically (optional)
             next_review_date: Next review date in ISO format - Explicit override of calculated date (optional)
+            due_date: Due date in ISO 8601 format, or "" to clear (optional)
+            defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
+            planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
 
         Returns:
             dict: {
@@ -1674,7 +1708,8 @@ class OmniFocusConnector:
         # Validate at least one field is provided
         if (folder_path is None and sequential is None and status is None and
                 review_interval_weeks is None and last_reviewed is None and
-                next_review_date is None):
+                next_review_date is None and due_date is None and
+                defer_date is None and planned_date is None):
             raise ValueError("At least one field must be provided to update")
 
         # Normalize project_ids to list
@@ -1749,6 +1784,19 @@ class OmniFocusConnector:
                 f'set next review date of ({or_chain_target}) to date "{as_date}"'
             )
             has_bulk = True
+
+        for field_name, field_val in [("due date", due_date), ("defer date", defer_date), ("planned date", planned_date)]:
+            if field_val is not None:
+                if field_val == "":
+                    bulk_commands.append(
+                        f"set {field_name} of ({or_chain_target}) to missing value"
+                    )
+                else:
+                    as_date = self._iso_to_applescript_date(field_val)
+                    bulk_commands.append(
+                        f'set {field_name} of ({or_chain_target}) to date "{as_date}"'
+                    )
+                has_bulk = True
 
         # --- Per-project fields (need repeat loop) ---
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -259,7 +259,10 @@ def create_project(
     sequential: bool = False,
     project_type: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
-    completed_by_children: Optional[bool] = None
+    completed_by_children: Optional[bool] = None,
+    due_date: Optional[str] = None,
+    defer_date: Optional[str] = None,
+    planned_date: Optional[str] = None,
 ) -> str:
     """Create a new project in OmniFocus.
 
@@ -275,6 +278,9 @@ def create_project(
             Ignored when project_type is provided. (default: False)
         review_interval_weeks: Optional review interval in weeks for GTD review cycle
         completed_by_children: Auto-complete the project when its last remaining action is completed. (optional)
+        due_date: Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00")
+        defer_date: Defer date in ISO 8601 format (when project becomes available)
+        planned_date: Planned date in ISO 8601 format (when you plan to work on the project)
 
     Returns:
         Success message with project ID and configuration details
@@ -288,7 +294,10 @@ def create_project(
             sequential=sequential,
             project_type=project_type,
             review_interval_weeks=review_interval_weeks,
-            completed_by_children=completed_by_children
+            completed_by_children=completed_by_children,
+            due_date=due_date,
+            defer_date=defer_date,
+            planned_date=planned_date,
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -324,7 +333,10 @@ def update_project(
     review_interval_weeks: Optional[int] = None,
     last_reviewed: Optional[str] = None,
     next_review_date: Optional[str] = None,
-    completed_by_children: Optional[bool] = None
+    completed_by_children: Optional[bool] = None,
+    due_date: Optional[str] = None,
+    defer_date: Optional[str] = None,
+    planned_date: Optional[str] = None,
 ) -> str:
     """Update an existing project in OmniFocus.
 
@@ -340,6 +352,9 @@ def update_project(
         last_reviewed: Last reviewed date in ISO format or "now"
         next_review_date: Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval. (optional)
         completed_by_children: Auto-complete the project when its last remaining action is completed. (optional)
+        due_date: Due date in ISO 8601 format, or "" to clear (optional)
+        defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
+        planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
 
     Returns:
         Success message with project ID and updated fields, or error message
@@ -370,7 +385,10 @@ def update_project(
             review_interval_weeks=review_interval_weeks,
             last_reviewed=last_reviewed,
             next_review_date=next_review_date,
-            completed_by_children=completed_by_children
+            completed_by_children=completed_by_children,
+            due_date=due_date,
+            defer_date=defer_date,
+            planned_date=planned_date,
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -399,7 +417,10 @@ def update_projects(
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
     last_reviewed: Optional[str] = None,
-    next_review_date: Optional[str] = None
+    next_review_date: Optional[str] = None,
+    due_date: Optional[str] = None,
+    defer_date: Optional[str] = None,
+    planned_date: Optional[str] = None,
 ) -> str:
     """Update multiple projects with the same properties (NEW API - Phase 2, Batch Function).
 
@@ -418,6 +439,9 @@ def update_projects(
         review_interval_weeks: Review interval in weeks
         last_reviewed: Last review date ("now" or ISO format like "2025-01-15")
         next_review_date: Explicit next review date in ISO format — overrides OmniFocus-calculated date (optional)
+        due_date: Due date in ISO 8601 format, or "" to clear (optional)
+        defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
+        planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
 
     Returns:
         Success message with updated and failed counts, or error message
@@ -453,7 +477,10 @@ def update_projects(
             status=status,
             review_interval_weeks=review_interval_weeks,
             last_reviewed=last_reviewed,
-            next_review_date=next_review_date
+            next_review_date=next_review_date,
+            due_date=due_date,
+            defer_date=defer_date,
+            planned_date=planned_date,
         )
 
         # Handle dict return from client

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -2579,7 +2579,6 @@ class TestTagSidePreFilter:
                     warnings.warn(f"Failed to clean up task {task_id}: {e}")
 
 
-@pytest.mark.skip(reason="Blocked by #329: create_project/update_project don't expose due_date yet")
 class TestEffectiveDates:
     """Test that get_tasks returns effective (inherited) dates from the containing project."""
 

--- a/tests/test_server_fastmcp.py
+++ b/tests/test_server_fastmcp.py
@@ -111,7 +111,7 @@ class TestProjectTools:
             assert "Successfully created project 'New Project'" in result
             assert "Folder: Work" in result
             mock_client.create_project.assert_called_once_with(
-                name="New Project", note=None, folder_path="Work", sequential=False, project_type=None, review_interval_weeks=None, completed_by_children=None
+                name="New Project", note=None, folder_path="Work", sequential=False, project_type=None, review_interval_weeks=None, completed_by_children=None, due_date=None, defer_date=None, planned_date=None
             )
 
 

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -44,7 +44,10 @@ class TestUpdateProjectServerRedesign:
                 review_interval_weeks=None,
                 last_reviewed=None,
                 next_review_date=None,
-                completed_by_children=None
+                completed_by_children=None,
+                due_date=None,
+                defer_date=None,
+                planned_date=None,
             )
 
             assert isinstance(result, str)


### PR DESCRIPTION
## Summary

- Add `due_date`, `defer_date`, `planned_date` to `create_project`, `update_project`, and `update_projects` (connector + server)
- Unskip `TestEffectiveDates` integration tests (both now pass)
- Follow-up issue #336 filed for adding these dates to `get_projects` return values

Closes #329

## Test plan

- [x] 782 unit tests pass
- [x] Client-server parity passes (22 tools)
- [x] Integration tests: TestEffectiveDates passes (was skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)