### PR TITLE
fix: rewrite tag replacement to use remove-all + add-each pattern

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3277,22 +3277,20 @@ class OmniFocusConnector:
                     move theTask to end of tasks of theParent''')
             updated_fields.append("parent_task_id")
 
-        # Tags
+        # Tags — full replacement uses remove-all + add-each because
+        # "set tags of theTask to {list}" causes -1700 type coercion errors
         if tags is not None:
-            if len(tags) > 0:
-                tag_adds = []
-                for tag in tags:
-                    tag_escaped = self._escape_applescript_string(tag)
-                    tag_adds.append(f'''
-                        set tagObj to first flattened tag whose name is "{tag_escaped}"
-                        copy tagObj to end of newTags''')
-                tag_adds_str = "\n                    ".join(tag_adds)
+            # Remove all existing tags
+            separate_commands.append('''
+                    repeat while (count of tags of theTask) > 0
+                        remove first tag of theTask from tags of theTask
+                    end repeat''')
+            # Add new tags one by one
+            for tag in tags:
+                tag_escaped = self._escape_applescript_string(tag)
                 separate_commands.append(f'''
-                    set newTags to {{}}
-                    {tag_adds_str}
-                    set tags of theTask to newTags''')
-            else:
-                separate_commands.append("set tags of theTask to {}")
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of theTask''')
             updated_fields.append("tags")
 
         if add_tags is not None:
@@ -3504,21 +3502,11 @@ class OmniFocusConnector:
                     "error": f"Unexpected result: {result}"
                 }
         except subprocess.CalledProcessError as e:
-            error_msg = f"AppleScript error: {e.stderr}"
-            # Type coercion error on tag operations typically means the task
-            # is dropped or in a state that prevents modification
-            if "(-1700)" in (e.stderr or "") and "type tag" in (e.stderr or ""):
-                error_msg = (
-                    f"Cannot modify tags on task '{task_id}': the task may be "
-                    f"dropped or completed. Change the task's status to active "
-                    f"first, or create a new task. "
-                    f"(Original error: {e.stderr})"
-                )
             return {
                 "success": False,
                 "task_id": task_id,
                 "updated_fields": [],
-                "error": error_msg
+                "error": f"AppleScript error: {e.stderr}"
             }
         except Exception as e:
             return {

--- a/tests/test_api_redesign_update.py
+++ b/tests/test_api_redesign_update.py
@@ -346,8 +346,8 @@ class TestUpdateTaskRedesign:
             assert "error" in result
             assert isinstance(result["error"], str)
 
-    def test_update_task_tag_on_dropped_task_gives_clear_error(self, client):
-        """Modifying tags on a dropped task returns a clear error, not opaque -1700."""
+    def test_update_task_applescript_error_returns_stderr(self, client):
+        """AppleScript errors are returned in the error dict with stderr content."""
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.side_effect = subprocess.CalledProcessError(
                 1, 'osascript',
@@ -355,14 +355,13 @@ class TestUpdateTaskRedesign:
             )
 
             result = client.update_task(
-                task_id="task-dropped",
+                task_id="task-123",
                 add_tags=["SomeTag"]
             )
 
             assert result["success"] is False
-            assert "dropped" in result["error"].lower() or "cannot modify" in result["error"].lower()
-            # Should still include enough context to debug
             assert "-1700" in result["error"]
+            assert "AppleScript error" in result["error"]
 
 
 class TestUpdateTasksRedesign:

--- a/tests/test_update_task_helpers.py
+++ b/tests/test_update_task_helpers.py
@@ -124,12 +124,18 @@ class TestBuildUpdateTaskCommands:
 
     def test_tags_full_replacement(self, client):
         _, cmds, fields, _ = self._call(client, tags=["urgent", "home"])
-        assert any('newTags' in c for c in cmds)
+        # Should remove all existing tags then add each new one
+        cmds_str = "\n".join(cmds)
+        assert "repeat while" in cmds_str and "remove" in cmds_str
+        assert "add tagObj to tags of theTask" in cmds_str
         assert "tags" in fields
 
     def test_tags_empty_clears(self, client):
         _, cmds, _, _ = self._call(client, tags=[])
-        assert any('set tags of theTask to {}' in c for c in cmds)
+        # Should remove all existing tags (no adds)
+        cmds_str = "\n".join(cmds)
+        assert "repeat while" in cmds_str and "remove" in cmds_str
+        assert "add tagObj" not in cmds_str
 
     def test_add_tags(self, client):
         _, cmds, fields, _ = self._call(client, add_tags=["urgent"])


### PR DESCRIPTION
## Summary

Closes #413

Investigation revealed that `update_task(tags=["X", "Y"])` was broken on **all tasks** (active, completed, dropped) — not just dropped tasks as #404 assumed. The AppleScript `set tags of theTask to {list}` causes a -1700 type coercion error because OmniFocus can't coerce a constructed list of tag references.

### Fix
- Rewrote full tag replacement to remove all existing tags individually (`repeat while ... remove`), then add new tags one by one (`add tagObj to tags of theTask`)
- Same pattern already used successfully by `add_tags` and `remove_tags`
- Removed the misleading "task may be dropped or completed" error message from #404

### Integration tested
- Tag replacement on active task: `tags=["Home", "Office"]` ✅
- Tag swap: `tags=["Computer"]` (replaces previous) ✅
- Tag clear: `tags=[]` ✅
- Tag replacement on dropped task ✅

## Test plan

- [x] Unit tests updated and passing (859 passed)
- [x] Integration tested against real OmniFocus (4 scenarios)
- [x] No API/tool description changes — no blind evals needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)