### PR TITLE
feat: add tags, flagged, estimated_minutes, recurrence to projects

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -1356,4 +1356,29 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+    {
+        "id": 55,
+        "category": "Parameter Usage",
+        "name": "Tag and Flag a Project",
+        "prompt": (
+            "Flag the project proj-website-001 as high priority and add the tag 'High Priority' to it."
+        ),
+        "expected": {
+            "tools": ["update_project"],
+            "key_params": {
+                "update_project": {
+                    "project_id": "proj-website-001",
+                    "flagged": True,
+                    "add_tags": ["High Priority"],
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: update_project(project_id='proj-website-001', flagged=True, add_tags=['High Priority']) "
+            "in a single call. "
+            "PARTIAL: Two separate calls (one for flag, one for tag). "
+            "FAIL: Uses update_task, says projects can't be flagged/tagged, or wrong tool."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -94,8 +94,20 @@ Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_
 - `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
 - `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
 - `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
+- `flagged: bool` (optional) — Flag marks a project as a priority. Pass True to flag, False to unflag.
+- `estimated_minutes: int` (optional) — Estimated time in minutes for the project
+- `tags: list[str]` (optional) — Full replacement — set exact tag list. Conflicts with add_tags/remove_tags.
+- `add_tags: list[str]` (optional) — Add these tags incrementally. Conflicts with tags.
+- `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
+- `recurrence: str` (optional) — iCalendar RRULE string, or empty string to remove recurrence.
+- `repetition_method: str` (optional) — "fixed", "start_after_completion", or "due_after_completion". Only meaningful when recurrence is set.
 
 **Returns:** Success message with project ID and updated fields, or error message
+
+**Examples:**
+- `update_project("proj-123", flagged=True)` — Flag project
+- `update_project("proj-123", add_tags=["High Priority"])` — Add tag to project
+- `update_project("proj-123", tags=[])` — Clear all tags from project
 
 ---
 
@@ -116,6 +128,10 @@ IMPORTANT: This function does NOT accept project_name or note parameters because
 - `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
 - `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
 - `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
+- `flagged: bool` (optional) — Flag/unflag all specified projects
+- `estimated_minutes: int` (optional) — Set estimated time for all specified projects
+- `add_tags: list[str]` (optional) — Add these tags to all specified projects
+- `remove_tags: list[str]` (optional) — Remove these tags from all specified projects
 
 **Returns:** Success message with updated and failed counts
 

--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -66,8 +66,8 @@ echo ""
 #   - _post_process_projects: CC ≤ 23 (22 current - projectType + 6 filter steps)
 #
 # Original functions not yet refactored:
-#   - update_projects: CC ≤ 44 (43 current — v0.10.0 added project dates)
-#   - update_project: CC ≤ 40 (39 current — v0.10.0 added project dates)
+#   - update_projects: CC ≤ 54 (53 current — #417 added flagged/estimated/tags)
+#   - update_project: CC ≤ 57 (56 current — #417 added flagged/estimated/tags/recurrence)
 #   - _format_task: CC ≤ 26 (25 current)
 #   - create_task: CC ≤ 23 (22 current)
 #   - _validate_update_task_params: CC ≤ 19 (18 current)
@@ -95,9 +95,9 @@ try:
                 elif name == '_post_process_projects' and cc <= 23:
                     continue
                 # Original functions
-                elif name == 'update_projects' and cc <= 44:
+                elif name == 'update_projects' and cc <= 54:
                     continue
-                elif name == 'update_project' and cc <= 40:
+                elif name == 'update_project' and cc <= 57:
                     continue
                 elif name == '_format_task' and cc <= 32:
                     continue
@@ -132,7 +132,7 @@ echo "✅ PASS: All functions within complexity limits"
 echo ""
 echo "Documented exceptions (see script comments for full list):"
 echo "  - Extracted helpers: _build_task_filter_checks (35), _build_update_task_commands (29), _post_process_tasks (28)"
-echo "  - Original functions: update_projects (43), update_project (39), _format_task (31), create_task (22)"
+echo "  - Original functions: update_project (56), update_projects (53), _format_task (31), create_task (22)"
 echo "  - All other functions: CC ≤ 20"
 echo ""
 echo "See inline documentation in omnifocus_connector.py for rationale."

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1368,6 +1368,13 @@ class OmniFocusConnector:
         due_date: Optional[str] = None,
         defer_date: Optional[str] = None,
         planned_date: Optional[str] = None,
+        flagged: Optional[bool] = None,
+        estimated_minutes: Optional[int] = None,
+        tags: Optional[list[str]] = None,
+        add_tags: Optional[list[str]] = None,
+        remove_tags: Optional[list[str]] = None,
+        recurrence: Optional[str] = None,
+        repetition_method: Optional[str] = None,
     ) -> dict:
         """Update properties of an existing project (NEW API - Phase 2).
 
@@ -1384,6 +1391,13 @@ class OmniFocusConnector:
             due_date: Due date in ISO 8601 format, or "" to clear (optional)
             defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
             planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
+            flagged: Flag the project as a priority (optional)
+            estimated_minutes: Estimated time in minutes (optional)
+            tags: Full replacement - set exact tag list (optional, conflicts with add_tags/remove_tags)
+            add_tags: Add these tags incrementally (optional, conflicts with tags)
+            remove_tags: Remove these tags (optional, conflicts with tags)
+            recurrence: iCalendar RRULE string, or "" to clear (optional)
+            repetition_method: "fixed", "start_after_completion", or "due_after_completion" (optional)
 
         Returns:
             dict: {
@@ -1394,13 +1408,19 @@ class OmniFocusConnector:
             }
 
         Raises:
-            ValueError: If project_id is empty, no fields provided, or invalid status
+            ValueError: If project_id is empty, no fields provided, invalid status, or conflicting tag params
         """
         # SAFETY: Verify database before modifying
         self._verify_database_safety('update_project')
 
         if not project_id:
             raise ValueError("project_id is required")
+
+        # Validate tag conflicts
+        if tags is not None and add_tags is not None:
+            raise ValueError("Cannot specify both tags and add_tags (use one or the other)")
+        if tags is not None and remove_tags is not None:
+            raise ValueError("Cannot specify both tags and remove_tags (use one or the other)")
 
         # Collect all provided fields
         all_fields = {
@@ -1417,6 +1437,13 @@ class OmniFocusConnector:
             "due_date": due_date,
             "defer_date": defer_date,
             "planned_date": planned_date,
+            "flagged": flagged,
+            "estimated_minutes": estimated_minutes,
+            "tags": tags,
+            "add_tags": add_tags,
+            "remove_tags": remove_tags,
+            "recurrence": recurrence,
+            "repetition_method": repetition_method,
         }
 
         # Check if at least one field is provided
@@ -1536,6 +1563,73 @@ class OmniFocusConnector:
             completed_by_children_command = f'set completed by children of theProject to {str(completed_by_children).lower()}'
             updated_fields.append("completed_by_children")
 
+        # Build flagged property
+        if flagged is not None:
+            properties.append(f'flagged:{str(flagged).lower()}')
+            updated_fields.append("flagged")
+
+        # Build estimated minutes command
+        estimated_command = ""
+        if estimated_minutes is not None:
+            estimated_command = f'set estimated minutes of theProject to {estimated_minutes}'
+            updated_fields.append("estimated_minutes")
+
+        # Build tag commands
+        tag_commands = ""
+        if tags is not None:
+            tag_lines = []
+            # Remove all existing tags
+            tag_lines.append('''
+                    repeat while (count of tags of theProject) > 0
+                        remove first tag of theProject from tags of theProject
+                    end repeat''')
+            # Add new tags
+            for tag in tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                tag_lines.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of theProject''')
+            tag_commands = "\n".join(tag_lines)
+            updated_fields.append("tags")
+
+        if add_tags is not None:
+            tag_lines = []
+            for tag in add_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                tag_lines.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of theProject''')
+            tag_commands += "\n".join(tag_lines)
+            updated_fields.append("add_tags")
+
+        if remove_tags is not None:
+            tag_lines = []
+            for tag in remove_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                tag_lines.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    remove tagObj from tags of theProject''')
+            tag_commands += "\n".join(tag_lines)
+            updated_fields.append("remove_tags")
+
+        # Build recurrence command (clear only — set is done post-AppleScript via OmniAutomation)
+        recurrence_command = ""
+        recurrence_js_needed = False
+        if recurrence is not None:
+            if recurrence == "":
+                # Clear recurrence
+                recurrence_command = 'set repetition rule of theProject to missing value'
+                updated_fields.append("recurrence")
+            else:
+                # Set recurrence — handled by _execute_recurrence_update after main script
+                recurrence_js_needed = True
+                updated_fields.append("recurrence")
+
+        if repetition_method is not None and recurrence is None:
+            # Update repetition method only (recurrence rule stays the same)
+            recurrence_js_needed = True
+            updated_fields.append("repetition_method")
+
         # Build folder path command
         folder_command = ""
         if folder_path is not None:
@@ -1610,12 +1704,15 @@ class OmniFocusConnector:
                     end if
 
                     {properties_command}
+                    {recurrence_command}
                     {status_command}
                     {review_command}
                     {reviewed_command}
                     {next_review_command}
                     {date_commands_str}
                     {completed_by_children_command}
+                    {estimated_command}
+                    {tag_commands}
                     {folder_command}
 
                     return "true"
@@ -1631,6 +1728,11 @@ class OmniFocusConnector:
             result = result.strip()
 
             if result.startswith("true"):
+                # Post-AppleScript: set recurrence via OmniAutomation if needed
+                if recurrence_js_needed:
+                    self._execute_recurrence_update(
+                        project_id, recurrence, repetition_method
+                    )
                 return {
                     "success": True,
                     "project_id": project_id,
@@ -1665,6 +1767,10 @@ class OmniFocusConnector:
         due_date: Optional[str] = None,
         defer_date: Optional[str] = None,
         planned_date: Optional[str] = None,
+        flagged: Optional[bool] = None,
+        estimated_minutes: Optional[int] = None,
+        add_tags: Optional[list[str]] = None,
+        remove_tags: Optional[list[str]] = None,
         **kwargs  # Catch invalid parameters like project_name, note
     ) -> dict:
         """Update properties of multiple projects (NEW API - Phase 2, Batch Function).
@@ -1687,6 +1793,10 @@ class OmniFocusConnector:
             due_date: Due date in ISO 8601 format, or "" to clear (optional)
             defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
             planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
+            flagged: Flag the projects as a priority (optional)
+            estimated_minutes: Estimated time in minutes (optional)
+            add_tags: Add these tags incrementally (optional)
+            remove_tags: Remove these tags (optional)
 
         Returns:
             dict: {
@@ -1732,7 +1842,9 @@ class OmniFocusConnector:
         if (folder_path is None and sequential is None and status is None and
                 review_interval_weeks is None and last_reviewed is None and
                 next_review_date is None and due_date is None and
-                defer_date is None and planned_date is None):
+                defer_date is None and planned_date is None and
+                flagged is None and estimated_minutes is None and
+                add_tags is None and remove_tags is None):
             raise ValueError("At least one field must be provided to update")
 
         # Normalize project_ids to list
@@ -1817,9 +1929,33 @@ class OmniFocusConnector:
                     )
                 has_bulk = True
 
+        if flagged is not None:
+            bulk_commands.append(f"set flagged of ({or_chain_target}) to {str(flagged).lower()}")
+            has_bulk = True
+
+        if estimated_minutes is not None:
+            bulk_commands.append(f"set estimated minutes of ({or_chain_target}) to {estimated_minutes}")
+            has_bulk = True
+
         # --- Per-project fields (need repeat loop) ---
 
         per_project_commands = []
+
+        if add_tags is not None:
+            for tag in add_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                per_project_commands.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    add tagObj to tags of theProject''')
+            has_per_project = True
+
+        if remove_tags is not None:
+            for tag in remove_tags:
+                tag_escaped = self._escape_applescript_string(tag)
+                per_project_commands.append(f'''
+                    set tagObj to first flattened tag whose name is "{tag_escaped}"
+                    remove tagObj from tags of theProject''')
+            has_per_project = True
 
         if folder_path is not None:
             # Build folder navigation commands (reuse existing logic)

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -366,6 +366,13 @@ def update_project(
     due_date: Optional[str] = None,
     defer_date: Optional[str] = None,
     planned_date: Optional[str] = None,
+    flagged: Optional[bool] = None,
+    estimated_minutes: Optional[int] = None,
+    tags: Optional[list[str]] = None,
+    add_tags: Optional[list[str]] = None,
+    remove_tags: Optional[list[str]] = None,
+    recurrence: Optional[str] = None,
+    repetition_method: Optional[str] = None,
 ) -> str:
     """Update an existing project in OmniFocus.
 
@@ -384,6 +391,17 @@ def update_project(
         due_date: Due date in ISO 8601 format, or "" to clear (optional)
         defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
         planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
+        flagged: Flag marks a project as a priority — pass True to flag, False to unflag. (optional)
+        estimated_minutes: Estimated time in minutes (optional)
+        tags: Full replacement — set exact tag list as a native list (optional, conflicts
+            with add_tags/remove_tags).
+        add_tags: Add these tags incrementally (optional, conflicts with tags)
+        remove_tags: Remove these tags (optional, conflicts with tags)
+        recurrence: iCalendar RRULE string (e.g., "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO"),
+            or empty string to remove recurrence. Omitting means no change. (optional)
+        repetition_method: How the next occurrence is calculated (optional). Only meaningful
+            when recurrence is set. Values: "fixed", "start_after_completion",
+            "due_after_completion".
 
     Returns:
         Success message with project ID and updated fields, or error message
@@ -418,6 +436,13 @@ def update_project(
             due_date=due_date,
             defer_date=defer_date,
             planned_date=planned_date,
+            flagged=flagged,
+            estimated_minutes=estimated_minutes,
+            tags=tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+            recurrence=recurrence,
+            repetition_method=repetition_method,
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -450,6 +475,10 @@ def update_projects(
     due_date: Optional[str] = None,
     defer_date: Optional[str] = None,
     planned_date: Optional[str] = None,
+    flagged: Optional[bool] = None,
+    estimated_minutes: Optional[int] = None,
+    add_tags: Optional[list[str]] = None,
+    remove_tags: Optional[list[str]] = None,
 ) -> str:
     """Update multiple projects with the same properties (NEW API - Phase 2, Batch Function).
 
@@ -471,6 +500,10 @@ def update_projects(
         due_date: Due date in ISO 8601 format, or "" to clear (optional)
         defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
         planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
+        flagged: Flag marks projects as a priority — pass True to flag, False to unflag. (optional)
+        estimated_minutes: Estimated time in minutes (optional)
+        add_tags: Add these tags incrementally (optional)
+        remove_tags: Remove these tags (optional)
 
     Returns:
         Success message with updated and failed counts, or error message
@@ -510,6 +543,10 @@ def update_projects(
             due_date=due_date,
             defer_date=defer_date,
             planned_date=planned_date,
+            flagged=flagged,
+            estimated_minutes=estimated_minutes,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
         )
 
         # Handle dict return from client

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -48,6 +48,13 @@ class TestUpdateProjectServerRedesign:
                 due_date=None,
                 defer_date=None,
                 planned_date=None,
+                flagged=None,
+                estimated_minutes=None,
+                tags=None,
+                add_tags=None,
+                remove_tags=None,
+                recurrence=None,
+                repetition_method=None,
             )
 
             assert isinstance(result, str)
@@ -303,3 +310,138 @@ class TestUpdateProjectCompletedByChildren:
             call_kwargs = mock_client.update_project.call_args[1]
             assert call_kwargs["completed_by_children"] is True
             assert "updated" in result.lower() or "success" in result.lower()
+
+
+class TestUpdateProjectNewParams:
+    """Tests for new parameters: tags, flagged, estimated_minutes, recurrence."""
+
+    def test_update_project_flagged(self):
+        """Server: update_project() can set flagged on a project."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["flagged"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-1", flagged=True)
+
+            mock_client.update_project.assert_called_once()
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["flagged"] is True
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_project_estimated_minutes(self):
+        """Server: update_project() can set estimated_minutes on a project."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["estimated_minutes"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-1", estimated_minutes=30)
+
+            mock_client.update_project.assert_called_once()
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["estimated_minutes"] == 30
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_project_add_tags(self):
+        """Server: update_project() can add tags to a project."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["add_tags"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-1", add_tags=["urgent", "work"])
+
+            mock_client.update_project.assert_called_once()
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["add_tags"] == ["urgent", "work"]
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_project_remove_tags(self):
+        """Server: update_project() can remove tags from a project."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["remove_tags"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-1", remove_tags=["old-tag"])
+
+            mock_client.update_project.assert_called_once()
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["remove_tags"] == ["old-tag"]
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_project_tags_replacement(self):
+        """Server: update_project() can do full tag replacement."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["tags"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-1", tags=["tag-a", "tag-b"])
+
+            mock_client.update_project.assert_called_once()
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["tags"] == ["tag-a", "tag-b"]
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_project_recurrence(self):
+        """Server: update_project() can set recurrence on a project."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["recurrence"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(
+                project_id="proj-1",
+                recurrence="FREQ=WEEKLY;BYDAY=MO",
+                repetition_method="fixed"
+            )
+
+            mock_client.update_project.assert_called_once()
+            call_kwargs = mock_client.update_project.call_args[1]
+            assert call_kwargs["recurrence"] == "FREQ=WEEKLY;BYDAY=MO"
+            assert call_kwargs["repetition_method"] == "fixed"
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_project_tags_conflict_with_add_tags(self):
+        """Server: update_project() rejects tags + add_tags together."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.side_effect = ValueError(
+                "Cannot specify both tags and add_tags"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = update_project(
+                project_id="proj-1",
+                tags=["a"],
+                add_tags=["b"]
+            )
+
+            assert "error" in result.lower()
+            assert "tags" in result.lower() or "add_tags" in result.lower()

--- a/tests/test_server_redesign_update_projects.py
+++ b/tests/test_server_redesign_update_projects.py
@@ -189,3 +189,104 @@ class TestUpdateProjectsServerRedesign:
             # Should be user-friendly, not raw JSON
             assert "5" in result
             assert "project" in result.lower()
+
+
+class TestUpdateProjectsNewParams:
+    """Tests for new parameters: flagged, estimated_minutes, add_tags, remove_tags."""
+
+    def test_update_projects_flagged(self):
+        """Server: update_projects() can set flagged on multiple projects."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_projects.return_value = {
+                "updated_count": 2,
+                "failed_count": 0,
+                "updated_ids": ["proj-1", "proj-2"],
+                "failures": []
+            }
+            mock_get_client.return_value = mock_client
+
+            update_projects = server.update_projects
+
+            result = update_projects(
+                project_ids=["proj-1", "proj-2"],
+                flagged=True
+            )
+
+            mock_client.update_projects.assert_called_once()
+            call_kwargs = mock_client.update_projects.call_args[1]
+            assert call_kwargs["flagged"] is True
+            assert "2" in result
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_update_projects_estimated_minutes(self):
+        """Server: update_projects() can set estimated_minutes on multiple projects."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_projects.return_value = {
+                "updated_count": 2,
+                "failed_count": 0,
+                "updated_ids": ["proj-1", "proj-2"],
+                "failures": []
+            }
+            mock_get_client.return_value = mock_client
+
+            update_projects = server.update_projects
+
+            result = update_projects(
+                project_ids=["proj-1", "proj-2"],
+                estimated_minutes=60
+            )
+
+            mock_client.update_projects.assert_called_once()
+            call_kwargs = mock_client.update_projects.call_args[1]
+            assert call_kwargs["estimated_minutes"] == 60
+            assert "2" in result
+
+    def test_update_projects_add_tags(self):
+        """Server: update_projects() can add tags to multiple projects."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_projects.return_value = {
+                "updated_count": 2,
+                "failed_count": 0,
+                "updated_ids": ["proj-1", "proj-2"],
+                "failures": []
+            }
+            mock_get_client.return_value = mock_client
+
+            update_projects = server.update_projects
+
+            result = update_projects(
+                project_ids=["proj-1", "proj-2"],
+                add_tags=["urgent"]
+            )
+
+            mock_client.update_projects.assert_called_once()
+            call_kwargs = mock_client.update_projects.call_args[1]
+            assert call_kwargs["add_tags"] == ["urgent"]
+            assert "2" in result
+
+    def test_update_projects_remove_tags(self):
+        """Server: update_projects() can remove tags from multiple projects."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_projects.return_value = {
+                "updated_count": 2,
+                "failed_count": 0,
+                "updated_ids": ["proj-1", "proj-2"],
+                "failures": []
+            }
+            mock_get_client.return_value = mock_client
+
+            update_projects = server.update_projects
+
+            result = update_projects(
+                project_ids=["proj-1", "proj-2"],
+                remove_tags=["old-tag"]
+            )
+
+            mock_client.update_projects.assert_called_once()
+            call_kwargs = mock_client.update_projects.call_args[1]
+            assert call_kwargs["remove_tags"] == ["old-tag"]
+            assert "2" in result


### PR DESCRIPTION
## Summary

Closes #417

Added full task-parity parameters to project update operations.

### `update_project` (7 new parameters)
- `tags`, `add_tags`, `remove_tags` — same patterns as `update_task` (remove-all+add-each for replacement)
- `flagged` — property-level flag
- `estimated_minutes` — separate command
- `recurrence`, `repetition_method` — AppleScript clear + OmniAutomation set

### `update_projects` batch (4 new parameters)
- `flagged`, `estimated_minutes` — bulk-settable via or-chain
- `add_tags`, `remove_tags` — per-project in repeat loop

### Integration tested
- flagged, estimated_minutes, add_tags, remove_tags, tags replacement, tags clear, recurrence clear, combined operations ✅
- Batch: flagged, estimated_minutes, add_tags, remove_tags (2 projects) ✅

## Test plan

- [x] Unit tests (873 passed, 11 new)
- [x] Integration tested against real OmniFocus (12 scenarios)
- [x] Client-server parity (23 functions, unchanged)
- [x] Blind eval scenario #55 passing (Claude Sonnet 4)
- [x] Complexity check passing (thresholds updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)