### PR TITLE
fix: replace dead undrop task code with clear ValueError

### DIFF
--- a/docs/reference/APPLESCRIPT_GOTCHAS.md
+++ b/docs/reference/APPLESCRIPT_GOTCHAS.md
@@ -437,13 +437,12 @@ set status of theProject to active status
 set status of theProject to on hold
 ```
 
-**Tasks — use `mark` commands and boolean properties:**
+**Tasks — dropping is one-way:**
 ```applescript
 -- Drop a task (command verb)
 mark dropped theTask
 
--- Reactivate a task (boolean property)
-set dropped of theTask to false
+-- ⚠️ UNDROPPING IS NOT POSSIBLE via any automation API
 ```
 
 **What does NOT work for projects:**
@@ -454,7 +453,20 @@ set dropped of theProject to false   -- "Can't set dropped of project to false"
 set status of theProject to dropped  -- AppleScript reads 'dropped' as boolean property
 ```
 
-**Discovered:** 2026-03-17, Issue #359
+**What does NOT work for undropping tasks:**
+```applescript
+-- AppleScript — all fail with "Can't set dropped of inbox task to false":
+set dropped of theTask to false
+tell theTask to set its dropped to false
+set properties of theTask to {dropped:false}
+```
+```javascript
+// OmniAutomation — property appears to set but doesn't persist:
+t.dropped = false;    // Returns false, but task remains dropped
+t.taskStatus = Task.Status.Available;  // Error: "taskStatus is read-only"
+```
+
+**Discovered:** 2026-03-17, Issues #359 (projects), #372 (tasks)
 
 ---
 

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -212,7 +212,7 @@ Consolidates: complete_task(), drop_task(), move_task(), set_parent_task(), set_
 
 **Examples:**
 - `update_task("task-123", completed=True)` — Mark complete
-- `update_task("task-123", status="dropped")` — Drop task
+- `update_task("task-123", status="dropped")` — Drop task (one-way — dropped tasks cannot be undropped via the API, only through the OmniFocus UI)
 - `update_task("task-123", project_id="proj-456")` — Move to project
 - `update_task("task-123", add_tags=["urgent"])` — Add tag
 - `update_task("task-123", recurrence="FREQ=WEEKLY;BYDAY=MO,WE,FR", repetition_method="fixed")` — Set weekly recurrence

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3234,7 +3234,12 @@ class OmniFocusConnector:
             if status == TaskStatus.DROPPED:
                 separate_commands.append("mark dropped theTask")
             elif status == TaskStatus.ACTIVE:
-                separate_commands.append("set dropped of theTask to false")
+                raise ValueError(
+                    "Cannot undrop a task via automation. "
+                    "OmniFocus does not support restoring dropped tasks "
+                    "through AppleScript or OmniAutomation. "
+                    "Use the OmniFocus UI to restore dropped tasks."
+                )
             updated_fields.append("status")
 
         # Hierarchy changes
@@ -3633,7 +3638,12 @@ class OmniFocusConnector:
             if status == TaskStatus.DROPPED:
                 per_task_commands.append("mark dropped theTask")
             elif status == TaskStatus.ACTIVE:
-                per_task_commands.append("set dropped of theTask to false")
+                raise ValueError(
+                    "Cannot undrop a task via automation. "
+                    "OmniFocus does not support restoring dropped tasks "
+                    "through AppleScript or OmniAutomation. "
+                    "Use the OmniFocus UI to restore dropped tasks."
+                )
 
         if project_id is not None:
             project_id_escaped = self._escape_applescript_string(project_id)

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -4,7 +4,7 @@ import subprocess
 from unittest import mock
 import pytest
 
-from omnifocus_mcp.omnifocus_connector import OmniFocusConnector, run_applescript
+from omnifocus_mcp.omnifocus_connector import OmniFocusConnector, TaskStatus, run_applescript
 
 
 class TestRunAppleScript:
@@ -1998,6 +1998,24 @@ class TestIdEscapingInMethods:
             script = mock_run.call_args[0][0]
             assert 'p\\"1' in script
             assert 'p\\"2' in script
+
+
+class TestUndropTaskLimitation:
+    """Tests that undropping tasks raises a clear error (#372)."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_update_task_status_active_raises_valueerror(self, client):
+        """update_task(status=ACTIVE) should raise ValueError — OmniFocus cannot undrop tasks."""
+        with pytest.raises(ValueError, match="Cannot undrop"):
+            client.update_task("task-001", status=TaskStatus.ACTIVE)
+
+    def test_update_tasks_status_active_raises_valueerror(self, client):
+        """update_tasks(status=ACTIVE) should raise ValueError — OmniFocus cannot undrop tasks."""
+        with pytest.raises(ValueError, match="Cannot undrop"):
+            client.update_tasks(["task-001"], status=TaskStatus.ACTIVE)
 
 
 class TestReorderProject:


### PR DESCRIPTION
## Summary

- `update_task(status=ACTIVE)` and `update_tasks(status=ACTIVE)` now raise `ValueError` with a clear message instead of generating AppleScript that silently fails
- Tested 5 approaches against real OmniFocus — none can undrop a task (AppleScript errors, OmniAutomation doesn't persist)
- Documented the limitation in APPLESCRIPT_GOTCHAS.md and tool descriptions

Closes #372

## Test plan

- [x] 787 unit tests pass (`make test`)
- [x] 2 new tests verify `ValueError` raised for both single and batch paths
- [x] No integration test needed (removing broken functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)