### PR TITLE
fix: set_focus cannot find nested folders (#381)

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -4990,7 +4990,7 @@ class OmniFocusConnector:
             if item_type == "project":
                 collection = f'flattened projects whose id is "{id_escaped}"'
             else:
-                collection = f'folders whose id is "{id_escaped}"'
+                collection = f'flattened folders whose id is "{id_escaped}"'
             lookup_lines.append(
                 f'set matchingItems{i} to {collection}\n'
                 f'                if (count of matchingItems{i}) = 0 then\n'

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -2503,6 +2503,35 @@ class TestUINavigation:
         # Clean up: clear focus
         client.set_focus()
 
+    def test_set_focus_nested_folder(self, client):
+        """Test setting focus on a nested (non-top-level) folder.
+
+        Regression test for #381: set_focus used 'folders whose id' which only
+        searched top-level folders. Must use 'flattened folders whose id' to
+        find nested folders.
+        """
+        import uuid
+        unique = uuid.uuid4().hex[:8]
+        parent_name = f"test-Parent-{unique}"
+        child_name = f"test-Child-{unique}"
+
+        # Create parent folder, then nested child folder
+        parent_id = client.create_folder(parent_name)
+        child_id = client.create_folder(child_name, parent_path=parent_name)
+
+        # Focus on the nested child folder — this was the bug
+        result = client.set_focus(item_ids=child_id, item_types="folder")
+
+        assert result["success"] is True
+        assert result["action"] == "set"
+        assert len(result["focused_items"]) == 1
+        assert result["focused_items"][0]["id"] == child_id
+        assert result["focused_items"][0]["type"] == "folder"
+        print(f"\n✓ Set focus on nested folder: {child_name} (inside {parent_name})")
+
+        # Clean up: clear focus
+        client.set_focus()
+
     def test_set_focus_multiple_items(self, client, test_project, test_folder):
         """Test setting focus on multiple items (project + folder)."""
         result = client.set_focus(

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -1398,7 +1398,7 @@ class TestSetFocus:
             assert 'set focus to' in call_args
 
     def test_set_focus_single_folder(self, client):
-        """Test focusing on a single folder."""
+        """Test focusing on a single folder uses flattened folders for nested support."""
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = "SUCCESS"
             result = client.set_focus(item_ids="folder-456", item_types="folder")
@@ -1406,7 +1406,7 @@ class TestSetFocus:
             assert result["action"] == "set"
             assert result["focused_items"] == [{"id": "folder-456", "type": "folder"}]
             call_args = mock_run.call_args[0][0]
-            assert 'folders whose id' in call_args
+            assert 'flattened folders whose id' in call_args
 
     def test_set_focus_multiple_items(self, client):
         """Test focusing on multiple items."""


### PR DESCRIPTION
## Summary

- `set_focus` used `folders whose id` which only searched top-level folders
- Changed to `flattened folders whose id` to find folders at any depth
- Matches the pattern already used by `update_folder` and `flattened projects`

## Root Cause

One-word bug on connector line 4993: `folders` should be `flattened folders`. The project lookup on the previous line already used `flattened projects` correctly.

## Test plan

- [x] Unit test updated: verifies generated AppleScript contains `flattened folders whose id`
- [x] New integration test: creates a nested folder and focuses on it (regression test)
- [x] All existing focus integration tests pass (10/10)
- [x] Full unit suite: 793 passed, 0 failed

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)