### PR TITLE
feat: expose completed_by_children on tasks (#379)

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1954,7 +1954,8 @@ class OmniFocusConnector:
         flagged: bool = False,
         tags: Optional[list[str]] = None,
         estimated_minutes: Optional[int] = None,
-        sequential: bool = False
+        sequential: bool = False,
+        completed_by_children: bool = False
     ) -> str:
         """Create a new task in OmniFocus (NEW API - consolidates add_task and create_inbox_task).
 
@@ -2010,6 +2011,8 @@ class OmniFocusConnector:
             properties.append('flagged:true')
         if sequential:
             properties.append('sequential:true')
+        if completed_by_children:
+            properties.append('completed by children:true')
         if estimated_minutes is not None:
             properties.append(f'estimated minutes:{estimated_minutes}')
 
@@ -2663,6 +2666,7 @@ class OmniFocusConnector:
                 set taskBlocks to blocked of ft
                 set taskNexts to next of ft
                 set taskSeqs to sequential of ft
+                set taskCompByChildren to completed by children of ft
                 set dueDates to effective due date of ft
                 set deferDates to effective defer date of ft
                 set plannedDates to effective planned date of ft
@@ -2875,6 +2879,7 @@ class OmniFocusConnector:
                             "\\"parentTaskId\\": \\"" & parentTaskId & "\\", " & ¬
                             "\\"subtaskCount\\": " & (taskSubtaskCount as text) & ", " & ¬
                             "\\"sequential\\": " & (item i of taskSeqs as text) & ", " & ¬
+                            "\\"completedByChildren\\": " & ((item i of taskCompByChildren) as text) & ", " & ¬
                             "\\"position\\": " & (i as text) & ", " & ¬
                             "\\"numberOfAvailableTasks\\": " & (numAvailableTasks as text) & ", " & ¬
                             "\\"inInbox\\": " & (item i of taskInInbox as text) & ", " & ¬
@@ -3099,6 +3104,7 @@ class OmniFocusConnector:
         planned_date: Optional[str],
         flagged: Optional[bool],
         sequential: Optional[bool],
+        completed_by_children: Optional[bool],
         estimated_minutes: Optional[int],
         completed: Optional[bool],
         recurrence: Optional[str],
@@ -3137,8 +3143,9 @@ class OmniFocusConnector:
 
         all_params = [
             task_name, project_id, parent_task_id, note, due_date, defer_date,
-            planned_date, flagged, sequential, tags, add_tags, remove_tags,
-            estimated_minutes, completed, status, recurrence, repetition_method
+            planned_date, flagged, sequential, completed_by_children, tags,
+            add_tags, remove_tags, estimated_minutes, completed, status,
+            recurrence, repetition_method
         ]
         if all(v is None for v in all_params):
             raise ValueError("At least one field must be provided to update")
@@ -3165,6 +3172,7 @@ class OmniFocusConnector:
         remove_tags: Optional[list[str]],
         recurrence: Optional[str],
         repetition_method: Optional[str],
+        completed_by_children: Optional[bool],
     ) -> tuple[list[str], list[str], list[str], bool]:
         """Build AppleScript property and command strings for update_task.
 
@@ -3192,6 +3200,10 @@ class OmniFocusConnector:
         if sequential is not None:
             properties.append(f'sequential:{str(sequential).lower()}')
             updated_fields.append("sequential")
+
+        if completed_by_children is not None:
+            properties.append(f'completed by children:{str(completed_by_children).lower()}')
+            updated_fields.append("completed_by_children")
 
         # Dates (clear vs set)
         if due_date is not None:
@@ -3371,6 +3383,7 @@ class OmniFocusConnector:
         planned_date: Optional[str] = None,
         flagged: Optional[bool] = None,
         sequential: Optional[bool] = None,
+        completed_by_children: Optional[bool] = None,
         tags: Optional[list[str]] = None,
         add_tags: Optional[list[str]] = None,
         remove_tags: Optional[list[str]] = None,
@@ -3439,6 +3452,7 @@ class OmniFocusConnector:
             status=status, repetition_method=repetition_method,
             note=note, due_date=due_date, defer_date=defer_date,
             planned_date=planned_date, flagged=flagged, sequential=sequential,
+            completed_by_children=completed_by_children,
             estimated_minutes=estimated_minutes, completed=completed,
             recurrence=recurrence,
         )
@@ -3453,6 +3467,7 @@ class OmniFocusConnector:
                 parent_task_id=parent_task_id, tags=tags, add_tags=add_tags,
                 remove_tags=remove_tags, recurrence=recurrence,
                 repetition_method=repetition_method,
+                completed_by_children=completed_by_children,
             )
 
         # Build and execute AppleScript

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -137,6 +137,8 @@ def _format_task(task: dict, truncate_notes: bool = True) -> str:
         result += f"Subtask Count: {task['subtaskCount']}\n"
     if 'sequential' in task:
         result += f"Sequential: {task['sequential']}\n"
+    if 'completedByChildren' in task:
+        result += f"Completed By Children: {task['completedByChildren']}\n"
     if 'position' in task:
         result += f"Position: {task['position']}\n"
 
@@ -651,7 +653,8 @@ def create_task(
     flagged: bool = False,
     tags: Optional[str] = None,
     estimated_minutes: Optional[int] = None,
-    sequential: bool = False
+    sequential: bool = False,
+    completed_by_children: bool = False
 ) -> str:
     """Create a new task in OmniFocus (NEW API - consolidates add_task and create_inbox_task).
 
@@ -714,7 +717,8 @@ def create_task(
             flagged=flagged,
             tags=tags_list,
             estimated_minutes=estimated_minutes,
-            sequential=sequential
+            sequential=sequential,
+            completed_by_children=completed_by_children
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -764,6 +768,7 @@ def update_task(
     recurrence: Optional[str] = None,
     repetition_method: Optional[str] = None,
     sequential: Optional[bool] = None,
+    completed_by_children: Optional[bool] = None,
     # Legacy parameters (backward compatibility)
     name: Optional[str] = None
 ) -> str:
@@ -852,6 +857,7 @@ def update_task(
             recurrence=recurrence,
             repetition_method=repetition_method,
             sequential=sequential,
+            completed_by_children=completed_by_children,
             name=name  # Pass to client for its own backward compat handling
         )
     except ValueError as e:

--- a/tests/test_api_redesign_create.py
+++ b/tests/test_api_redesign_create.py
@@ -240,6 +240,35 @@ class TestCreateTaskRedesign:
             assert "sequential:true" not in script
 
     # ========================================================================
+    # Completed By Children (#379)
+    # ========================================================================
+
+    def test_create_task_completed_by_children(self, client):
+        """#379: create_task() supports completed_by_children parameter."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "task-379"
+            result = client.create_task(
+                task_name="Auto-Complete Group",
+                project_id="proj-123",
+                completed_by_children=True
+            )
+            assert result == "task-379"
+            script = mock_run.call_args[0][0]
+            assert "completed by children:true" in script
+
+    def test_create_task_completed_by_children_default(self, client):
+        """#379: create_task() defaults to completed_by_children=False."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "task-379b"
+            result = client.create_task(
+                task_name="Normal Task",
+                project_id="proj-123"
+            )
+            assert result == "task-379b"
+            script = mock_run.call_args[0][0]
+            assert "completed by children:true" not in script
+
+    # ========================================================================
     # Required Parameters
     # ========================================================================
 

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -294,6 +294,45 @@ class TestRealOmniFocusIntegration:
         assert tasks[0]['inInbox'] is False
         print(f"\n✓ Project task has inInbox=False")
 
+    def test_completed_by_children_create_and_read(self, client, test_project):
+        """Test that completed_by_children can be set on create and read back."""
+        task_id = client.create_task(
+            "test-CompByChildren",
+            project_id=test_project,
+            completed_by_children=True
+        )
+        tasks = client.get_tasks(task_id=task_id)
+        assert len(tasks) == 1
+        assert tasks[0]['completedByChildren'] is True
+        print(f"\n✓ Created task with completedByChildren=True, read back correctly")
+
+        # Clean up
+        client.delete_tasks(task_id)
+
+    def test_completed_by_children_update(self, client, test_project):
+        """Test that completed_by_children can be toggled via update."""
+        task_id = client.create_task(
+            "test-CompByChildrenUpdate",
+            project_id=test_project,
+        )
+        # Default should be false
+        tasks = client.get_tasks(task_id=task_id)
+        assert tasks[0]['completedByChildren'] is False
+
+        # Toggle on
+        client.update_task(task_id, completed_by_children=True)
+        tasks = client.get_tasks(task_id=task_id)
+        assert tasks[0]['completedByChildren'] is True
+
+        # Toggle off
+        client.update_task(task_id, completed_by_children=False)
+        tasks = client.get_tasks(task_id=task_id)
+        assert tasks[0]['completedByChildren'] is False
+        print(f"\n✓ Toggled completedByChildren on/off via update_task")
+
+        # Clean up
+        client.delete_tasks(task_id)
+
     def test_get_tags_real(self, client):
         """Test getting tags from real OmniFocus."""
         tags = client.get_tags()

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -462,6 +462,38 @@ class TestGetTasks:
             # Verify the AppleScript includes inInbox in JSON output
             assert '\\"inInbox\\"' in call_args
 
+    def test_get_tasks_includes_completed_by_children_field(self, client):
+        """Test that get_tasks includes completedByChildren in AppleScript and response."""
+        tasks_json = json.dumps([
+            {
+                "id": "task-001",
+                "name": "Action Group",
+                "note": "",
+                "completed": False,
+                "flagged": False,
+                "dropped": False,
+                "blocked": False,
+                "completedByChildren": True,
+                "projectId": "proj-001",
+                "projectName": "Test Project",
+                "dueDate": "",
+                "deferDate": "",
+                "completionDate": "",
+                "tags": ""
+            }
+        ])
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = tasks_json
+            tasks = client.get_tasks()
+            # Verify field is in returned data
+            assert 'completedByChildren' in tasks[0]
+            assert tasks[0]['completedByChildren'] is True
+            # Verify AppleScript reads the property
+            call_args = mock_run.call_args[0][0]
+            assert "completed by children of ft" in call_args
+            # Verify JSON output includes the field
+            assert '\\"completedByChildren\\"' in call_args
+
     def test_get_tasks_blocked_only(self, client):
         """Test filtering for only blocked tasks."""
         blocked_tasks_json = json.dumps([
@@ -1070,6 +1102,24 @@ class TestUpdateTask:
             assert result["success"] is True
             call_args = mock_run.call_args[0][0]
             assert "sequential:false" in call_args
+
+    def test_update_task_completed_by_children_true(self, client):
+        """#379: update_task() sets completed_by_children on action groups."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_task("task-001", completed_by_children=True)
+            assert result["success"] is True
+            call_args = mock_run.call_args[0][0]
+            assert "completed by children:true" in call_args
+
+    def test_update_task_completed_by_children_false(self, client):
+        """#379: update_task() can set completed_by_children to false."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = "true"
+            result = client.update_task("task-001", completed_by_children=False)
+            assert result["success"] is True
+            call_args = mock_run.call_args[0][0]
+            assert "completed by children:false" in call_args
 
     def test_update_task_multiple_fields(self, client):
         """Test updating multiple task fields at once (LEGACY TEST - updated for new API return format)."""

--- a/tests/test_server_formatting.py
+++ b/tests/test_server_formatting.py
@@ -194,6 +194,31 @@ class TestTaskFormatting:
         result = _format_task(task)
         assert "In Inbox" not in result
 
+    def test_format_task_displays_completed_by_children(self):
+        """Test that _format_task shows Completed By Children when present."""
+        task = {
+            "id": "task-group",
+            "name": "Action Group",
+            "projectName": "Project",
+            "completed": False,
+            "completedByChildren": True,
+        }
+
+        result = _format_task(task)
+        assert "Completed By Children: True" in result
+
+    def test_format_task_omits_completed_by_children_when_absent(self):
+        """Test that _format_task omits Completed By Children when not in dict."""
+        task = {
+            "id": "task-plain",
+            "name": "Plain Task",
+            "projectName": "Project",
+            "completed": False,
+        }
+
+        result = _format_task(task)
+        assert "Completed By Children" not in result
+
 
 class TestProjectFormatting:
     """Test project formatting function."""

--- a/tests/test_server_redesign_create.py
+++ b/tests/test_server_redesign_create.py
@@ -50,7 +50,8 @@ class TestCreateTaskServerRedesign:
                 flagged=False,
                 tags=None,
                 estimated_minutes=None,
-                sequential=False
+                sequential=False,
+                completed_by_children=False
             )
 
             # Verify response mentions task ID
@@ -140,7 +141,8 @@ class TestCreateTaskServerRedesign:
                 flagged=True,
                 tags=["urgent", "work"],  # Parsed to list by server
                 estimated_minutes=60,
-                sequential=False
+                sequential=False,
+                completed_by_children=False
             )
             assert "task-005" in result
 

--- a/tests/test_update_task_helpers.py
+++ b/tests/test_update_task_helpers.py
@@ -26,6 +26,7 @@ class TestValidateUpdateTaskParams:
             status=None, repetition_method=None,
             note=None, due_date=None, defer_date=None,
             planned_date=None, flagged=None, sequential=None,
+            completed_by_children=None,
             estimated_minutes=None, completed=None, recurrence=None,
         )
         defaults.update(overrides)
@@ -80,6 +81,7 @@ class TestBuildUpdateTaskCommands:
     def _call(self, client, **overrides):
         defaults = dict(
             task_name=None, note=None, flagged=None, sequential=None,
+            completed_by_children=None,
             due_date=None, defer_date=None, planned_date=None,
             estimated_minutes=None, completed=None, status=None,
             project_id=None, parent_task_id=None,


### PR DESCRIPTION
## Summary

Mirrors the existing project `completed_by_children` implementation for tasks (action groups):

- **get_tasks**: Batch reads `completed by children` property, includes `completedByChildren` boolean in response
- **create_task**: New `completed_by_children` parameter (default: False)
- **update_task**: New `completed_by_children` parameter to toggle the property
- **_format_task**: Displays "Completed By Children: true/false" in output

When `completedByChildren` is true on an action group, completing all subtasks auto-completes the parent task.

## Test plan

- [x] 2 formatter tests (display when present, omit when absent)
- [x] 1 unit test: AppleScript batch read contains `completed by children of ft`
- [x] 2 create_task tests (set true, default false)
- [x] 2 update_task tests (set true, set false)
- [x] 2 integration tests (create+read, update toggle on/off)
- [x] 3 existing tests updated for new parameter
- [x] Full unit suite: 803 passed, 0 failed

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)