### PR TITLE
test: tighten AppleScript tell-block balance checker tolerance

### DIFF
--- a/tests/test_applescript_syntax.py
+++ b/tests/test_applescript_syntax.py
@@ -124,8 +124,8 @@ class TestAppleScriptSyntax:
 
         # They should be roughly balanced
         # (rough check because of string escaping and multi-line blocks)
-        if abs(tell_count - end_tell_count) > 10:
+        if abs(tell_count - end_tell_count) > 5:
             pytest.fail(
                 f"Unbalanced tell blocks: {tell_count} 'tell' vs {end_tell_count} 'end tell'. "
-                "Difference > 10 suggests syntax errors."
+                "Difference > 5 suggests syntax errors."
             )


### PR DESCRIPTION
## Summary

Closes #433

Reduced tell/end-tell balance checker tolerance from 10 to 5. Actual difference is 4 (legitimate mismatches from string contexts). New tolerance catches 1 additional unbalanced block.

## Test plan

- [x] Balance check still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)