### PR TITLE
fix: normalize create_task tags parameter to native list

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -185,7 +185,7 @@ SCENARIOS = [
     {
         "id": 9,
         "category": "Parameter Usage",
-        "name": "Tags JSON String vs Native List",
+        "name": "Tags on Create vs Add Tags on Update",
         "prompt": (
             "Create a task 'Review PR' with tags Computer and Work, "
             "then add the tag 'Urgent' to existing task task-555."
@@ -193,14 +193,14 @@ SCENARIOS = [
         "expected": {
             "tools": ["create_task", "update_task"],
             "key_params": {
-                "create_task": {"task_name": "Review PR", "tags": '["Computer", "Work"]'},
+                "create_task": {"task_name": "Review PR", "tags": ["Computer", "Work"]},
                 "update_task": {"task_id": "task-555", "add_tags": ["Urgent"]},
             },
         },
         "scoring_notes": (
-            "PASS: create_task tags as JSON string, update_task add_tags as native list. "
-            "PARTIAL: Correct tools but wrong tag format (e.g., native list for create_task). "
-            "FAIL: Uses 'tags' instead of 'add_tags' on update (would replace all tags)."
+            "PASS: create_task tags as native list, update_task add_tags as native list. "
+            "PARTIAL: Correct tools but uses 'tags' instead of 'add_tags' on update. "
+            "FAIL: Wrong tools or missing tag assignment entirely."
         ),
         "safety_critical": False,
     },
@@ -308,14 +308,14 @@ SCENARIOS = [
                 },
                 "create_task": {
                     "project_id": "<returned_id>",
-                    "tags": '["Web Team"]',
+                    "tags": ["Web Team"],
                 },
             },
         },
         "scoring_notes": (
-            "PASS: create_project with all params, 6x create_task in order with tags as JSON string, "
+            "PASS: create_project with all params, 6x create_task in order with tags as native list, "
             "uses returned project ID. "
-            "PARTIAL: Missing some params (e.g., no review_interval_weeks) or wrong tag format. "
+            "PARTIAL: Missing some params (e.g., no review_interval_weeks). "
             "FAIL: Parallel project or wrong task order."
         ),
         "safety_critical": False,

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -180,7 +180,7 @@ Create a new task in OmniFocus.
 - `defer_date: str` (optional) — Defer date in ISO 8601 format (when task becomes available — hidden until then)
 - `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on this task — a scheduling signal with no availability or overdue constraints, unlike defer/due dates)
 - `flagged: bool` (default: False) — Flag marks a task as a priority — typically 'I want to work on this today.' Flagged tasks can be queried with get_tasks(flagged_only=True).
-- `tags: str` (optional) — JSON array string of tag names (e.g., '["Computer", "Work"]'). Tags must already exist. Note: this takes a JSON string; update_task takes a native list instead.
+- `tags: list[str]` (optional) — List of tag names (e.g., ["Computer", "Work"]). Tags must already exist.
 - `estimated_minutes: int` (optional) — Estimated time in minutes
 - `sequential: bool` (default: False) — If True, subtasks of this task (action group) must be completed in order — only the first available subtask is actionable.
 
@@ -206,7 +206,7 @@ Consolidates: complete_task(), drop_task(), move_task(), set_parent_task(), set_
 - `defer_date: str` (optional) — New defer date in ISO 8601 format (when task becomes available), or empty string to clear. Omitting means no change.
 - `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on this task), or empty string to clear. A scheduling signal with no availability or overdue constraints.
 - `flagged: bool` (optional) — Flag marks a task as a priority — typically 'I want to work on this today.' Pass True to flag, False to unflag.
-- `tags: list[str]` (optional) — Full replacement — set exact tag list as a native list. Conflicts with add_tags/remove_tags. Note: unlike create_task, this takes a list not a JSON string.
+- `tags: list[str]` (optional) — Full replacement — set exact tag list. Conflicts with add_tags/remove_tags.
 - `add_tags: list[str]` (optional) — Add these tags incrementally. Conflicts with tags.
 - `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
 - `estimated_minutes: int` (optional) — Estimated time in minutes

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """FastMCP Server for OmniFocus integration."""
-import json
 import os
 from typing import Optional, Union
 
@@ -659,7 +658,7 @@ def create_task(
     defer_date: Optional[str] = None,
     planned_date: Optional[str] = None,
     flagged: bool = False,
-    tags: Optional[str] = None,
+    tags: Optional[list[str]] = None,
     estimated_minutes: Optional[int] = None,
     sequential: bool = False,
     completed_by_children: bool = False
@@ -685,8 +684,7 @@ def create_task(
             purely a scheduling signal with no behavioral constraints.
         flagged: Flag marks a task as a priority — typically 'I want to work on this today.'
             Flagged tasks can be queried with get_tasks(flagged_only=True). (default: False)
-        tags: Optional JSON array string of tag names (e.g., '["Computer", "Work"]'). Tags must
-            already exist. Note: this takes a JSON string; update_task takes a native list instead.
+        tags: Optional list of tag names (e.g., ["Computer", "Work"]). Tags must already exist.
         estimated_minutes: Estimated time in minutes to complete the task
         sequential: If True, subtasks of this task (action group) must be completed in order —
             only the first available subtask is actionable. (default: False = parallel)
@@ -705,15 +703,9 @@ def create_task(
     """
     client = get_client()
 
-    # Parse tags parameter - convert JSON string to list
-    tags_list = None
-    if tags:
-        try:
-            tags_list = json.loads(tags)
-            if not isinstance(tags_list, list):
-                return f"Error: tags must be a JSON array string, e.g., '[\"Computer\"]'"
-        except json.JSONDecodeError as e:
-            return f"Error: Invalid JSON for tags parameter: {e}"
+    # Validate tags parameter
+    if tags is not None and not isinstance(tags, list):
+        return f"Error: tags must be a list of tag names, e.g., [\"Computer\", \"Work\"]. Got {type(tags).__name__}."
 
     try:
         task_id = client.create_task(
@@ -725,7 +717,7 @@ def create_task(
             defer_date=defer_date,
             planned_date=planned_date,
             flagged=flagged,
-            tags=tags_list,
+            tags=tags,
             estimated_minutes=estimated_minutes,
             sequential=sequential,
             completed_by_children=completed_by_children
@@ -749,8 +741,8 @@ def create_task(
         result += f"\nDefer date: {defer_date}"
     if flagged:
         result += "\nFlagged: Yes"
-    if tags_list:
-        result += f"\nTags: {', '.join(tags_list)}"
+    if tags:
+        result += f"\nTags: {', '.join(tags)}"
     if estimated_minutes:
         result += f"\nEstimated time: {estimated_minutes} minutes"
 
@@ -810,7 +802,7 @@ def update_task(
         flagged: Flag marks a task as a priority — typically 'I want to work on this today.'
             Pass True to flag, False to unflag. (optional)
         tags: Full replacement — set exact tag list as a native list (optional, conflicts
-            with add_tags/remove_tags). Note: unlike create_task, this takes a list not a JSON string.
+            with add_tags/remove_tags).
         add_tags: Add these tags incrementally (optional, conflicts with tags)
         remove_tags: Remove these tags (optional, conflicts with tags)
         estimated_minutes: Estimated time in minutes (optional)

--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -92,12 +92,11 @@ class TestCreateTaskE2E:
         print(f"\n✓ E2E create_task in inbox: {result}")
 
     def test_create_task_with_tags_e2e(self, test_project, ensure_test_tags):
-        """E2E: Create task with tags via MCP tool (tests JSON string conversion)."""
-        # MCP tools receive tags as JSON string
+        """E2E: Create task with tags via MCP tool."""
         result = create_task(
             task_name="E2E Test Task - Tags",
             project_id=test_project,
-            tags='["work"]'  # JSON string, not Python list!
+            tags=["work"]
         )
 
         assert isinstance(result, str)

--- a/tests/test_server_redesign_create.py
+++ b/tests/test_server_redesign_create.py
@@ -126,7 +126,7 @@ class TestCreateTaskServerRedesign:
                 due_date="2025-12-31",
                 defer_date="2025-12-01",
                 flagged=True,
-                tags='["urgent", "work"]',  # JSON string, not list
+                tags=["urgent", "work"],  # Native list, same as update_task
                 estimated_minutes=60
             )
 
@@ -145,6 +145,21 @@ class TestCreateTaskServerRedesign:
                 completed_by_children=False
             )
             assert "task-005" in result
+
+    def test_create_task_tags_rejects_json_string(self):
+        """Tags parameter must be a native list, not a JSON string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_task.return_value = "task-006"
+            mock_get_client.return_value = mock_client
+
+            result = create_task(
+                task_name="Task with JSON string tags",
+                tags='["urgent", "work"]'  # Old format — should error
+            )
+
+            assert "error" in result.lower()
+            mock_client.create_task.assert_not_called()
 
     # ========================================================================
     # Error Handling


### PR DESCRIPTION
## Summary

Closes #403

- Changed `create_task` `tags` parameter from `Optional[str]` (JSON string) to `Optional[list[str]]` (native list), matching `update_task`'s interface
- Removed JSON parsing logic and unused `import json` from server_fastmcp.py
- Added validation that rejects non-list types with a clear error message
- Updated eval tool descriptions, scenarios, and E2E tests to reflect the new format
- Blind evals pass on Claude Sonnet 4 (scenarios 9 and 14)

## Test plan

- [x] Unit tests updated and passing (804 passed)
- [x] Client-server parity check passing
- [x] Blind agent evals passing (Claude Sonnet 4, scenarios 9 + 14)
- [ ] E2E test with real OmniFocus (`make test-e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)