### PR TITLE
test: add E2E coverage for 14 previously uncovered MCP functions

### DIFF
--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -38,6 +38,18 @@ update_task = server.update_task
 update_tasks = server.update_tasks
 delete_tasks = server.delete_tasks
 get_tasks = server.get_tasks
+get_projects = server.get_projects
+create_project = server.create_project
+delete_projects = server.delete_projects
+get_tags = server.get_tags
+create_tag = server.create_tag
+update_tag = server.update_tag
+delete_tags = server.delete_tags
+get_folders = server.get_folders
+create_folder = server.create_folder
+update_folder = server.update_folder
+get_perspectives = server.get_perspectives
+get_focus = server.get_focus
 
 # Skip all tests unless in test mode
 pytestmark = pytest.mark.skipif(
@@ -450,3 +462,278 @@ class TestSetFocusE2E:
         assert "task" in result.lower()
 
         print(f"\n✓ E2E set_focus invalid type: {result}")
+
+
+# ============================================================================
+# E2E Tests for get_tasks() with filters
+# ============================================================================
+
+class TestGetTasksE2E:
+    """E2E tests for get_tasks() MCP tool with various filters.
+
+    Tests the full stack:
+    MCP tool → client.get_tasks() → AppleScript → OmniFocus
+    """
+
+    def test_get_tasks_all_e2e(self, client, test_project):
+        """E2E: Get all tasks via MCP tool."""
+        # Create a task first so we have at least one
+        client.create_task("E2E Get Tasks Test", project_id=test_project)
+        result = get_tasks()
+        assert isinstance(result, str)
+        assert "Found" in result
+        assert "tasks" in result.lower()
+
+        print(f"\n✓ E2E get_tasks (all): {result[:200]}")
+
+    def test_get_tasks_with_query_e2e(self, client, test_project):
+        """E2E: Get tasks with query filter via MCP tool."""
+        client.create_task("E2E Unique Query Target XYZ", project_id=test_project)
+        result = get_tasks(query="Unique Query Target XYZ")
+        assert isinstance(result, str)
+        assert "Unique Query Target XYZ" in result
+
+        print(f"\n✓ E2E get_tasks (query): {result[:200]}")
+
+    def test_get_tasks_flagged_e2e(self, client, test_project):
+        """E2E: Get flagged tasks via MCP tool."""
+        task_id = client.create_task("E2E Flagged Task", project_id=test_project, flagged=True)
+        result = get_tasks(flagged_only=True)
+        assert isinstance(result, str)
+        # Should find at least one flagged task
+        assert "Found" in result
+
+        print(f"\n✓ E2E get_tasks (flagged): {result[:200]}")
+
+        client.delete_tasks(task_id)
+
+    def test_get_tasks_inbox_e2e(self):
+        """E2E: Get inbox tasks via MCP tool."""
+        result = get_tasks(inbox_only=True)
+        assert isinstance(result, str)
+        # Either finds tasks or says none
+        assert "Found" in result or "No tasks in inbox" in result
+
+        print(f"\n✓ E2E get_tasks (inbox): {result[:200]}")
+
+
+# ============================================================================
+# E2E Tests for get_projects()
+# ============================================================================
+
+class TestGetProjectsE2E:
+    """E2E tests for get_projects() MCP tool.
+
+    Tests the full stack:
+    MCP tool → client.get_projects() → AppleScript → OmniFocus
+    """
+
+    def test_get_projects_all_e2e(self):
+        """E2E: Get all projects via MCP tool."""
+        result = get_projects()
+        assert isinstance(result, str)
+        assert "Found" in result
+
+        print(f"\n✓ E2E get_projects (all): {result[:200]}")
+
+    def test_get_projects_with_query_e2e(self, test_project):
+        """E2E: Get projects with query filter via MCP tool."""
+        # test_project creates a project with a unique name containing "test-"
+        result = get_projects(query="test-")
+        assert isinstance(result, str)
+        assert "Found" in result
+
+        print(f"\n✓ E2E get_projects (query): {result[:200]}")
+
+
+# ============================================================================
+# E2E Tests for create_project()
+# ============================================================================
+
+class TestCreateProjectE2E:
+    """E2E tests for create_project() MCP tool.
+
+    Tests the full stack:
+    MCP tool → client.create_project() → AppleScript → OmniFocus
+    """
+
+    def test_create_project_e2e(self, client):
+        """E2E: Create project via MCP tool."""
+        result = create_project(name="E2E Test Project Creation")
+        assert isinstance(result, str)
+        assert "Successfully created" in result
+        assert "Project ID:" in result
+
+        # Extract ID and cleanup
+        match = re.search(r'Project ID: (\S+)', result)
+        if match:
+            client.delete_projects(match.group(1))
+
+        print(f"\n✓ E2E create_project: {result}")
+
+
+# ============================================================================
+# E2E Tests for delete_projects()
+# ============================================================================
+
+class TestDeleteProjectsE2E:
+    """E2E tests for delete_projects() MCP tool.
+
+    Tests the full stack:
+    MCP tool → client.delete_projects() → AppleScript → OmniFocus
+    """
+
+    def test_delete_projects_e2e(self, client):
+        """E2E: Delete project via MCP tool."""
+        proj_id = client.create_project("E2E Delete Project Test")
+        result = delete_projects(project_ids=proj_id)
+        assert isinstance(result, str)
+        assert "deleted" in result.lower()
+
+        print(f"\n✓ E2E delete_projects: {result}")
+
+
+# ============================================================================
+# E2E Tests for get_tags()
+# ============================================================================
+
+class TestGetTagsE2E:
+    """E2E tests for get_tags() MCP tool.
+
+    Tests the full stack:
+    MCP tool → client.get_tags() → AppleScript → OmniFocus
+    """
+
+    def test_get_tags_e2e(self):
+        """E2E: Get all tags via MCP tool."""
+        result = get_tags()
+        assert isinstance(result, str)
+        assert "Found" in result
+        assert "tags" in result.lower()
+
+        print(f"\n✓ E2E get_tags: {result[:200]}")
+
+
+# ============================================================================
+# E2E Tests for tag lifecycle (create, update, delete)
+# ============================================================================
+
+class TestTagCRUDE2E:
+    """E2E tests for tag create/update/delete MCP tools.
+
+    Tests the full stack:
+    MCP tool → client methods → AppleScript → OmniFocus
+    """
+
+    def test_tag_lifecycle_e2e(self, client):
+        """E2E: Full tag lifecycle via MCP tools."""
+        # Create
+        result = create_tag(name="E2E-Test-Tag-Lifecycle")
+        assert isinstance(result, str)
+        assert "Successfully" in result
+
+        # Extract tag ID
+        match = re.search(r'Tag ID: (\S+)', result)
+        assert match, f"Could not find tag ID in: {result}"
+        tag_id = match.group(1)
+
+        print(f"\n✓ E2E create_tag: {result}")
+
+        # Update (rename)
+        result = update_tag(tag_id=tag_id, name="E2E-Test-Tag-Renamed")
+        assert isinstance(result, str)
+        assert "Successfully" in result
+
+        print(f"\n✓ E2E update_tag: {result}")
+
+        # Delete
+        result = delete_tags(tag_ids=tag_id)
+        assert isinstance(result, str)
+        assert "deleted" in result.lower()
+
+        print(f"\n✓ E2E delete_tags: {result}")
+
+
+# ============================================================================
+# E2E Tests for folder operations
+# ============================================================================
+
+class TestFolderE2E:
+    """E2E tests for folder MCP tools.
+
+    Tests the full stack:
+    MCP tool → client methods → AppleScript → OmniFocus
+    """
+
+    def test_get_folders_e2e(self):
+        """E2E: Get all folders via MCP tool."""
+        result = get_folders()
+        assert isinstance(result, str)
+        assert "Found" in result or "folder" in result.lower()
+
+        print(f"\n✓ E2E get_folders: {result[:200]}")
+
+    def test_folder_lifecycle_e2e(self, client):
+        """E2E: Create and update folder via MCP tools."""
+        # Create
+        result = create_folder(name="E2E-Test-Folder")
+        assert isinstance(result, str)
+        assert "Successfully" in result
+
+        # Extract folder ID
+        match = re.search(r'ID: (\S+)', result)
+        assert match, f"Could not find folder ID in: {result}"
+        folder_id = match.group(1).rstrip(')')
+
+        print(f"\n✓ E2E create_folder: {result}")
+
+        # Update (rename)
+        result = update_folder(folder_id=folder_id, name="E2E-Test-Folder-Renamed")
+        assert isinstance(result, str)
+        assert "Successfully" in result
+
+        print(f"\n✓ E2E update_folder: {result}")
+
+        # Cleanup - drop the folder
+        server.update_folder(folder_id=folder_id, status="dropped")
+
+
+# ============================================================================
+# E2E Tests for get_perspectives()
+# ============================================================================
+
+class TestPerspectivesE2E:
+    """E2E tests for get_perspectives() MCP tool.
+
+    Tests the full stack:
+    MCP tool → client.get_perspectives() → AppleScript → OmniFocus
+    """
+
+    def test_get_perspectives_e2e(self):
+        """E2E: Get perspectives via MCP tool."""
+        result = get_perspectives()
+        assert isinstance(result, str)
+        assert "Found" in result or "perspective" in result.lower()
+
+        print(f"\n✓ E2E get_perspectives: {result[:200]}")
+
+
+# ============================================================================
+# E2E Tests for get_focus()
+# ============================================================================
+
+class TestGetFocusE2E:
+    """E2E tests for get_focus() MCP tool.
+
+    Tests the full stack:
+    MCP tool → client.get_focus() → AppleScript → OmniFocus
+    """
+
+    def test_get_focus_e2e(self):
+        """E2E: Get current focus via MCP tool."""
+        result = get_focus()
+        assert isinstance(result, str)
+        # Either has focus or doesn't
+        assert "focus" in result.lower() or "No focus" in result
+
+        print(f"\n✓ E2E get_focus: {result}")


### PR DESCRIPTION
## Summary

Closes #435

Added 14 E2E tests covering functions that previously had zero E2E coverage:

- **get_tasks** (4 tests): all tasks, query filter, flagged filter, inbox filter
- **get_projects** (2 tests): all projects, query filter
- **create_project** (1 test): create with ID extraction and cleanup
- **delete_projects** (1 test): delete via MCP tool
- **get_tags** (1 test): list all tags
- **Tag lifecycle** (1 test): create → update (rename) → delete
- **Folder lifecycle** (2 tests): get all, create → update → drop
- **get_perspectives** (1 test): list perspectives
- **get_focus** (1 test): get current focus state

Not included (tracked separately): reorder_task/reorder_project (#436), switch_perspective (changes UI state).

## Test plan

- [x] All 34 E2E tests pass against real OmniFocus (104s)
- [x] All 873 unit tests still pass
- [x] Tests properly skipped without OMNIFOCUS_TEST_MODE=true

🤖 Generated with [Claude Code](https://claude.com/claude-code)