### PR TITLE
chore: documentation review — fix stale numbers and add missing info

### DIFF
--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -18,13 +18,12 @@ The project has two types of tests:
 1. **Unit Tests** - Test individual components with mocked dependencies
 2. **Integration Tests (Real)** - Test with real OmniFocus (requires setup)
 
-**Total Test Coverage**: 544 tests (v0.7.2)
-- Unit tests (omnifocus_connector.py core) ✅ 406 passing
-- Unit tests (FastMCP server) ✅ Included above
+**Total Test Coverage**: 920 tests (v0.10.0)
+- Unit tests (connector, server, helpers) ✅ 782 passing
 - Integration tests (real OmniFocus) ⏭️ 138 skipped by default
 
-**Test Execution**: ~0.53 seconds for all mocked tests
-**Code Coverage**: 89% overall
+**Test Execution**: ~2.5 seconds for all unit tests
+**Code Coverage**: 91% overall
 
 ## Database Safety
 
@@ -550,16 +549,12 @@ Before running real integration tests:
 
 **If in doubt, run with safety checks enabled. The system will block operations if configuration is incorrect.**
 
-## Test Metrics
+## Test Metrics (v0.10.0)
 
-- **Total Tests**: 501 (v0.7.1 - increased from 483 in v0.7.0)
-- **Passing**: 385 (all unit tests with mocks)
-- **Skipped**: 116 (integration tests, require real OmniFocus setup)
-- **Coverage**: 86% (exceeds 85% threshold)
-- **Execution Time**: ~110s for all unit tests
-- **Test Reduction**: v0.6.0 API consolidation removed deprecated function tests
-  - Unit tests (FastMCP server): 33 tests
-  - Real OmniFocus tests: 3 tests (skipped by default)
-- **Code Coverage**: 89% overall
-  - `omnifocus_connector.py`: 97%
-  - `server_fastmcp.py`: 73%
+- **Total Tests**: 920 (782 unit + 138 integration)
+- **Passing**: 782 unit tests
+- **Skipped**: 237 (integration/benchmark tests skipped without test DB)
+- **Coverage**: 91% overall
+  - `omnifocus_connector.py`: 93%
+  - `server_fastmcp.py`: 83%
+- **Execution Time**: ~2.5s for all unit tests

--- a/docs/reference/APPLESCRIPT_GOTCHAS.md
+++ b/docs/reference/APPLESCRIPT_GOTCHAS.md
@@ -47,6 +47,10 @@ set note of t to styledNote  -- Accepted, but no formatting applied
 
 **⚠️ Test database crash:** On the headless test database, `evaluate javascript` crashes OmniFocus silently when accessing OmniFocus objects (e.g., `Task.byIdentifier()`). Simple string expressions work, but any object model access causes a crash with no crash report dialog. OmniFocus restarts with the production database open. This is likely because the test database opens as a headless document without proper window/UI context.
 
+**Mitigation (v0.9.2, #324):** The connector detects test mode (`self._test_mode`) and skips all `evaluate javascript` calls on headless test databases, defaulting to safe fallbacks (e.g., `childrenAreMutuallyExclusive=False`).
+
+**String escaping (v0.9.2, #318):** OmniAutomation JavaScript strings embedded in `evaluate javascript "..."` require dedicated escaping via `_escape_js_string()`, not the AppleScript escaper. The JS runs inside a single-quoted string inside an AppleScript double-quoted string — a double-context escaping problem.
+
 **✅ Production database:** With the production database and full UI context, `evaluate javascript` works correctly for both reads and writes:
 
 ```applescript

--- a/docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md
+++ b/docs/reference/OMNIFOCUS_AUTOMATION_NOTES.md
@@ -109,7 +109,9 @@ The `evaluate javascript` AppleScript command calls OmniAutomation from AppleScr
 - Tested twice with consistent crashes
 - Likely cause: test database opens without proper window/UI context that OmniAutomation requires
 
-**Implication:** Any connector feature using `evaluate javascript` cannot be covered by integration tests (which use the headless test database). Such features would require manual testing against the production database.
+**Mitigation (v0.9.2, #324):** The connector detects test mode (`self._test_mode`) and skips all `evaluate javascript` calls on headless test databases. Affected operations default to safe fallbacks (e.g., `childrenAreMutuallyExclusive=False` for `get_tags()`). OmniAutomation features are tested via `make test-prod` against the production database with sandbox isolation.
+
+**Implication:** OmniAutomation features require `make test-prod` (production database with sandbox folder). Standard integration tests (`make test-integration`) skip OmniAutomation calls automatically.
 
 ### Rich Text via OmniAutomation
 

--- a/docs/reference/PERFORMANCE_PROFILING.md
+++ b/docs/reference/PERFORMANCE_PROFILING.md
@@ -2,6 +2,8 @@
 
 ## v0.9.1 Benchmark (2026-03-15)
 
+> **Note:** These baselines remain representative for v0.10.0. The v0.10.0 changes (project dates in get_projects, complexity refactoring) add 3 batch property reads to get_projects — minimal overhead on an already-fast operation.
+
 Clean test database: 32 projects, ~202 tasks, 10 tags, 4 folders.
 Changes since last benchmark: +3 batch date reads (nextDueDate, nextDeferDate, nextPlannedDate), +catchUpAutomatically (from repetition rule), +OmniAutomation exclusivity call in get_tags, +sequential on tasks.
 


### PR DESCRIPTION
## Summary

- Fix TESTING.md: test counts (544→920), execution time (0.53s→2.5s), coverage (89%→91%)
- Add OmniAutomation test mode mitigation to APPLESCRIPT_GOTCHAS.md and OMNIFOCUS_AUTOMATION_NOTES.md
- Document `_escape_js_string()` in APPLESCRIPT_GOTCHAS.md
- Add v0.10.0 note to PERFORMANCE_PROFILING.md

CLAUDE.md, ARCHITECTURE.md, and README.md confirmed accurate — no changes needed.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)