### PR TITLE
fix: standardize sequential parameter to bool across all functions

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -85,7 +85,7 @@ Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_
 - `folder_path: str` (optional) — Folder path to move project to (e.g., "Work : Projects")
 - `note: str` (optional) — New note content. WARNING: Removes rich text formatting.
 - `project_type: str` (optional) — Change project type: "parallel", "sequential", or "single_actions"
-- `sequential: str` (optional, DEPRECATED) — Use project_type instead. Sequential setting - "true" or "false"
+- `sequential: bool` (optional, DEPRECATED) — Use project_type instead.
 - `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
 - `review_interval_weeks: int` (optional) — Review interval in weeks (0 to clear)
 - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
@@ -120,7 +120,7 @@ IMPORTANT: This function does NOT accept project_name or note parameters because
 **Parameters:**
 - `project_ids: str | list[str]` (required) — Single project ID or list of project IDs
 - `folder_path: str` (optional) — Folder path to move projects to
-- `sequential: str` (optional) — Sequential setting ("true" or "false")
+- `sequential: bool` (optional) — Sequential setting
 - `status: str` (optional) — Project status - "active", "on_hold", "done", "dropped"
 - `review_interval_weeks: int` (optional) — Review interval in weeks
 - `last_reviewed: str` (optional) — Last review date ("now" or ISO format)

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -356,7 +356,7 @@ def update_project(
     project_name: Optional[str] = None,
     folder_path: Optional[str] = None,
     note: Optional[str] = None,
-    sequential: Optional[str] = None,
+    sequential: Optional[bool] = None,
     project_type: Optional[str] = None,
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
@@ -382,7 +382,7 @@ def update_project(
         folder_path: Folder path to move project to (e.g., "Work : Projects")
         note: New note content (optional). WARNING: Removes rich text formatting.
         project_type: Change project type — "parallel", "sequential", or "single_actions" (optional)
-        sequential: DEPRECATED — use project_type instead. Sequential setting - "true" or "false"
+        sequential: DEPRECATED — use project_type instead. (optional)
         status: Project status - "active", "on_hold", "done", or "dropped"
         review_interval_weeks: Review interval in weeks (0 to clear)
         last_reviewed: Last reviewed date in ISO format or "now"
@@ -406,19 +406,6 @@ def update_project(
     Returns:
         Success message with project ID and updated fields, or error message
     """
-    # Convert sequential parameter to boolean for client (handle both string and bool)
-    sequential_bool: Optional[bool] = None
-    if sequential is not None:
-        if isinstance(sequential, bool):
-            sequential_bool = sequential
-        elif isinstance(sequential, str):
-            if sequential.lower() == "true":
-                sequential_bool = True
-            elif sequential.lower() == "false":
-                sequential_bool = False
-            else:
-                return f"Error: Invalid sequential value '{sequential}'. Must be 'true' or 'false'."
-
     client = get_client()
     try:
         result = client.update_project(
@@ -426,7 +413,7 @@ def update_project(
             project_name=project_name,
             folder_path=folder_path,
             note=note,
-            sequential=sequential_bool,
+            sequential=sequential,
             project_type=project_type,
             status=status,
             review_interval_weeks=review_interval_weeks,
@@ -467,7 +454,7 @@ def update_project(
 def update_projects(
     project_ids: Union[str, list[str]],
     folder_path: Optional[str] = None,
-    sequential: Optional[str] = None,
+    sequential: Optional[bool] = None,
     status: Optional[str] = None,
     review_interval_weeks: Optional[int] = None,
     last_reviewed: Optional[str] = None,
@@ -492,7 +479,7 @@ def update_projects(
     Args:
         project_ids: Single project ID (str) or list of project IDs to update
         folder_path: Folder path to move projects to (e.g., "Work > Projects")
-        sequential: Sequential setting as string ("true" or "false")
+        sequential: Sequential setting (optional)
         status: Project status - one of: "active", "on_hold", "done", "dropped"
         review_interval_weeks: Review interval in weeks
         last_reviewed: Last review date ("now" or ISO format like "2025-01-15")
@@ -515,27 +502,12 @@ def update_projects(
             status="dropped"
         )
     """
-    # Convert sequential parameter to boolean for client (handle both string and bool)
-    sequential_bool: Optional[bool] = None
-    if sequential is not None:
-        if isinstance(sequential, bool):
-            # Direct boolean (from tests or Python calls)
-            sequential_bool = sequential
-        elif isinstance(sequential, str):
-            # String from MCP (Claude passes strings)
-            if sequential.lower() == "true":
-                sequential_bool = True
-            elif sequential.lower() == "false":
-                sequential_bool = False
-            else:
-                return f"Error: Invalid sequential value '{sequential}'. Must be 'true' or 'false'."
-
     try:
         client = get_client()
         result = client.update_projects(
             project_ids=project_ids,
             folder_path=folder_path,
-            sequential=sequential_bool,
+            sequential=sequential,
             status=status,
             review_interval_weeks=review_interval_weeks,
             last_reviewed=last_reviewed,

--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -337,7 +337,7 @@ class TestUpdateProjectE2E:
             project_name="E2E Updated Project Name",
             status="active",
             review_interval_weeks=2,
-            sequential="true"
+            sequential=True
         )
 
         assert isinstance(result, str)
@@ -400,7 +400,7 @@ class TestUpdateProjectsE2E:
         proj_id = client.create_project("E2E Single ID")
 
         # Call MCP tool
-        result = server.update_projects(project_ids=proj_id, sequential="true")
+        result = server.update_projects(project_ids=proj_id, sequential=True)
 
         assert isinstance(result, str)
         assert "1" in result  # Should mention 1 project

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -171,11 +171,6 @@ class TestUpdateProjectsEdgeCases:
     """Cover error paths in update_projects()."""
 
     @mock.patch("omnifocus_mcp.server_fastmcp.get_client")
-    def test_invalid_sequential_string(self, mock_gc):
-        result = server.update_projects(project_ids=["p1"], sequential="maybe")
-        assert "Invalid sequential value" in result
-
-    @mock.patch("omnifocus_mcp.server_fastmcp.get_client")
     def test_all_updates_failed(self, mock_gc):
         mock_gc.return_value.update_projects.return_value = {
             "updated_count": 0,

--- a/tests/test_server_fastmcp.py
+++ b/tests/test_server_fastmcp.py
@@ -729,7 +729,7 @@ class TestHierarchyFieldFormatting:
             }
             mock_get_client.return_value = mock_client
 
-            result = update_project("proj-001", sequential="true")
+            result = update_project("proj-001", sequential=True)
 
             # Verify the client was called with boolean True
             call_kwargs = mock_client.update_project.call_args[1]
@@ -737,11 +737,10 @@ class TestHierarchyFieldFormatting:
             assert call_kwargs['sequential'] is True
             assert "Successfully updated project" in result
 
-    def test_update_project_sequential_with_string_false(self):
-        """Test that update_project accepts string 'false' for sequential parameter."""
+    def test_update_project_sequential_with_bool_false(self):
+        """Test that update_project accepts bool False for sequential parameter."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            # NEW API returns dict, not boolean
             mock_client.update_project.return_value = {
                 "success": True,
                 "project_id": "proj-001",
@@ -750,25 +749,12 @@ class TestHierarchyFieldFormatting:
             }
             mock_get_client.return_value = mock_client
 
-            result = update_project("proj-001", sequential="false")
+            result = update_project("proj-001", sequential=False)
 
-            # Verify the client was called with boolean False
             call_kwargs = mock_client.update_project.call_args[1]
             assert call_kwargs['project_id'] == "proj-001"
             assert call_kwargs['sequential'] is False
             assert "Successfully updated project" in result
-
-    def test_update_project_sequential_with_invalid_string(self):
-        """Test that update_project rejects invalid sequential values."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_get_client.return_value = mock_client
-
-            result = update_project("proj-001", sequential="maybe")
-
-            # Should return error without calling client
-            assert "Error: Invalid sequential value" in result
-            mock_client.update_project.assert_not_called()
 
     def test_update_project_sequential_omitted(self):
         """Test that update_project works when sequential parameter is omitted."""

--- a/tests/test_server_redesign_update_projects.py
+++ b/tests/test_server_redesign_update_projects.py
@@ -83,13 +83,13 @@ class TestUpdateProjectsServerRedesign:
             result = update_projects(
                 project_ids=["proj-001", "proj-002"],
                 status="active",
-                sequential="true",
+                sequential=True,
                 review_interval_weeks=4
             )
 
             call_kwargs = mock_client.update_projects.call_args[1]
             assert call_kwargs["status"] == "active"
-            assert call_kwargs["sequential"] is True  # Converted from string
+            assert call_kwargs["sequential"] is True
             assert call_kwargs["review_interval_weeks"] == 4
 
             assert "2" in result
@@ -151,20 +151,15 @@ class TestUpdateProjectsServerRedesign:
 
             update_projects = server.update_projects
 
-            # Test with "true"
-            result = update_projects(project_ids="proj-001", sequential="true")
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["sequential"] is True
-
-            # Test with "false"
-            result = update_projects(project_ids="proj-001", sequential="false")
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["sequential"] is False
-
-            # Test with bool (from tests)
+            # Test with True
             result = update_projects(project_ids="proj-001", sequential=True)
             call_kwargs = mock_client.update_projects.call_args[1]
             assert call_kwargs["sequential"] is True
+
+            # Test with False
+            result = update_projects(project_ids="proj-001", sequential=False)
+            call_kwargs = mock_client.update_projects.call_args[1]
+            assert call_kwargs["sequential"] is False
 
     def test_update_projects_returns_human_readable_response(self):
         """Server: update_projects() MCP tool returns human-readable response."""


### PR DESCRIPTION
## Summary

Closes #470

Changed `sequential` from `Optional[str]` to `Optional[bool]` on `update_project` and `update_projects`, matching every other function in the API. Removed string-to-bool conversion boilerplate (~50 lines). Type system now prevents invalid values.

## Test plan

- [x] 893 tests passing (-2: removed invalid-string test and string-conversion test)
- [x] Eval tool descriptions updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)