### PR TITLE
release: v0.10.5

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.4 | **Tests:** 873 unit, 144 integration/E2E, 26 benchmark/profiling | **Coverage:** 93%
+**Version:** v0.10.5 | **Tests:** 895 unit, 158 integration/E2E, 26 benchmark/profiling | **Coverage:** 93%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - 2026-03-21
+
+### Added
+
+- **E2E test coverage for 14 previously uncovered MCP functions** (#435, #450)
+  - get_tasks (4 filter variants), get_projects, create_project, delete_projects
+  - Tag lifecycle (create/update/delete), folder lifecycle, perspectives, focus
+
+- **Unicode/emoji test fixture across all layers** (#434, #456)
+  - 19 unit tests + 4 integration tests verifying round-trip for accented chars, emoji, CJK, Cyrillic
+
+- **Performance baseline assertions in benchmarks** (#447, #453)
+  - 19 read benchmarks now assert against 5x documented baselines — catches catastrophic regressions
+
+- **Batch mode invariant tests** (#444, #452)
+  - Verifies `a reference to` pattern exists in get_tasks, get_projects, and get_folders
+
+- **8 new blind eval scenarios** (#440-#443, #463)
+  - Under-covered tools (reorder, delete_tags, perspectives, folders), multi-step triage, error recovery, tags-format regression
+
+- **Full blind eval run on Claude + 4 open-weight models** (#464, #465)
+  - DeepSeek Chat matched Claude at 99.2%; Llama improved +6.1pp to 93.1% (0 FAILs)
+  - All 9 new scenarios passed universally across all models
+
+### Changed
+
+- **get_folders converted to batch mode — 15x speedup** (#454, #462)
+  - Replaced recursive per-folder AppleScript traversal with `a reference to flattened folders`
+  - 28 folders: 4.0s → 0.26s
+
+- **Benchmark iterations increased from 3 to 5** for read operations (#446, #463)
+
+### Fixed
+
+- **Hollow coverage tests strengthened** (#448, #449)
+  - Added `assert_called_once_with` to 30 tests that previously only checked output strings
+
+- **reviewInterval commented-out assertion replaced with pytest.xfail** (#437, #457)
+
+- **AppleScript tell-block balance checker tightened** from tolerance 10 to 5 (#433, #458)
+
+- **Folder rename and cross-folder project move integration tests** (#439, #461)
+
 ## [0.10.4] - 2026-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 ```bash
 git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
-git checkout v0.10.4  # Latest stable release
+git checkout v0.10.5  # Latest stable release
 
 # Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.10.4"
+version = "0.10.5"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Release v0.10.5

Test quality milestone — comprehensive test suite improvements driven by #429 critical evaluation.

### Changes (11 PRs)

**Added**
- E2E coverage for 14 previously uncovered MCP functions (#435)
- Unicode/emoji test fixture across all layers (#434)
- Performance baseline assertions on 19 read benchmarks (#447)
- Batch mode invariant tests for get_tasks, get_projects, get_folders (#444)
- 8 new blind eval scenarios: reorder, delete_tags, perspectives, folders, multi-step, error recovery (#440-#443)
- Full blind eval run — DeepSeek matched Claude at 99.2%, Llama +6.1pp (#464)

**Changed**
- get_folders converted to batch mode — 15x speedup (#454)
- Benchmark iterations 3 → 5 for read operations (#446)

**Fixed**
- Hollow coverage tests strengthened with argument verification (#448)
- reviewInterval assertion: commented-out → pytest.xfail (#437)
- AppleScript tell-block balance checker tightened (#433)
- Folder rename + cross-folder move integration tests (#439)

### Validation

- [x] Version sync
- [x] Client-server parity (23 functions)
- [x] Complexity check
- [x] Unit tests (895 passed)
- [x] Coverage (92.76%, threshold 90%)
- [x] Dependency audit
- [x] AppleScript safety audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)