### PR TITLE
release: v0.10.3

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.2 | **Tests:** 803 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 90%
+**Version:** v0.10.3 | **Tests:** 859 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 95%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2026-03-20
+
+### Added
+
+- **Drop entire recurring task series** (#405, #410)
+  - `update_task(task_id, recurrence="", status="dropped")` now drops the whole series in a single call
+  - Reordered internal command building so recurrence removal precedes `mark dropped`, preventing next occurrence from spawning
+  - New blind eval scenario (#53) validates Claude discovers the pattern from tool descriptions
+
+- **Test coverage threshold enforcement** (#396, #411)
+  - `fail_under` raised from 89 → 90 in `pyproject.toml`
+  - 55 new unit tests covering format helpers, error handlers, and batch response formatting
+  - `server_fastmcp.py` coverage: 82% → 99%; overall: 90% → 95%
+  - Added `make coverage` Makefile target
+  - Excluded unreachable `if __name__ == "__main__"` from coverage
+
+### Fixed
+
+- **Normalized `create_task` tags parameter to native list** (#403, #406)
+  - Changed `tags` from `Optional[str]` (JSON string) to `Optional[list[str]]`, matching `update_task`
+  - Removed JSON parsing logic and unused `import json` from server
+  - Clear error message when non-list type is passed
+
+- **Clear error when modifying tags on dropped tasks** (#404, #407)
+  - AppleScript type coercion error (-1700) on tag operations against dropped tasks now returns an actionable message instead of opaque error
+
+- **Removed redundant Python-side query filter in `get_tasks`** (#398, #408)
+  - `_post_process_tasks()` re-checked name/note containment after both upstream paths (whose clause and batch filter) already handled it
+  - Removed dead code and `query` parameter from `_post_process_tasks()`
+
 ## [0.10.2] - 2026-03-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 ```bash
 git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
-git checkout v0.10.2  # Latest stable release
+git checkout v0.10.3  # Latest stable release
 
 # Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.10.2"
+version = "0.10.3"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Release v0.10.3

### Changes (5 PRs)

**Added**
- Drop entire recurring task series via `update_task(recurrence="", status="dropped")` (#405, #410)
- 55 new coverage tests; `server_fastmcp.py` 82% → 99%; overall 90% → 95% (#396, #411)
- `make coverage` Makefile target

**Fixed**
- `create_task` tags parameter normalized from JSON string to native `list[str]` (#403, #406)
- Clear error message when modifying tags on dropped tasks instead of opaque -1700 (#404, #407)
- Removed redundant Python-side query filter in `get_tasks` (#398, #408)

### Validation

- [x] Version sync (pyproject.toml, __init__.py, CLAUDE.md, README.md, CHANGELOG.md)
- [x] Client-server parity (23 functions)
- [x] Complexity check (all within limits)
- [x] Unit tests (859 passed)
- [x] Coverage (94.85%, threshold 90%)
- [x] Dependency audit (no vulnerabilities)
- [x] AppleScript safety audit
- [x] Code review (no critical issues)

### Code Review Notes

- **Important:** No integration test for the combined `recurrence="" + status="dropped"` path (#410). Individual commands are integration-tested separately. Should be added in a follow-up.
- **Minor:** Coverage tests use single-assertion pattern — adequate for coverage-focused tests.
- **Minor:** Error message for -1700 says "dropped or completed" — hedging is appropriate given uncertainty about completed task behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)