### PR TITLE
release: v0.10.4

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.3 | **Tests:** 859 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 95%
+**Version:** v0.10.4 | **Tests:** 873 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 93%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] - 2026-03-20
+
+### Added
+
+- **Tags, flagged, estimated_minutes, recurrence on projects** (#417, #418)
+  - `update_project` gains 7 new parameters: `tags`, `add_tags`, `remove_tags`, `flagged`, `estimated_minutes`, `recurrence`, `repetition_method`
+  - `update_projects` (batch) gains 4 new parameters: `flagged`, `estimated_minutes`, `add_tags`, `remove_tags`
+  - Projects are tasks in OmniFocus's data model — same AppleScript patterns apply
+
+- **Tag reparenting via `update_tag(parent_tag=...)`** (#415, #416)
+  - Move tags between parents: `update_tag(tag_id, parent_tag="People")`
+  - Move to top level: `update_tag(tag_id, parent_tag="")`
+  - Preserves all task associations
+
+- **GitHub project polish** (#409, #419-#426)
+  - MIT license (`LICENSE`)
+  - PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
+  - SECURITY.md responsible disclosure policy
+  - Dependabot for monthly dependency updates and security alerts
+  - README badges (CI, coverage, Python version, license)
+  - Required status checks on branch protection (CI must pass to merge)
+
+### Fixed
+
+- **Tag full replacement broken on all tasks** (#413, #414)
+  - `update_task(tags=["X"])` was silently failing with -1700 on ALL tasks (not just dropped)
+  - Root cause: AppleScript `set tags of theTask to {list}` can't coerce constructed tag lists
+  - Rewrote to remove-all + add-each pattern (same as working `add_tags`/`remove_tags`)
+  - Removed misleading "dropped task" error message from #404
+
 ## [0.10.3] - 2026-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OmniFocus MCP Server
 
 [![CI](https://github.com/s-morgan-jeffries/omnifocus-mcp/actions/workflows/test.yml/badge.svg)](https://github.com/s-morgan-jeffries/omnifocus-mcp/actions/workflows/test.yml)
-[![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/s-morgan-jeffries/omnifocus-mcp)
+[![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/s-morgan-jeffries/omnifocus-mcp)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -86,7 +86,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 ```bash
 git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
-git checkout v0.10.3  # Latest stable release
+git checkout v0.10.4  # Latest stable release
 
 # Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.10.3"
+version = "0.10.4"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -4310,7 +4310,9 @@ class OmniFocusConnector:
 
         if parent_tag is not None:
             if parent_tag == "":
-                # Move to top level
+                # Move to top level — "it" refers to front document from the
+                # enclosing tell block. "front document" doesn't work here
+                # (tested: causes AppleScript error in this context).
                 set_lines.append("move theTag to end of tags of it")
             else:
                 parent_escaped = self._escape_applescript_string(parent_tag)


### PR DESCRIPTION
## Release v0.10.4

### Changes (7 PRs)

**Added**
- Tags, flagged, estimated_minutes, recurrence on projects (#417, #418)
- Tag reparenting via `update_tag(parent_tag=...)` (#415, #416)
- MIT license, PR template, SECURITY.md (#421-#424)
- Dependabot for monthly updates + security alerts (#401, #425)
- README badges: CI, coverage, Python, license (#420, #426)
- Required status checks on branch protection (#419)

**Fixed**
- Tag full replacement broken on all tasks — rewrote to remove-all + add-each (#413, #414)

### Validation

- [x] Version sync
- [x] Client-server parity (23 functions)
- [x] Complexity check
- [x] Unit tests (873 passed)
- [x] Coverage (92.76%, threshold 90%)
- [x] Dependency audit
- [x] AppleScript safety audit
- [x] Code review (no critical issues)

### Code Review Notes

- **Important:** `_execute_recurrence_update` uses `Task.byIdentifier()` for project recurrence — works because OF projects are tasks, but should be documented/tested as follow-up
- **Important:** Tag reparenting top-level move uses `it` (implicit `front document` reference) — documented with comment explaining why explicit `front document` doesn't work
- **Minor:** Complexity thresholds bumped for `update_project` (57) and `update_projects` (54) — proportional to 7 new parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)