### PR TITLE
feat: support dropping entire recurring task series

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -1303,4 +1303,31 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    {
+        "id": 53,
+        "category": "Recurrence",
+        "name": "Drop Entire Recurring Series",
+        "prompt": (
+            "I have a recurring task task-weekly-123 that repeats every week. "
+            "I don't want it anymore — drop the whole series so no more occurrences spawn."
+        ),
+        "expected": {
+            "tools": ["update_task"],
+            "key_params": {
+                "update_task": {
+                    "task_id": "task-weekly-123",
+                    "recurrence": "",
+                    "status": "dropped",
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: update_task(task_id='task-weekly-123', recurrence='', status='dropped') "
+            "in a single call — removes recurrence and drops in one operation. "
+            "PARTIAL: Two separate calls (remove recurrence then drop) — works but suboptimal. "
+            "FAIL: Only drops without removing recurrence (spawns next occurrence), "
+            "or says it can't be done."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -211,7 +211,7 @@ Consolidates: complete_task(), drop_task(), move_task(), set_parent_task(), set_
 - `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
 - `estimated_minutes: int` (optional) — Estimated time in minutes
 - `completed: bool` (optional) — Mark task complete/incomplete. Uses `mark complete` internally, which correctly handles recurring tasks by spawning the next occurrence.
-- `status: str` (optional) — Task status - "active" or "dropped"
+- `status: str` (optional) — Task status - "active" or "dropped". To drop an entire recurring series (not just the current occurrence), pass both recurrence="" and status="dropped" in the same call.
 - `recurrence: str` (optional) — iCalendar RRULE string (e.g., "FREQ=WEEKLY;BYDAY=MO,WE,FR"), or empty string to remove recurrence. Omitting means no change.
 - `repetition_method: str` (optional) — How the next occurrence is calculated. Values: "fixed" (next occurrence on the original schedule regardless of when completed), "start_after_completion" (next defer date = completion date + interval), "due_after_completion" (next due date = completion date + interval). Only meaningful when recurrence is set.
 - `sequential: bool` (optional) — If True, subtasks of this task (action group) must be completed in order. If False, subtasks are parallel (all available). Omitting means no change.
@@ -225,6 +225,7 @@ Consolidates: complete_task(), drop_task(), move_task(), set_parent_task(), set_
 - `update_task("task-123", add_tags=["urgent"])` — Add tag
 - `update_task("task-123", recurrence="FREQ=WEEKLY;BYDAY=MO,WE,FR", repetition_method="fixed")` — Set weekly recurrence
 - `update_task("task-123", recurrence="")` — Remove recurrence
+- `update_task("task-123", recurrence="", status="dropped")` — Drop entire recurring series
 
 ---
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3233,6 +3233,19 @@ class OmniFocusConnector:
                 separate_commands.append("set completed of theTask to false")
             updated_fields.append("completed")
 
+        # Recurrence (must precede status drop — removing recurrence before
+        # "mark dropped" prevents OmniFocus from spawning the next occurrence)
+        _recurrence_js_needed = False
+        if recurrence is not None:
+            if recurrence == "":
+                separate_commands.append("set repetition rule of theTask to missing value")
+            else:
+                _recurrence_js_needed = True
+            updated_fields.append("recurrence")
+        elif repetition_method is not None:
+            _recurrence_js_needed = True
+            updated_fields.append("repetition_method")
+
         # Status (use "mark dropped" command)
         if status is not None:
             if status == TaskStatus.DROPPED:
@@ -3297,18 +3310,6 @@ class OmniFocusConnector:
                     set tagObj to first flattened tag whose name is "{tag_escaped}"
                     remove tagObj from tags of theTask''')
             updated_fields.append("remove_tags")
-
-        # Recurrence
-        _recurrence_js_needed = False
-        if recurrence is not None:
-            if recurrence == "":
-                separate_commands.append("set repetition rule of theTask to missing value")
-            else:
-                _recurrence_js_needed = True
-            updated_fields.append("recurrence")
-        elif repetition_method is not None:
-            _recurrence_js_needed = True
-            updated_fields.append("repetition_method")
 
         return properties, separate_commands, updated_fields, _recurrence_js_needed
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -808,7 +808,9 @@ def update_task(
         estimated_minutes: Estimated time in minutes (optional)
         completed: Mark task complete/incomplete (optional). Uses `mark complete` internally,
             which correctly handles recurring tasks by spawning the next occurrence.
-        status: Task status - "active" or "dropped" (optional)
+        status: Task status - "active" or "dropped" (optional). To drop an entire
+            recurring series (not just the current occurrence), pass both
+            recurrence="" and status="dropped" in the same call.
         recurrence: iCalendar RRULE string (e.g., "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"),
             or empty string to remove recurrence. Omitting means no change. (optional)
         repetition_method: How the next occurrence is calculated (optional). Only meaningful
@@ -836,6 +838,7 @@ def update_task(
         update_task("task-123", task_name="New Name", flagged=True, due_date="2025-12-31")
         update_task("task-123", recurrence="FREQ=WEEKLY;BYDAY=MO,WE,FR", repetition_method="fixed")
         update_task("task-123", recurrence="")  # Remove recurrence
+        update_task("task-123", recurrence="", status="dropped")  # Drop entire recurring series
     """
     # Support legacy 'name' parameter for backward compatibility
     if name is not None and task_name is None:

--- a/tests/test_update_task_helpers.py
+++ b/tests/test_update_task_helpers.py
@@ -149,6 +149,24 @@ class TestBuildUpdateTaskCommands:
         _, _, _, js_needed = self._call(client, repetition_method="fixed")
         assert js_needed is True
 
+    def test_recurrence_clear_before_drop_in_command_order(self, client):
+        """Recurrence removal must precede mark dropped to prevent next occurrence."""
+        _, cmds, fields, _ = self._call(
+            client, recurrence="", status=TaskStatus.DROPPED
+        )
+        recurrence_idx = next(
+            i for i, c in enumerate(cmds) if 'missing value' in c
+        )
+        drop_idx = next(
+            i for i, c in enumerate(cmds) if 'mark dropped' in c
+        )
+        assert recurrence_idx < drop_idx, (
+            f"Recurrence removal (index {recurrence_idx}) must come before "
+            f"mark dropped (index {drop_idx})"
+        )
+        assert "recurrence" in fields
+        assert "status" in fields
+
 
 # ── _execute_recurrence_update ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #405

- Reordered `_build_update_task_commands()` so recurrence removal (`set repetition rule to missing value`) precedes `mark dropped` in the AppleScript command list
- This enables `update_task(task_id, recurrence="", status="dropped")` to drop the entire recurring series in a single call without spawning the next occurrence
- No new API surface — no new parameters, no new functions
- Documented the pattern in `update_task` docstring and eval tool descriptions
- Added blind eval scenario #53 (Claude Sonnet 4 passes)

## Test plan

- [x] Unit test verifying command ordering (804 passed)
- [x] Client-server parity check passing (23 functions)
- [x] Blind eval scenario #53 passing (Claude Sonnet 4)
- [ ] Integration test: create recurring task, drop with `recurrence=""` + `status="dropped"`, verify no new occurrence (`make test-integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)