### PR TITLE
fix: remove redundant Python-side query filter in get_tasks

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -2220,14 +2220,14 @@ class OmniFocusConnector:
         modified_after: Optional[str],
         modified_before: Optional[str],
         recurring_only: Optional[bool],
-        query: Optional[str],
         sort_by: Optional[str],
         sort_order: str,
     ) -> list[dict[str, Any]]:
         """Post-process tasks returned from AppleScript: normalize and filter.
 
-        Handles repetition normalization, Python-side tag/date/recurring/query
-        filtering, and sorting.
+        Handles repetition normalization, Python-side tag/date/recurring
+        filtering, and sorting. Query filtering is handled upstream by
+        AppleScript (whose clause or batch filter check).
         """
         # Normalize repetitionMethod values
         for task in tasks:
@@ -2273,15 +2273,6 @@ class OmniFocusConnector:
                 tasks = [t for t in tasks if t.get('isRecurring', False)]
             else:
                 tasks = [t for t in tasks if not t.get('isRecurring', False)]
-
-        # Apply query filter if provided
-        if query:
-            query_lower = query.lower()
-            tasks = [
-                t for t in tasks
-                if query_lower in t.get('name', '').lower()
-                or query_lower in t.get('note', '').lower()
-            ]
 
         # Apply sorting if requested
         if sort_by:
@@ -3073,7 +3064,6 @@ class OmniFocusConnector:
                     modified_after=modified_after,
                     modified_before=modified_before,
                     recurring_only=recurring_only,
-                    query=query,
                     sort_by=sort_by,
                     sort_order=sort_order,
                 )

--- a/tests/test_get_tasks_helpers.py
+++ b/tests/test_get_tasks_helpers.py
@@ -422,7 +422,7 @@ class TestPostProcessTasks:
             tag_filter=None, tag_filter_mode="and", tag_prefiltered_ids=None,
             created_after=None, created_before=None,
             modified_after=None, modified_before=None,
-            recurring_only=None, query=None,
+            recurring_only=None,
             sort_by=None, sort_order="asc",
         )
         defaults.update(overrides)
@@ -491,22 +491,6 @@ class TestPostProcessTasks:
         result = client._post_process_tasks(tasks, **self._default_params(recurring_only=False))
         assert len(result) == 1
         assert result[0]['id'] == 't2'
-
-    def test_query_filter_case_insensitive(self, client):
-        tasks = [
-            self._sample_task(id="t1", name="Buy groceries"),
-            self._sample_task(id="t2", name="Read book"),
-        ]
-        result = client._post_process_tasks(tasks, **self._default_params(query="BUY"))
-        assert len(result) == 1
-        assert result[0]['id'] == 't1'
-
-    def test_query_filter_matches_note(self, client):
-        tasks = [
-            self._sample_task(id="t1", name="Task", note="important meeting"),
-        ]
-        result = client._post_process_tasks(tasks, **self._default_params(query="meeting"))
-        assert len(result) == 1
 
     def test_sort_by_name(self, client):
         tasks = [


### PR DESCRIPTION
## Summary

Closes #398

- Removed redundant Python-side query filter from `_post_process_tasks()` that re-checked name/note containment after both upstream paths already handled it:
  - `whose` clause path: `whose (name contains "X" or note contains "X")`  
  - Batch fallback path: AppleScript-side filter when `whose_active` is False
- Removed `query` parameter from `_post_process_tasks()` signature and call site
- Removed 2 unit tests that tested the now-removed redundant filter

## Test plan

- [x] Unit tests passing (803 passed, -2 removed query filter tests)
- [ ] Integration tests with query parameter (`make test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)