### PR TITLE
feat: support tag reparenting via update_tag(parent_tag=...)

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -1330,4 +1330,30 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    {
+        "id": 54,
+        "category": "Tag Management",
+        "name": "Reparent Tag Under New Parent",
+        "prompt": (
+            "I have a tag 'Aimee' (ID: tag-aimee-001) that's currently at the top level. "
+            "I want to move it under the 'People' tag to organize my tag hierarchy. "
+            "Make sure all existing task associations are preserved."
+        ),
+        "expected": {
+            "tools": ["update_tag"],
+            "key_params": {
+                "update_tag": {
+                    "tag_id": "tag-aimee-001",
+                    "parent_tag": "People",
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: update_tag(tag_id='tag-aimee-001', parent_tag='People') — "
+            "single call, preserves task associations. "
+            "PARTIAL: Suggests delete + recreate (works but loses task associations). "
+            "FAIL: Says tag reparenting isn't possible, or uses wrong tool."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -370,15 +370,21 @@ Tags can be nested (e.g., create "High" under parent "Energy" to get "Energy : H
 
 Update properties of an existing tag in OmniFocus.
 
-Tags can be renamed or have their status changed. Tags have three states: active (tasks are actionable), on_hold (tasks excluded from available queries), and dropped (tag hidden from most views).
+Tags can be renamed, reparented, or have their status changed. Tags have three states: active (tasks are actionable), on_hold (tasks excluded from available queries), and dropped (tag hidden from most views).
 
 **Parameters:**
 - `tag_id: str` (required) — The ID of the tag to update (from get_tags)
 - `name: str` (optional) — New tag name
 - `status: str` (optional) — Tag status. Values: "active", "on_hold", "dropped". Active = tasks with this tag are actionable. On hold = tag is paused, **tasks with this tag become unavailable** (excluded from Available perspective) — use for temporary pauses. Dropped = tag is retired/archived, **tasks remain available** but the tag is hidden from most views — use for permanent retirement.
 - `children_are_mutually_exclusive: bool` (optional) — If True, child tags of this tag will be mutually exclusive. If False, children are independent (default behavior).
+- `parent_tag: str` (optional) — Move this tag under a different parent tag (by name), or empty string to move to top level. Preserves all task associations.
 
 **Returns:** Success message with updated fields, or error message
+
+**Examples:**
+- `update_tag("tag-123", parent_tag="People")` — Move tag under "People"
+- `update_tag("tag-123", parent_tag="")` — Move tag to top level
+- `update_tag("tag-123", name="Renamed", parent_tag="Work")` — Rename and reparent in one call
 
 ---
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -4100,7 +4100,8 @@ class OmniFocusConnector:
         tag_id: str,
         name: Optional[str] = None,
         status: Optional[str] = None,
-        children_are_mutually_exclusive: Optional[bool] = None
+        children_are_mutually_exclusive: Optional[bool] = None,
+        parent_tag: Optional[str] = None
     ) -> dict:
         """Update properties of an existing tag.
 
@@ -4114,6 +4115,8 @@ class OmniFocusConnector:
             children_are_mutually_exclusive: If True, child tags of this
                 tag are mutually exclusive (assigning one removes others).
                 Set via OmniAutomation. (optional)
+            parent_tag: Move tag under this parent tag (by name), or
+                empty string to move to top level. (optional)
 
         Returns:
             dict: {
@@ -4144,6 +4147,7 @@ class OmniFocusConnector:
             "name": name,
             "status": status,
             "children_are_mutually_exclusive": children_are_mutually_exclusive,
+            "parent_tag": parent_tag,
         }
         if all(v is None for v in all_fields.values()):
             raise ValueError("At least one field must be provided to update")
@@ -4168,7 +4172,19 @@ class OmniFocusConnector:
                 set_lines.append('set hidden of theTag to true')
             updated_fields.append("status")
 
-        # Run AppleScript for name/status changes (if any)
+        if parent_tag is not None:
+            if parent_tag == "":
+                # Move to top level
+                set_lines.append("move theTag to end of tags of it")
+            else:
+                parent_escaped = self._escape_applescript_string(parent_tag)
+                set_lines.append(
+                    f'set parentTag to first flattened tag whose name is "{parent_escaped}"\n'
+                    f'                        move theTag to end of tags of parentTag'
+                )
+            updated_fields.append("parent_tag")
+
+        # Run AppleScript for name/status/parent changes (if any)
         if set_lines:
             set_block = "\n                        ".join(set_lines)
             fields_json = ", ".join(f'\\"{f}\\"' for f in updated_fields)

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -1069,13 +1069,14 @@ def update_tag(
     tag_id: str,
     name: Optional[str] = None,
     status: Optional[str] = None,
-    children_are_mutually_exclusive: Optional[bool] = None
+    children_are_mutually_exclusive: Optional[bool] = None,
+    parent_tag: Optional[str] = None
 ) -> str:
     """Update properties of an existing tag in OmniFocus.
 
-    Tags can be renamed or have their status changed. Tags have three states:
-    active (tasks are actionable), on_hold (tasks excluded from available queries),
-    and dropped (tag hidden from most views).
+    Tags can be renamed, reparented, or have their status changed. Tags have three
+    states: active (tasks are actionable), on_hold (tasks excluded from available
+    queries), and dropped (tag hidden from most views).
 
     Args:
         tag_id: The ID of the tag to update (from get_tags)
@@ -1088,9 +1089,15 @@ def update_tag(
         children_are_mutually_exclusive: If True, child tags of this tag will be
             mutually exclusive — assigning one child tag to a task silently removes
             any other child from the same group. Set via OmniAutomation. (optional)
+        parent_tag: Move this tag under a different parent tag (by name), or empty
+            string to move to top level. Preserves all task associations. (optional)
 
     Returns:
         Success message with updated fields, or error message
+
+    Examples:
+        update_tag("tag-123", parent_tag="People")  # Move under "People"
+        update_tag("tag-123", parent_tag="")  # Move to top level
     """
     client = get_client()
     try:
@@ -1098,7 +1105,8 @@ def update_tag(
             tag_id=tag_id,
             name=name,
             status=status,
-            children_are_mutually_exclusive=children_are_mutually_exclusive
+            children_are_mutually_exclusive=children_are_mutually_exclusive,
+            parent_tag=parent_tag
         )
 
         fields = ", ".join(result["updated_fields"])

--- a/tests/test_update_tag.py
+++ b/tests/test_update_tag.py
@@ -31,7 +31,8 @@ class TestUpdateTagServer:
 
             mock_client.update_tag.assert_called_once_with(
                 tag_id="tag-001", name="Renamed", status=None,
-                children_are_mutually_exclusive=None
+                children_are_mutually_exclusive=None,
+                parent_tag=None
             )
             assert "tag-001" in result
             assert "Successfully" in result
@@ -52,7 +53,8 @@ class TestUpdateTagServer:
 
             mock_client.update_tag.assert_called_once_with(
                 tag_id="tag-002", name=None, status="on_hold",
-                children_are_mutually_exclusive=None
+                children_are_mutually_exclusive=None,
+                parent_tag=None
             )
             assert "tag-002" in result
             assert "Successfully" in result
@@ -99,6 +101,59 @@ class TestUpdateTagServer:
             result = update_tag(tag_id="tag-001")
 
             assert "Error" in result
+
+
+class TestUpdateTagReparenting:
+    """Tests for update_tag() parent_tag parameter (tag reparenting)."""
+
+    def test_server_passes_parent_tag_to_connector(self):
+        """Server passes parent_tag parameter to connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True,
+                "tag_id": "tag-001",
+                "updated_fields": ["parent_tag"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-001", parent_tag="People")
+
+            mock_client.update_tag.assert_called_once_with(
+                tag_id="tag-001", name=None, status=None,
+                children_are_mutually_exclusive=None,
+                parent_tag="People"
+            )
+            assert "Successfully" in result
+
+    def test_connector_move_under_parent(self):
+        """Connector builds move command to reparent tag under another tag."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = '{"success": true, "updated_fields": ["parent_tag"]}'
+
+            client = OmniFocusConnector()
+            result = client.update_tag("tag-child", parent_tag="People")
+
+            assert result["success"] is True
+            assert "parent_tag" in result["updated_fields"]
+            call_args = mock_run.call_args[0][0]
+            assert "move theTag" in call_args
+            assert "People" in call_args
+
+    def test_connector_move_to_top_level(self):
+        """Connector builds move command to make tag top-level (parent_tag='')."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
+            mock_run.return_value = '{"success": true, "updated_fields": ["parent_tag"]}'
+
+            client = OmniFocusConnector()
+            result = client.update_tag("tag-child", parent_tag="")
+
+            assert result["success"] is True
+            call_args = mock_run.call_args[0][0]
+            assert "move theTag" in call_args
+            # Should move to document level, not under a parent
+            assert "tags of it" in call_args
 
 
 class TestGetTagsDroppedStatus:
@@ -271,7 +326,8 @@ class TestUpdateTagStatus:
 
             mock_client.update_tag.assert_called_once_with(
                 tag_id="tag-001", name=None, status="dropped",
-                children_are_mutually_exclusive=None
+                children_are_mutually_exclusive=None,
+                parent_tag=None
             )
             assert "Successfully" in result
 


### PR DESCRIPTION
## Summary

Closes #415

Added `parent_tag` parameter to `update_tag` for reorganizing tag hierarchies without losing task associations.

```python
update_tag("tag-123", parent_tag="People")  # Move under "People"
update_tag("tag-123", parent_tag="")         # Move to top level
```

### Implementation
- Uses AppleScript `move theTag to end of tags of parentTag` (same pattern as task/project reparenting)
- Top-level move uses `move theTag to end of tags of it` (referring to front document)
- Lookup by tag name (matching `create_tag` convention)
- No new API functions — parameter added to existing `update_tag` per API design philosophy

### Integration tested
- Move tag under parent ✅
- Move tag to top level ✅
- Task associations preserved after reparenting ✅
- Combined rename + reparent in single call ✅

## Test plan

- [x] Unit tests (862 passed, 3 new reparenting tests)
- [x] Integration tested against real OmniFocus (4 scenarios)
- [x] Client-server parity (23 functions, unchanged)
- [x] Blind eval scenario #54 passing (Claude Sonnet 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)