### PR TITLE
feat: expose inInbox boolean on tasks (#378)

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -2679,6 +2679,7 @@ class OmniFocusConnector:
                 set subtaskCounts to number of tasks of ft
                 set effComps to effectively completed of ft
                 set effDrops to effectively dropped of ft
+                set taskInInbox to in inbox of ft
 
                 -- Nested batch reads (project, parent, tags)
                 set projIds to id of (containing project of ft)
@@ -2876,6 +2877,7 @@ class OmniFocusConnector:
                             "\\"sequential\\": " & (item i of taskSeqs as text) & ", " & ¬
                             "\\"position\\": " & (i as text) & ", " & ¬
                             "\\"numberOfAvailableTasks\\": " & (numAvailableTasks as text) & ", " & ¬
+                            "\\"inInbox\\": " & (item i of taskInInbox as text) & ", " & ¬
                             "\\"available\\": " & (taskAvailable as text) & ¬
                             "}}"
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -91,6 +91,8 @@ def _format_task(task: dict, truncate_notes: bool = True) -> str:
         result += f"Next: Yes\n"
     if task.get('flagged'):
         result += f"Flagged: Yes\n"
+    if task.get('inInbox'):
+        result += f"In Inbox: Yes\n"
     if task.get('dueDate'):
         result += f"Due: {task['dueDate']}\n"
     if task.get('deferDate'):
@@ -572,8 +574,8 @@ def get_tasks(
 
     Returns:
         Each task includes: id, name, projectName, completed, dropped, blocked, available, next,
-        flagged, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note (truncated unless
-        include_full_notes=True), parentTaskId, subtaskCount, sequential, nextDueDate,
+        flagged, inInbox, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note (truncated
+        unless include_full_notes=True), parentTaskId, subtaskCount, sequential, nextDueDate,
         nextDeferDate, nextPlannedDate, catchUpAutomatically.
         `available` is true when the task is not completed, not dropped, not blocked, and not
         deferred (defer date is in the past or unset). Equivalent to OmniFocus's native Available

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -279,6 +279,21 @@ class TestRealOmniFocusIntegration:
 
         print(f"\n✓ Found {len(inbox_tasks)} inbox tasks")
 
+    def test_inbox_task_has_in_inbox_true(self, client, test_task_inbox):
+        """Test that inbox tasks return inInbox=True and project tasks return inInbox=False."""
+        # Inbox task should have inInbox=True
+        inbox_tasks = client.get_tasks(task_id=test_task_inbox)
+        assert len(inbox_tasks) == 1
+        assert inbox_tasks[0]['inInbox'] is True
+        print(f"\n✓ Inbox task has inInbox=True")
+
+    def test_project_task_has_in_inbox_false(self, client, test_task):
+        """Test that project tasks return inInbox=False."""
+        tasks = client.get_tasks(task_id=test_task)
+        assert len(tasks) == 1
+        assert tasks[0]['inInbox'] is False
+        print(f"\n✓ Project task has inInbox=False")
+
     def test_get_tags_real(self, client):
         """Test getting tags from real OmniFocus."""
         tags = client.get_tags()

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -430,6 +430,38 @@ class TestGetTasks:
             # Verify the AppleScript includes blocked in JSON output
             assert '\\"blocked\\"' in call_args
 
+    def test_get_tasks_includes_in_inbox_field(self, client):
+        """Test that get_tasks includes the inInbox field in the AppleScript and response."""
+        tasks_json = json.dumps([
+            {
+                "id": "task-001",
+                "name": "Inbox Task",
+                "note": "",
+                "completed": False,
+                "flagged": False,
+                "dropped": False,
+                "blocked": False,
+                "inInbox": True,
+                "projectId": "",
+                "projectName": "",
+                "dueDate": "",
+                "deferDate": "",
+                "completionDate": "",
+                "tags": ""
+            }
+        ])
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = tasks_json
+            tasks = client.get_tasks()
+            # Verify inInbox field is in returned data
+            assert 'inInbox' in tasks[0]
+            assert tasks[0]['inInbox'] is True
+            # Verify the AppleScript retrieves the in inbox field
+            call_args = mock_run.call_args[0][0]
+            assert "in inbox of ft" in call_args
+            # Verify the AppleScript includes inInbox in JSON output
+            assert '\\"inInbox\\"' in call_args
+
     def test_get_tasks_blocked_only(self, client):
         """Test filtering for only blocked tasks."""
         blocked_tasks_json = json.dumps([

--- a/tests/test_server_formatting.py
+++ b/tests/test_server_formatting.py
@@ -168,6 +168,32 @@ class TestTaskFormatting:
         assert "Completed Date:" not in result
         assert "Dropped Date:" not in result
 
+    def test_format_task_displays_in_inbox(self):
+        """Test that _format_task shows In Inbox when inInbox is true."""
+        task = {
+            "id": "task-inbox",
+            "name": "Inbox Task",
+            "projectName": "N/A",
+            "completed": False,
+            "inInbox": True,
+        }
+
+        result = _format_task(task)
+        assert "In Inbox: Yes" in result
+
+    def test_format_task_omits_in_inbox_when_false(self):
+        """Test that _format_task omits In Inbox when inInbox is false."""
+        task = {
+            "id": "task-proj",
+            "name": "Project Task",
+            "projectName": "My Project",
+            "completed": False,
+            "inInbox": False,
+        }
+
+        result = _format_task(task)
+        assert "In Inbox" not in result
+
 
 class TestProjectFormatting:
     """Test project formatting function."""


### PR DESCRIPTION
## Summary

- Added `in inbox` to batch property read in the connector (one Apple Event, ~17ms)
- `inInbox` boolean now included in task JSON output
- `_format_task` displays "In Inbox: Yes" when true
- Updated `get_tasks` docstring to document the new field

## Test plan

- [x] 2 formatter tests: displays when true, omits when false
- [x] 1 unit test: verifies AppleScript contains `in inbox of ft` and `inInbox` in JSON
- [x] 2 integration tests: inbox task has `inInbox=True`, project task has `inInbox=False`
- [x] Full unit suite: 796 passed, 0 failed

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)