### PR TITLE
chore: add SECURITY.md responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported with security updates.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+| Older   | No        |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's private security advisory feature:
+
+1. Go to the [Security tab](https://github.com/s-morgan-jeffries/omnifocus-mcp/security/advisories) of this repository
+2. Click "Report a vulnerability"
+3. Provide a description of the issue, steps to reproduce, and any relevant details
+
+Please do **not** file a public issue for security vulnerabilities.
+
+## What to Expect
+
+- Acknowledgment within 48 hours
+- Assessment and response within 7 days
+- A fix or mitigation plan shared with you before public disclosure


### PR DESCRIPTION
## Summary

Closes #422

Adds a security policy with instructions to use GitHub's private security advisory feature for vulnerability reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)