### PR TITLE
fix: return clear error when modifying tags on dropped tasks

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3513,11 +3513,21 @@ class OmniFocusConnector:
                     "error": f"Unexpected result: {result}"
                 }
         except subprocess.CalledProcessError as e:
+            error_msg = f"AppleScript error: {e.stderr}"
+            # Type coercion error on tag operations typically means the task
+            # is dropped or in a state that prevents modification
+            if "(-1700)" in (e.stderr or "") and "type tag" in (e.stderr or ""):
+                error_msg = (
+                    f"Cannot modify tags on task '{task_id}': the task may be "
+                    f"dropped or completed. Change the task's status to active "
+                    f"first, or create a new task. "
+                    f"(Original error: {e.stderr})"
+                )
             return {
                 "success": False,
                 "task_id": task_id,
                 "updated_fields": [],
-                "error": f"AppleScript error: {e.stderr}"
+                "error": error_msg
             }
         except Exception as e:
             return {

--- a/tests/test_api_redesign_update.py
+++ b/tests/test_api_redesign_update.py
@@ -346,6 +346,24 @@ class TestUpdateTaskRedesign:
             assert "error" in result
             assert isinstance(result["error"], str)
 
+    def test_update_task_tag_on_dropped_task_gives_clear_error(self, client):
+        """Modifying tags on a dropped task returns a clear error, not opaque -1700."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, 'osascript',
+                stderr='Can\'t make {tag id "aSKRkTUXWBe" of default document} into type tag. (-1700)'
+            )
+
+            result = client.update_task(
+                task_id="task-dropped",
+                add_tags=["SomeTag"]
+            )
+
+            assert result["success"] is False
+            assert "dropped" in result["error"].lower() or "cannot modify" in result["error"].lower()
+            # Should still include enough context to debug
+            assert "-1700" in result["error"]
+
 
 class TestUpdateTasksRedesign:
     """Tests for update_tasks() batch function (NEW API).


### PR DESCRIPTION
## Summary

Closes #404

- Pattern-matches AppleScript error `-1700` (type coercion on tag operations) and returns a clear message: "Cannot modify tags on task: the task may be dropped or completed. Change the task's status to active first, or create a new task."
- Preserves the original error for debugging
- No extra round-trip — catches the error after the fact rather than pre-fetching task status

## Test plan

- [x] Unit test for improved error message (805 passed)
- [ ] Integration test: drop a task, try to modify tags, verify clear error (`make test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)