### PR TITLE
feat: add reorder_project for positioning within folders

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,11 +21,11 @@ make test-prod             # Production DB tests (OmniAutomation, sandbox folder
 
 **Running the server:** `uv run python -m omnifocus_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (21 functions: 19 core + UI navigation)
+## API Surface (22 functions: 20 core + UI navigation)
 
 The API was consolidated from 40+ functions to 16 in October 2025. This is intentional — resist adding new functions.
 
-**Projects (5):** create_project, get_projects, update_project, update_projects, delete_projects
+**Projects (6):** create_project, get_projects, update_project, update_projects, delete_projects, reorder_project
 **Tasks (6):** create_task, get_tasks, update_task, update_tasks, delete_tasks, reorder_task
 **Folders (2):** create_folder, get_folders
 **Tags (4):** get_tags, create_tag, update_tag, delete_tags

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive, fast, reliable, and agent-friendly MCP server for OmniFocus on 
 
 ### Comprehensive
 
-22 tools covering projects, tasks, folders, tags, perspectives, and focus. Full CRUD on projects and tasks with batch operations, 14 filter types on task queries, and date management including recurrence (RRULE read/write).
+23 tools covering projects, tasks, folders, tags, perspectives, and focus. Full CRUD on projects and tasks with batch operations, 14 filter types on task queries, and date management including recurrence (RRULE read/write).
 
 ### Fast
 
@@ -33,14 +33,15 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 
 47-scenario blind eval suite with 100% pass rate — agents that have never seen OmniFocus can correctly use every tool from descriptions alone. Scenarios cover tool selection, parameter usage, multi-step workflows, date semantics, recurrence, tag behavior, task movement, text search, and safety-critical operations (drop vs delete, destructive action guardrails). Server instructions teach GTD concepts (task states, project types, sequential dependencies, review cycles) so agents make informed decisions, not just API calls.
 
-## Tools (22)
+## Tools (23)
 
-### Projects (5)
+### Projects (6)
 - **get_projects** — filter by ID, query, status; includes dates, review info, task health, stalled detection
 - **create_project** — with folder placement, dates, review interval, project type
 - **update_project** — all properties: name, note, status, dates, folder, review settings
 - **update_projects** — batch update (status, dates, folder, review settings)
 - **delete_projects** — single or batch
+- **reorder_project** — position relative to siblings within a folder (before/after)
 
 ### Tasks (6)
 - **get_tasks** — 14 filter types: by ID, project, parent, tags, status, dates, flags, text search, inbox

--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-16 (project date interface changes #329, #336)
-- **Model:** claude-sonnet-4-6 (new scenarios), claude-opus-4-6 (prior scenarios)
-- **Total Score:** 102/102 (100%)
+- **Date:** 2026-03-17 (reorder_project #357)
+- **Model:** claude-opus-4-6 (scenario 52), claude-sonnet-4-6 (scenarios 43-51), claude-opus-4-6 (prior scenarios)
+- **Total Score:** 104/104 (100%)
 - **Critical Failures:** 0 of 5
-- **Previous Score:** 84/84 (100%) — eval consistency improvements #314
+- **Previous Score:** 102/102 (100%) — project date interface changes #329, #336
 
 ## Category Scores
 
@@ -35,6 +35,7 @@
 | Tag Hierarchy | 48 | 2 | 2 | 100% |
 | Dropping | 49-50 | 4 | 4 | 100% |
 | Inherited Status | 51 | 2 | 2 | 100% |
+| Project Reordering | 52 | 2 | 2 | 100% |
 
 ## Per-Scenario Results
 
@@ -285,26 +286,28 @@
 - **Score:** 2/2 (PASS)
 - **Concept Understanding:** Excellent — correctly explained that completed=false is expected (task-level, not inherited), that available=false accounts for container status, and recommended available_only=True to exclude them.
 
+### Scenario 52: Reorder Project Within Folder
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `reorder_project`
+- **Parameters:** Correct — `project_id="proj-C"`, `before_project_id="proj-A"`
+- **Concept Understanding:** Excellent — also suggested `get_projects` first to resolve names to IDs
+
 ## Key Findings
 
-### Changes in This Run (#329, #336 — Project Dates)
+### Changes in This Run (#357 — reorder_project)
 
-**Added 3 new scenarios (43-45) for project date operations — all PASS.**
+**Added 1 new scenario (52) for project reordering — PASS.**
 
-1. **Scenario 43 (Create Project with Due Date):** Agent correctly used `due_date` for deadline and `defer_date` for availability start.
-2. **Scenario 44 (Clear Project Due Date):** Agent correctly used empty string `""` to clear.
-3. **Scenario 45 (Check Project Dates):** Agent correctly identified date fields in `get_projects` response.
-
-Tool descriptions updated to include `due_date`, `defer_date`, `planned_date` on `create_project`, `update_project`, `update_projects`, and in `get_projects` return schema.
+1. **Scenario 52 (Reorder Project Within Folder):** Agent correctly selected `reorder_project` with correct parameters.
 
 ### Score Delta
 
-102/102 vs 84/84 previous. 9 new scenarios added (43-51), all pass. Prior 42 scenarios unchanged (not re-run).
+104/104 vs 102/102 previous. 1 new scenario added (52), pass. Prior 51 scenarios unchanged (not re-run).
 
 ### Issues Found
 
-None. All 51 scenarios pass at 2/2. All 7 safety-critical scenarios pass.
+None. All 52 scenarios pass at 2/2. All 7 safety-critical scenarios pass.
 
 ## Conclusion
 
-All interface additions and behavioral documentation are well-understood by agents from tool descriptions alone. 102/102 (100%).
+All interface additions and behavioral documentation are well-understood by agents from tool descriptions alone. 104/104 (100%).

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -1220,4 +1220,29 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    # ── Project Reordering ────────────────────────────────────────────────
+    {
+        "id": 52,
+        "category": "Project Reordering",
+        "name": "Reorder Project Within Folder",
+        "prompt": (
+            "I have three projects in my Work folder: proj-A, proj-B, proj-C "
+            "(in that order). I want proj-C to appear first, before proj-A."
+        ),
+        "expected": {
+            "tools": ["reorder_project"],
+            "key_params": {
+                "reorder_project": {
+                    "project_id": "proj-C",
+                    "before_project_id": "proj-A",
+                }
+            },
+        },
+        "scoring_notes": (
+            "PASS: reorder_project(project_id='proj-C', before_project_id='proj-A'). "
+            "PARTIAL: Correct tool but swapped parameters or used after instead of before. "
+            "FAIL: Tries to use update_project or reorder_task instead."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -280,6 +280,21 @@ Use this to reorder tasks within a project or within a parent task's subtasks. I
 
 ---
 
+### reorder_project
+
+Move a project before or after another project to change its position within a folder.
+
+**Parameters:**
+- `project_id: str` (required) — The ID of the project to move
+- `before_project_id: str` (optional) — Move the project before this project (provide either this OR after_project_id)
+- `after_project_id: str` (optional) — Move the project after this project (provide either this OR before_project_id)
+
+**Returns:** Success message confirming the project was reordered
+
+**Note:** Both projects must be in the same folder. Exactly one of before_project_id or after_project_id must be provided.
+
+---
+
 ### get_folders
 
 Get all folders from OmniFocus with their hierarchy.

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -4712,6 +4712,66 @@ class OmniFocusConnector:
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error reordering task: {e.stderr}")
 
+    def reorder_project(self, project_id: str, before_project_id: Optional[str] = None, after_project_id: Optional[str] = None) -> bool:
+        """Reorder a project by moving it before or after another project.
+
+        Args:
+            project_id: The ID of the project to move
+            before_project_id: Move the project before this project (optional)
+            after_project_id: Move the project after this project (optional)
+
+        Note:
+            Exactly one of before_project_id or after_project_id must be provided.
+            Both projects must be in the same folder.
+
+        Returns:
+            True if operation was successful
+
+        Raises:
+            ValueError: If project_id is empty, or neither/both reference IDs provided
+            Exception: If projects not found, not in same folder, or operation fails
+        """
+        # SAFETY: Verify database before modifying
+        self._verify_database_safety('reorder_project')
+
+        if not project_id:
+            raise ValueError("project_id is required")
+
+        # Validate parameters
+        if before_project_id is None and after_project_id is None:
+            raise ValueError("Must provide either before_project_id or after_project_id")
+        if before_project_id is not None and after_project_id is not None:
+            raise ValueError("Cannot provide both before_project_id and after_project_id")
+
+        reference_project_id = before_project_id if before_project_id else after_project_id
+        position = "before" if before_project_id else "after"
+
+        script = f'''
+        tell application "OmniFocus"
+            tell front document
+                try
+                    set theProject to first flattened project whose id is "{self._escape_applescript_string(project_id)}"
+                    set refProject to first flattened project whose id is "{self._escape_applescript_string(reference_project_id)}"
+
+                    -- Move project to before/after reference project
+                    move theProject to {position} refProject
+                    return "true"
+                on error errMsg
+                    return "false: " & errMsg
+                end try
+            end tell
+        end tell
+        '''
+
+        try:
+            result = run_applescript(script)
+            if result.strip() == "true":
+                return True
+            else:
+                raise Exception(f"Error reordering project: {result}")
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"Error reordering project: {e.stderr}")
+
 
 
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -1336,6 +1336,38 @@ def reorder_task(task_id: str, before_task_id: Optional[str] = None, after_task_
         return f"Error reordering task: {str(e)}"
 
 
+@mcp.tool()
+def reorder_project(project_id: str, before_project_id: Optional[str] = None, after_project_id: Optional[str] = None) -> str:
+    """Move a project before or after another project to change its position within a folder.
+
+    Use this to reorder projects within a folder. Both projects must be in the same folder.
+
+    Args:
+        project_id: The ID of the project to move
+        before_project_id: Move the project before this project (provide either this OR after_project_id)
+        after_project_id: Move the project after this project (provide either this OR before_project_id)
+
+    Returns:
+        Success message confirming the project was reordered
+
+    Note:
+        Both projects must be in the same folder.
+        Exactly one of before_project_id or after_project_id must be provided.
+    """
+    client = get_client()
+    try:
+        success = client.reorder_project(project_id, before_project_id, after_project_id)
+        if success:
+            if before_project_id:
+                return f"Successfully moved project {project_id} before project {before_project_id}"
+            else:
+                return f"Successfully moved project {project_id} after project {after_project_id}"
+        else:
+            return f"Error: Failed to reorder project {project_id}"
+    except ValueError as e:
+        return f"Error: {str(e)}"
+    except Exception as e:
+        return f"Error reordering project: {str(e)}"
 
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -338,6 +338,30 @@ class TestWriteBenchmarks:
             times.append(time.perf_counter() - start)
         BenchmarkResult("delete_projects", times).report()
 
+    def test_reorder_project(self, client):
+        """reorder_project() — move project before another."""
+        # Create 2 projects to reorder between
+        p1 = client.create_project(f"__bench_reorder_a_{uuid.uuid4().hex[:8]}")
+        p2 = client.create_project(f"__bench_reorder_b_{uuid.uuid4().hex[:8]}")
+        try:
+            toggle = [True, False, True]
+            idx = 0
+
+            def reorder():
+                nonlocal idx
+                if toggle[idx % len(toggle)]:
+                    client.reorder_project(p1, before_project_id=p2)
+                else:
+                    client.reorder_project(p1, after_project_id=p2)
+                idx += 1
+
+            _benchmark("reorder_project", reorder, iterations=WRITE_ITERATIONS)
+        finally:
+            try:
+                client.delete_projects([p1, p2])
+            except Exception:
+                pass
+
     def test_update_tasks_batch(self, client, test_project):
         """update_tasks() — batch update (N sequential calls, pre-optimization baseline)."""
         batch_size = 5

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -2143,6 +2143,83 @@ class TestTaskReordering:
             client.delete_projects(project_id)
 
 
+class TestProjectReordering:
+    """Tests for reordering projects within a folder."""
+
+    def test_reorder_project_before_another(self, client):
+        """Test moving a project before another project in the same folder."""
+        # Create a folder and 3 projects in it
+        folder_name = f"test-reorder-{__import__('uuid').uuid4().hex[:8]}"
+        client.create_folder(folder_name)
+
+        try:
+            proj_a = client.create_project("test-ProjA", folder_path=folder_name)
+            proj_b = client.create_project("test-ProjB", folder_path=folder_name)
+            proj_c = client.create_project("test-ProjC", folder_path=folder_name)
+
+            # Get initial order (should be A, B, C by creation)
+            test_names = {"test-ProjA", "test-ProjB", "test-ProjC"}
+            projects = [p for p in client.get_projects() if p['name'] in test_names]
+            names_before = [p['name'] for p in projects]
+            assert names_before == ["test-ProjA", "test-ProjB", "test-ProjC"], \
+                f"Initial order should be A, B, C but got {names_before}"
+
+            # Move C before A
+            success = client.reorder_project(proj_c, before_project_id=proj_a)
+            assert success is True
+
+            # Verify new order: C, A, B
+            projects_after = [p for p in client.get_projects() if p['name'] in test_names]
+            names_after = [p['name'] for p in projects_after]
+            assert names_after == ["test-ProjC", "test-ProjA", "test-ProjB"], \
+                f"After moving C before A, expected [C, A, B] but got {names_after}"
+
+            print(f"\n✓ Reordered projects: {names_before} → {names_after}")
+        finally:
+            for pid in [proj_a, proj_b, proj_c]:
+                try:
+                    client.delete_projects(pid)
+                except Exception:
+                    pass
+
+    def test_reorder_project_after_another(self, client):
+        """Test moving a project after another project in the same folder."""
+        folder_name = f"test-reorder-{__import__('uuid').uuid4().hex[:8]}"
+        client.create_folder(folder_name)
+
+        try:
+            proj_a = client.create_project("test-ProjX", folder_path=folder_name)
+            proj_b = client.create_project("test-ProjY", folder_path=folder_name)
+            proj_c = client.create_project("test-ProjZ", folder_path=folder_name)
+
+            # Move A after C
+            success = client.reorder_project(proj_a, after_project_id=proj_c)
+            assert success is True
+
+            # Verify new order: B, C, A
+            test_names = {"test-ProjX", "test-ProjY", "test-ProjZ"}
+            projects_after = [p for p in client.get_projects() if p['name'] in test_names]
+            names_after = [p['name'] for p in projects_after]
+            assert names_after == ["test-ProjY", "test-ProjZ", "test-ProjX"], \
+                f"After moving A after C, expected [Y, Z, X] but got {names_after}"
+
+            print(f"\n✓ Reordered projects with 'after': {names_after}")
+        finally:
+            for pid in [proj_a, proj_b, proj_c]:
+                try:
+                    client.delete_projects(pid)
+                except Exception:
+                    pass
+
+    def test_reorder_project_requires_one_parameter(self, client):
+        """Test that reorder_project requires either before or after."""
+        with pytest.raises(ValueError, match="Must provide either"):
+            client.reorder_project("proj-1")
+        with pytest.raises(ValueError, match="Cannot provide both"):
+            client.reorder_project("proj-1", before_project_id="proj-2", after_project_id="proj-3")
+        print("\n✓ Parameter validation works correctly")
+
+
 class TestAvailabilityFields:
     """Tests for availability status fields.
 

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -1990,6 +1990,73 @@ class TestIdEscapingInMethods:
             assert 't\\"1' in script
             assert 't\\"2' in script
 
+    def test_reorder_project_escapes_ids(self, client):
+        """reorder_project() should escape project_id and reference_project_id."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            client.reorder_project(project_id='p"1', before_project_id='p"2')
+            script = mock_run.call_args[0][0]
+            assert 'p\\"1' in script
+            assert 'p\\"2' in script
+
+
+class TestReorderProject:
+    """Tests for reorder_project method."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_reorder_project_before(self, client):
+        """reorder_project() with before_project_id uses 'before' in AppleScript."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.reorder_project("proj-A", before_project_id="proj-B")
+            assert result is True
+            script = mock_run.call_args[0][0]
+            assert "before" in script
+            assert "proj-A" in script
+            assert "proj-B" in script
+
+    def test_reorder_project_after(self, client):
+        """reorder_project() with after_project_id uses 'after' in AppleScript."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.reorder_project("proj-A", after_project_id="proj-C")
+            assert result is True
+            script = mock_run.call_args[0][0]
+            assert "after" in script
+            assert "proj-A" in script
+            assert "proj-C" in script
+
+    def test_reorder_project_requires_one_param(self, client):
+        """reorder_project() raises ValueError when both or neither params provided."""
+        with pytest.raises(ValueError, match="Must provide either"):
+            client.reorder_project("proj-A")
+        with pytest.raises(ValueError, match="Cannot provide both"):
+            client.reorder_project("proj-A", before_project_id="proj-B", after_project_id="proj-C")
+
+    def test_reorder_project_requires_project_id(self, client):
+        """reorder_project() raises ValueError on empty project_id."""
+        with pytest.raises(ValueError, match="project_id"):
+            client.reorder_project("", before_project_id="proj-B")
+
+    def test_reorder_project_uses_flattened_project(self, client):
+        """reorder_project() uses 'flattened project' in AppleScript (not 'flattened task')."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            client.reorder_project("proj-A", before_project_id="proj-B")
+            script = mock_run.call_args[0][0]
+            assert "flattened project" in script
+            assert "flattened task" not in script
+
+    def test_reorder_project_raises_on_failure(self, client):
+        """reorder_project() raises Exception on AppleScript failure."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "false: Projects not in same folder"
+            with pytest.raises(Exception, match="reordering project"):
+                client.reorder_project("proj-A", before_project_id="proj-B")
+
 
 class TestGetTags:
     """Tests for get_tags method."""


### PR DESCRIPTION
## Summary

- Add `reorder_project(project_id, before_project_id/after_project_id)` — parallel to `reorder_task`
- Moves a project before or after another project within the same folder
- 23 tools total (was 22)

Closes #357

## Test plan

- [x] 785 unit tests pass — 7 new for reorder_project (before/after, validation, escaping, error handling)
- [x] 3 integration tests pass — before/after reordering in folder, parameter validation
- [x] Benchmark: 0.85s mean (consistent with other write ops)
- [x] Client-server parity: 23/23
- [x] Blind eval scenario 52: PASS — agent correctly selects `reorder_project` with right params (104/104, 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)