### PR TITLE
chore: run blind agent evals for project date interface changes

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-15 (eval consistency improvements #314)
-- **Model:** claude-opus-4-6
-- **Total Score:** 84/84 (100%)
+- **Date:** 2026-03-16 (project date interface changes #329, #336)
+- **Model:** claude-sonnet-4-6 (new scenarios), claude-opus-4-6 (prior scenarios)
+- **Total Score:** 90/90 (100%)
 - **Critical Failures:** 0 of 5
-- **Previous Score:** 82/84 (98%) — mutually exclusive tag configuration #303
+- **Previous Score:** 84/84 (100%) — eval consistency improvements #314
 
 ## Category Scores
 
@@ -29,6 +29,7 @@
 | Stalled Projects | 40 | 2 | 2 | 100% |
 | Catch Up Automatically | 41 | 2 | 2 | 100% |
 | Tag Exclusivity | 42 | 2 | 2 | 100% |
+| Project Dates | 43-45 | 6 | 6 | 100% |
 
 ## Per-Scenario Results
 
@@ -230,26 +231,44 @@
 - **Concept Understanding:** Excellent — warned about silent removal of 'High' when 'Low' is added if `childrenAreMutuallyExclusive=true`. Explained both scenarios (true vs false).
 - **Safety:** PASSED — correctly flagged the silent data modification risk
 
+### Scenario 43: Create Project with Due Date
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `create_project`
+- **Parameters:** Correct — `name="Q3 Report"`, `folder_path="Work"`, `due_date="2026-07-15"`, `defer_date="2026-06-01"`
+- **Concept Understanding:** Excellent — correctly mapped "completed by" to due_date and "available starting" to defer_date
+
+### Scenario 44: Clear Project Due Date
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `update_project`
+- **Parameters:** Correct — `project_id="proj-abc"`, `due_date=""`
+- **Concept Understanding:** Correctly used empty string to clear, not null/None
+
+### Scenario 45: Check Project Dates
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `get_projects`
+- **Parameters:** Correct — `project_id="proj-xyz"`
+- **Concept Understanding:** Excellent — identified dueDate, deferDate, plannedDate in response schema, noted they're returned by default
+
 ## Key Findings
 
-### Changes in This Run (#314 — Eval Consistency)
+### Changes in This Run (#329, #336 — Project Dates)
 
-**All 3 stochastic scenarios fixed — 84/84 (100%).**
+**Added 3 new scenarios (43-45) for project date operations — all PASS.**
 
-1. **Scenario 21 (Inherited Dates):** Added concrete example to docs ("if project has dueDate=April 15, task returns dueDate='2026-04-15T17:00:00'"). Multi-trial: 5/5 PASS.
+1. **Scenario 43 (Create Project with Due Date):** Agent correctly used `due_date` for deadline and `defer_date` for availability start.
+2. **Scenario 44 (Clear Project Due Date):** Agent correctly used empty string `""` to clear.
+3. **Scenario 45 (Check Project Dates):** Agent correctly identified date fields in `get_projects` response.
 
-2. **Scenario 31 (Set Recurrence with Method):** Added "when to use which" guidance to docs ("due_after_completion = deadline shifts; start_after_completion = availability window shifts"). Changed prompt from "next occurrence" to "next due date". Multi-trial: 5/5 PASS.
-
-3. **Scenario 33 (Drop a Tag):** Clarified behavioral consequences in docs ("On hold = tasks become unavailable; Dropped = tasks remain available"). Added "tasks should still be available and actionable" to prompt. Multi-trial: 5/5 PASS.
+Tool descriptions updated to include `due_date`, `defer_date`, `planned_date` on `create_project`, `update_project`, `update_projects`, and in `get_projects` return schema.
 
 ### Score Delta
 
-84/84 vs 82/84 previous. All 3 previously-stochastic scenarios now pass consistently at 5/5 multi-trial.
+90/90 vs 84/84 previous. 3 new scenarios added, all pass. Prior 42 scenarios unchanged (not re-run).
 
 ### Issues Found
 
-None. All 42 scenarios pass at 2/2. All 5 safety-critical scenarios pass.
+None. All 45 scenarios pass at 2/2. All 5 safety-critical scenarios pass.
 
 ## Conclusion
 
-Tool description improvements (concrete examples, behavioral consequences, "when to use which" guidance) and scenario prompt clarifications eliminated all stochastic failures. The eval suite achieves 100% (84/84) with 5/5 multi-trial consistency on previously-oscillating scenarios. Server docstrings synced with the improved tool descriptions.
+Project date parameters are well-understood by agents from tool descriptions alone. The create/update/read pattern matches the existing task date pattern, so agents apply the same knowledge. 90/90 (100%).

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -989,4 +989,85 @@ SCENARIOS = [
         ),
         "safety_critical": True,
     },
+    # ── Project Dates ──────────────────────────────────────────────────
+    {
+        "id": 43,
+        "category": "Project Dates",
+        "name": "Create Project with Due Date",
+        "prompt": (
+            "Create a project called 'Q3 Report' in the 'Work' folder that must be "
+            "completed by July 15, 2026. It should become available starting June 1, 2026."
+        ),
+        "expected": {
+            "tools": ["create_project"],
+            "key_params": {
+                "create_project": {
+                    "name": "Q3 Report",
+                    "folder_path": "Work",
+                    "due_date": "2026-07-15",
+                    "defer_date": "2026-06-01",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses create_project with due_date for deadline and defer_date for "
+            "availability start. Both in ISO format. "
+            "PARTIAL: Gets one date right but not the other, or uses update_project "
+            "as a second step instead of setting at creation. "
+            "FAIL: Tries to set dates on tasks instead of the project, or doesn't "
+            "use the date parameters at all."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 44,
+        "category": "Project Dates",
+        "name": "Clear Project Due Date",
+        "prompt": (
+            "Project 'proj-abc' currently has a due date. I want to remove the due date "
+            "so it's no longer deadline-driven."
+        ),
+        "expected": {
+            "tools": ["update_project"],
+            "key_params": {
+                "update_project": {
+                    "project_id": "proj-abc",
+                    "due_date": "",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses update_project with due_date=\"\" (empty string to clear). "
+            "PARTIAL: Uses update_project but sets due_date to null/None instead of "
+            "empty string. "
+            "FAIL: Tries to delete and recreate the project, or doesn't know how to "
+            "clear a date."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 45,
+        "category": "Project Dates",
+        "name": "Check Project Dates",
+        "prompt": (
+            "I want to see what dates are set on project 'proj-xyz' — specifically "
+            "its due date, defer date, and planned date."
+        ),
+        "expected": {
+            "tools": ["get_projects"],
+            "key_params": {
+                "get_projects": {
+                    "project_id": "proj-xyz",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses get_projects with project_id filter. Mentions that dueDate, "
+            "deferDate, plannedDate are returned in the project dict. "
+            "PARTIAL: Uses get_projects but doesn't mention the specific date fields "
+            "by name. "
+            "FAIL: Tries to use get_tasks or a non-existent get_project_dates tool."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -41,7 +41,7 @@ Retrieve ALL active projects with full details and hierarchy, optionally filtere
 - `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
 - `stalled_only: bool` (default: False) — Only return active projects with no available actions (implies include_task_health=True)
 
-**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, creationDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status. `stalled` (boolean) — true when availableCount=0 and tasks are not just deferred (project needs attention). With include_last_activity: lastActivityDate.
+**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, creationDate, dueDate, deferDate, plannedDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. `dueDate`, `deferDate`, `plannedDate` — project-level dates in ISO format (empty string if not set). Tasks inherit effective dates from their containing project. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status. `stalled` (boolean) — true when availableCount=0 and tasks are not just deferred (project needs attention). With include_last_activity: lastActivityDate.
 
 ---
 
@@ -57,6 +57,9 @@ Create a new project in OmniFocus.
 - `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
 - `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
 - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
+- `due_date: str` (optional) — Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00"). Tasks inherit this as their effective due date.
+- `defer_date: str` (optional) — Defer date in ISO 8601 format (when project becomes available)
+- `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on the project)
 
 **Returns:** Success message with project ID and configuration details
 
@@ -80,6 +83,9 @@ Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_
 - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
 - `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
 - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
+- `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
+- `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
+- `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
 
 **Returns:** Success message with project ID and updated fields, or error message
 
@@ -99,6 +105,9 @@ IMPORTANT: This function does NOT accept project_name or note parameters because
 - `review_interval_weeks: int` (optional) — Review interval in weeks
 - `last_reviewed: str` (optional) — Last review date ("now" or ISO format)
 - `next_review_date: str` (optional) — Explicit next review date in ISO format
+- `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
+- `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
+- `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
 
 **Returns:** Success message with updated and failed counts
 


### PR DESCRIPTION
## Summary

- Update `tool_descriptions.md` with project date params on 4 tools
- Add 3 new eval scenarios (43-45) for project date create/clear/read
- All 3 pass — total 90/90 (100%)

Closes #339

## Test plan

- [x] Scenario 43 (Create Project with Due Date): PASS
- [x] Scenario 44 (Clear Project Due Date): PASS
- [x] Scenario 45 (Check Project Dates): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)