### PR TITLE
eval: add blind eval scenarios for mutually exclusive tag creation (#303)

### DIFF
--- a/evals/agent_tool_usability/results/scored_results.md
+++ b/evals/agent_tool_usability/results/scored_results.md
@@ -2,11 +2,11 @@
 
 ## Summary
 
-- **Date:** 2026-03-17 (reorder_project #357)
-- **Model:** claude-opus-4-6 (scenario 52), claude-sonnet-4-6 (scenarios 43-51), claude-opus-4-6 (prior scenarios)
-- **Total Score:** 104/104 (100%)
+- **Date:** 2026-03-18 (tag exclusivity creation #303)
+- **Model:** claude-sonnet-4-6 (scenarios 53-54), claude-opus-4-6 (scenario 52), claude-sonnet-4-6 (scenarios 43-51), claude-opus-4-6 (prior scenarios)
+- **Total Score:** 108/108 (100%)
 - **Critical Failures:** 0 of 5
-- **Previous Score:** 102/102 (100%) — project date interface changes #329, #336
+- **Previous Score:** 104/104 (100%) — reorder_project #357
 
 ## Category Scores
 
@@ -28,7 +28,7 @@
 | Next Occurrence Dates | 39 | 2 | 2 | 100% |
 | Stalled Projects | 40 | 2 | 2 | 100% |
 | Catch Up Automatically | 41 | 2 | 2 | 100% |
-| Tag Exclusivity | 42 | 2 | 2 | 100% |
+| Tag Exclusivity | 42, 53-54 | 6 | 6 | 100% |
 | Project Dates | 43-45 | 6 | 6 | 100% |
 | Task Movement | 46 | 2 | 2 | 100% |
 | Text Search | 47 | 2 | 2 | 100% |
@@ -300,14 +300,26 @@
 
 1. **Scenario 52 (Reorder Project Within Folder):** Agent correctly selected `reorder_project` with correct parameters.
 
+### Scenario 53: Create Mutually Exclusive Tag Group
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `create_tag` x4 (parent + 3 children)
+- **Parameters:** Correct — parent with `children_are_mutually_exclusive=True`, children with `parent_tag="Priority"`
+- **Concept Understanding:** Excellent — correctly set exclusivity on parent (not children), noted order dependency (parent must exist before children), explained the automatic removal behavior
+
+### Scenario 54: Toggle Exclusivity on Existing Tag
+- **Score:** 2/2 (PASS)
+- **Tool Selection:** Correct — `update_tag` (single call)
+- **Parameters:** Correct — `tag_id="tag-energy-001"`, `children_are_mutually_exclusive=True`
+- **Concept Understanding:** Excellent — correctly identified that exclusivity is a property of the parent tag, no other calls needed
+
 ### Score Delta
 
-104/104 vs 102/102 previous. 1 new scenario added (52), pass. Prior 51 scenarios unchanged (not re-run).
+108/108 vs 104/104 previous. 2 new scenarios added (53-54), both pass. Prior 52 scenarios unchanged (not re-run).
 
 ### Issues Found
 
-None. All 52 scenarios pass at 2/2. All 7 safety-critical scenarios pass.
+None. All 54 scenarios pass at 2/2. All 5 safety-critical scenarios pass.
 
 ## Conclusion
 
-All interface additions and behavioral documentation are well-understood by agents from tool descriptions alone. 104/104 (100%).
+All interface additions and behavioral documentation are well-understood by agents from tool descriptions alone. 108/108 (100%).

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -1245,4 +1245,62 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    # ── Tag Exclusivity: Creation & Configuration ─────────────────────────
+    {
+        "id": 53,
+        "category": "Tag Exclusivity",
+        "name": "Create Mutually Exclusive Tag Group",
+        "prompt": (
+            "I want to set up a 'Priority' tag group where each task can only have one "
+            "priority level at a time. If a task has 'High' and I assign 'Low', "
+            "the 'High' tag should be automatically removed. Create the Priority "
+            "parent tag with child tags High, Medium, and Low."
+        ),
+        "expected": {
+            "tools": ["create_tag", "create_tag", "create_tag", "create_tag"],
+            "key_params": {
+                "create_tag (parent)": {
+                    "name": "Priority",
+                    "children_are_mutually_exclusive": True,
+                },
+                "create_tag (children)": {
+                    "parent_tag": "Priority",
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Creates parent tag with children_are_mutually_exclusive=True, "
+            "then creates child tags with parent_tag='Priority'. "
+            "PARTIAL: Correct structure but forgets children_are_mutually_exclusive=True. "
+            "FAIL: Doesn't use children_are_mutually_exclusive, or creates flat tags "
+            "without parent-child relationship."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 54,
+        "category": "Tag Exclusivity",
+        "name": "Toggle Exclusivity on Existing Tag",
+        "prompt": (
+            "I have an existing 'Energy' tag (ID: tag-energy-001) with child tags "
+            "'High Energy', 'Medium Energy', 'Low Energy'. Right now a task can have "
+            "multiple energy levels, but I want to change it so only one energy level "
+            "can be assigned at a time. How do I fix this?"
+        ),
+        "expected": {
+            "tools": ["update_tag"],
+            "key_params": {
+                "update_tag": {
+                    "tag_id": "tag-energy-001",
+                    "children_are_mutually_exclusive": True,
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: update_tag(tag_id='tag-energy-001', children_are_mutually_exclusive=True). "
+            "PARTIAL: Correct tool and concept but wrong parameter name or missing tag_id. "
+            "FAIL: Suggests recreating tags, or doesn't know about children_are_mutually_exclusive."
+        ),
+        "safety_critical": False,
+    },
 ]


### PR DESCRIPTION
## Summary

The mutually exclusive tag feature was implemented in v0.9.1 (PR #313), but the blind evals only tested whether agents understand the *consequences* of exclusivity (scenario 42). These new scenarios verify agents can *create and configure* exclusive tag groups.

- **Scenario 53**: Create a mutually exclusive tag group — agent must use `create_tag(children_are_mutually_exclusive=True)` for the parent, then create children with `parent_tag`
- **Scenario 54**: Toggle exclusivity on an existing tag — agent must use `update_tag(tag_id, children_are_mutually_exclusive=True)`

Both pass 2/2 with claude-sonnet-4-6. Total eval score: 108/108 (100%).

## Test plan

- [x] Scenario 53: PASS — correct tool selection, correct parameters, correct reasoning
- [x] Scenario 54: PASS — single update_tag call with correct parameters
- [x] Results updated in scored_results.md

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)