### PR TITLE
chore: add release review phases and fix stale docs (#388)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.1 | **Tests:** 787 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 91%
+**Version:** v0.10.1 | **Tests:** 803 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 90%
 
 ## Commands
 
@@ -21,13 +21,13 @@ make test-prod             # Production DB tests (OmniAutomation, sandbox folder
 
 **Running the server:** `uv run python -m omnifocus_mcp.server_fastmcp` or via Claude Desktop config.
 
-## API Surface (22 functions: 20 core + UI navigation)
+## API Surface (23 functions: 21 core + UI navigation)
 
 The API was consolidated from 40+ functions to 16 in October 2025. This is intentional — resist adding new functions.
 
 **Projects (6):** create_project, get_projects, update_project, update_projects, delete_projects, reorder_project
 **Tasks (6):** create_task, get_tasks, update_task, update_tasks, delete_tasks, reorder_task
-**Folders (2):** create_folder, get_folders
+**Folders (3):** create_folder, get_folders, update_folder
 **Tags (4):** get_tags, create_tag, update_tag, delete_tags
 **Perspectives (2):** get_perspectives, switch_perspective
 **Navigation (2):** set_focus, get_focus
@@ -67,8 +67,8 @@ The API was consolidated from 40+ functions to 16 in October 2025. This is inten
 **What is NOT a bottleneck:** Loop iteration itself (0.17s for 381 tasks), string concatenation (<100ms for 400 items), JSON building.
 
 **Current baselines** (35 projects, ~202 tasks, 10 tags, 4 folders — see profiling doc for full table):
-- `get_tasks(flagged)`: 0.66s (14) | `get_tasks(inbox)`: 0.64s (10) | `get_tasks(query)`: 1.07s (~37)
-- `get_tasks()` (all): 2.20s (~202) | `get_projects()`: 0.57s (35) | Write ops: 0.9s
+- `get_tasks(flagged)`: 0.66s (14) | `get_tasks(inbox)`: 0.64s (10) | `get_tasks(query)`: 1.07s (37)
+- `get_tasks()` (all): 2.20s (202) | `get_projects()`: 0.57s (35) | Write ops: 0.9s
 
 Default timeout: 60s, max: 300s (configurable).
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -78,7 +78,65 @@ Use the Edit tool for each file. Be precise about what to change.
 
 4. Insert the new entry at the top of CHANGELOG.md (after the header, before the previous version).
 
-## Phase 6: Validation
+## Phase 6: Test Coverage Review
+
+1. Run coverage report:
+   ```bash
+   pytest --cov=omnifocus_mcp --cov-report=term-missing tests/ -q
+   ```
+
+2. Compare overall coverage against the `fail_under` threshold in `pyproject.toml`. If coverage dropped below the threshold, **stop and report** — new code likely needs tests.
+
+3. Get the cumulative diff to identify changed files:
+   ```bash
+   git diff v{previous}..HEAD --stat
+   ```
+
+4. Audit changed `src/` files for adequate test coverage:
+   - New code paths without unit tests
+   - Modified AppleScript strings without integration tests (per CLAUDE.md hard rule: "If you wrote or modified an AppleScript string, integration tests must cover it before merge")
+   - New parameters or return fields without test assertions
+
+5. Flag any gaps. If coverage dropped or critical paths are untested, stop and fix before proceeding.
+
+## Phase 7: Code Review
+
+1. Get the cumulative diff since the last release:
+   ```bash
+   git diff v{previous}..HEAD
+   ```
+
+2. Launch the `superpowers:code-reviewer` agent to review the full diff. Provide context about the release scope (PRs included, features added/changed).
+
+3. The reviewer will report issues by severity:
+   - **Critical** — security issues, data loss risks, correctness bugs → blocks the release
+   - **Important** — code quality, missed edge cases → fix or document in PR
+   - **Minor** — style, naming, suggestions → note in PR description
+
+4. If Critical issues are found, **stop and fix** before proceeding.
+
+5. Include Important/Minor findings in the release PR description under a "Code Review Notes" section.
+
+## Phase 8: Documentation Review
+
+1. Enumerate documentation to check:
+   - `README.md` — feature descriptions, installation, usage examples
+   - `.claude/CLAUDE.md` — version, test counts, coverage %, API surface count, performance baselines
+   - `CHANGELOG.md` — new entry completeness
+   - `docs/**` — architecture, profiling, AppleScript gotchas, automation notes
+   - Tool docstrings in `src/omnifocus_mcp/server_fastmcp.py`
+   - Skill files in `.claude/skills/`
+
+2. Verify accuracy against changes in this release:
+   - Stale version numbers (should still be old version — Phase 4 bumped them)
+   - Outdated performance baselines if perf-related changes were made
+   - Missing feature documentation for new capabilities
+   - Incorrect cross-references between docs
+   - Test count / coverage stats in CLAUDE.md header
+
+3. Flag discrepancies and fix them on the release branch before proceeding.
+
+## Phase 9: Validation
 
 Run ALL validation checks. Stop on any failure.
 
@@ -114,7 +172,7 @@ Run ALL validation checks. Stop on any failure.
 
 If any check fails, fix the issue and re-run. Do not proceed with failures.
 
-## Phase 7: Commit, Push, and PR
+## Phase 10: Commit, Push, and PR
 
 1. **Commit** the version bump and changelog:
    ```bash
@@ -131,10 +189,11 @@ If any check fails, fix the issue and re-run. Do not proceed with failures.
    ```bash
    gh pr create --title "release: vX.Y.Z" --body "..."
    ```
+   Include any Code Review Notes from Phase 7 in the PR body.
 
 4. Tell the user the PR is ready for review. Do NOT merge it automatically.
 
-## Phase 8: Merge, Tag, and Push Tag
+## Phase 11: Merge, Tag, and Push Tag
 
 After the user approves the PR:
 
@@ -164,7 +223,7 @@ After the user approves the PR:
    git describe --tags --abbrev=0  # Should return vX.Y.Z
    ```
 
-## Phase 9: Close Milestone
+## Phase 12: Close Milestone
 
 After the tag is pushed, close the milestone:
 

--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ A comprehensive, fast, reliable, and agent-friendly MCP server for OmniFocus on 
 
 Sub-second reads on filtered queries, even with hundreds of tasks in the database.
 
-| Operation | Time | Database |
-|-----------|------|----------|
-| Get flagged tasks | 0.66s | ~200 tasks |
-| Get overdue tasks | 0.69s | ~200 tasks |
-| Get next tasks | 0.66s | ~200 tasks |
-| Get inbox tasks | 0.64s | ~200 tasks |
-| Search tasks by keyword | 1.07s | ~200 tasks |
-| Get all tasks (unfiltered) | 2.20s | ~200 tasks |
-| Get all projects | 0.57s | 35 projects |
-| Create or update a task | 0.9s | — |
+| Operation | Time | Items | Database |
+|-----------|------|-------|----------|
+| Get flagged tasks | 0.66s | 14 | 202 tasks |
+| Get overdue tasks | 0.69s | 8 | 202 tasks |
+| Get next tasks | 0.66s | 27 | 202 tasks |
+| Get inbox tasks | 0.64s | 10 | 202 tasks |
+| Search tasks by keyword | 1.07s | 37 | 202 tasks |
+| Get all tasks (unfiltered) | 2.20s | 202 | 202 tasks |
+| Get all projects | 0.57s | 35 | 35 projects |
+| Create or update a task | 0.9s | — | — |
 
 Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFILING.md)
 
 ### Reliable
 
-91% code coverage from 787 unit tests. 144 integration tests run against real OmniFocus covering task, project, and tag lifecycles, filtering, hierarchy, dates, recurrence, and review workflows.
+90% code coverage from 803 unit tests. 144 integration tests run against real OmniFocus covering task, project, and tag lifecycles, filtering, hierarchy, dates, recurrence, and review workflows.
 
 ### Agent-Friendly
 
-52-scenario blind eval suite with 100% pass rate — agents that have never seen OmniFocus can correctly use every tool from descriptions alone. Scenarios cover tool selection, parameter usage, multi-step workflows, date semantics, recurrence, tag behavior, task movement, text search, and safety-critical operations (drop vs delete, destructive action guardrails). Server instructions teach GTD concepts (task states, project types, sequential dependencies, review cycles) so agents make informed decisions, not just API calls.
+54-scenario blind eval suite with frontier models scoring 100% and popular open-weight models averaging over 90% ([full results](evals/agent_tool_usability/results/scored_results.md)). Agents that have never seen OmniFocus can correctly use every tool from descriptions alone. Scenarios cover tool selection, parameter usage, multi-step workflows, date semantics, recurrence, tag behavior, task movement, text search, and safety-critical operations (drop vs delete, destructive action guardrails). Server instructions teach GTD concepts (task states, project types, sequential dependencies, review cycles) so agents make informed decisions, not just API calls.
 
 ## Tools (23)
 
@@ -51,9 +51,10 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 - **delete_tasks** — single or batch
 - **reorder_task** — position relative to siblings (before/after)
 
-### Folders (2)
+### Folders (3)
 - **get_folders** — hierarchy with paths
 - **create_folder** — with optional parent
+- **update_folder** — rename or move to different parent
 
 ### Tags (4)
 - **get_tags** — with status and mutual exclusivity info

--- a/docs/reference/PERFORMANCE_PROFILING.md
+++ b/docs/reference/PERFORMANCE_PROFILING.md
@@ -9,12 +9,12 @@ Change: eliminated per-task execution paths — all `get_tasks()` source types n
 
 | Operation | v0.10.1 | Items | v0.9.1 | Delta |
 |-----------|---------|-------|--------|-------|
-| `get_tasks()` (unfiltered) | **2.20s** | ~202 | 2.09s | ~same |
+| `get_tasks()` (unfiltered) | **2.20s** | 202 | 2.09s | ~same |
 | `get_tasks(flagged_only)` | **0.66s** | 14 | 0.60s | ~same |
 | `get_tasks(overdue)` | **0.69s** | 8 | 0.63s | ~same |
 | `get_tasks(next_only)` | **0.66s** | 27 | 0.63s | ~same |
-| `get_tasks(query='bench')` | **1.07s** | ~37 | 0.78s | +37% |
-| `get_tasks(available_only)` | **2.33s** | ~180 | 2.13s | ~same |
+| `get_tasks(query='bench')` | **1.07s** | 37 | 0.78s | +37% |
+| `get_tasks(available_only)` | **2.33s** | 180 | 2.13s | ~same |
 | `get_tasks(inbox_only)` | **0.64s** | 10 | 9.13s | **14x faster** |
 | `get_tasks(project_id)` | **0.63s** | varies | 0.69s | ~same |
 | `get_tasks(tag_filter)` | **0.81s** | varies | 0.77s | ~same |
@@ -22,7 +22,7 @@ Change: eliminated per-task execution paths — all `get_tasks()` source types n
 
 **Key improvement:** `inbox_only` went from 9.13s (per-task) to 0.64s (batch) — **14x faster**. All source types (inbox, project, subtask, single task, unfiltered) now use the same batch path.
 
-The query regression (+37%) is likely variance — the v0.9.1 number was 0.78s vs the dedicated query test showing 1.07s at ~37 items.
+The query regression (+37%) is likely variance — the v0.9.1 number was 0.78s vs the dedicated query test showing 1.07s at 37 items.
 
 ---
 
@@ -35,12 +35,12 @@ Changes since last benchmark: +3 batch date reads (nextDueDate, nextDeferDate, n
 
 | Operation | v0.9.1 | Items | Previous (batch) | Delta |
 |-----------|--------|-------|-----------------|-------|
-| `get_tasks()` (unfiltered) | **2.09s** | ~202 | 5.70s | 2.7x faster |
+| `get_tasks()` (unfiltered) | **2.09s** | 202 | 5.70s | 2.7x faster |
 | `get_tasks(flagged_only)` | **0.60s** | 14 | 0.82s | 27% faster |
 | `get_tasks(overdue)` | **0.63s** | 8 | 0.60s | ~same |
 | `get_tasks(next_only)` | **0.63s** | 27 | 1.10s | 43% faster |
-| `get_tasks(query='bench')` | **0.78s** | ~37 | 2.00s | 2.6x faster |
-| `get_tasks(available_only)` | **2.13s** | ~180 | 5.79s | 2.7x faster |
+| `get_tasks(query='bench')` | **0.78s** | 37 | 2.00s | 2.6x faster |
+| `get_tasks(available_only)` | **2.13s** | 180 | 5.79s | 2.7x faster |
 | `get_tasks(inbox_only)` | **9.13s** | 10 | 4.20s | 2.2x slower |
 | `get_tasks(project_id)` | **0.69s** | varies | 0.20s | 3.5x slower |
 | `get_tasks(tag_filter)` | **0.77s** | varies | — | new |
@@ -65,7 +65,7 @@ Changes since last benchmark: +3 batch date reads (nextDueDate, nextDeferDate, n
 |-----------|--------|-------|----------|-------|
 | `get_folders()` | **0.62s** | 4 | 0.60s | ~same |
 | `get_tags()` | **2.00s** | 10 | 0.96s | +1.04s (OmniAutomation exclusivity call) |
-| `get_perspectives()` | **0.96s** | ~24 | 0.21s | +0.75s (variance) |
+| `get_perspectives()` | **0.96s** | 24 | 0.21s | +0.75s (variance) |
 
 **`get_tags()` regression explained:** The +1.04s overhead is from the new OmniAutomation `evaluate javascript` call that reads `childrenAreMutuallyExclusive` for all tags (#303). This is a single additional round-trip, not per-tag — acceptable for the safety benefit.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,12 @@ markers = [
     "prod: production database integration tests",
 ]
 
+[tool.coverage.run]
+source = ["omnifocus_mcp"]
+
+[tool.coverage.report]
+fail_under = 90
+
 [tool.pyright]
 include = ["src", "tests"]
 exclude = ["**/node_modules", "**/__pycache__", ".venv", "venv"]


### PR DESCRIPTION
## Summary
- Add three review phases to the release skill (test coverage, code review, documentation review) between changelog generation and validation
- Add `fail_under = 90` coverage threshold to `pyproject.toml`
- Fix stale numbers across docs: coverage 91→90%, unit tests 787→803, API surface 22→23 (missing `update_folder`), eval scenarios 52→54
- Remove tilde approximations from benchmark item counts
- Update README Agent-Friendly section to reflect multi-model eval results

Closes #388

## Test plan
- [x] `make test` passes (803 passed, 247 skipped)
- [x] `pytest --cov` works with new pyproject.toml config
- [ ] Read through updated SKILL.md to verify phase ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)