### PR TITLE
fix: get_projects response text now reflects active filter

### DIFF
--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -263,16 +263,26 @@ def get_projects(
     except ValueError as e:
         return f"Error: {str(e)}"
 
+    # Build descriptor based on filter
+    if project_id:
+        descriptor = "project"
+    elif on_hold_only:
+        descriptor = "on-hold projects"
+    elif stalled_only:
+        descriptor = "stalled projects"
+    else:
+        descriptor = "active projects"
+
     if not projects:
         if query:
-            return f"No projects found matching '{query}'"
-        return "Found 0 active projects"
+            return f"No {descriptor} found matching '{query}'"
+        return f"Found 0 {descriptor}"
 
     # Format projects for display
     if query:
-        result = f"Found {len(projects)} projects matching '{query}':\n\n"
+        result = f"Found {len(projects)} {descriptor} matching '{query}':\n\n"
     else:
-        result = f"Found {len(projects)} active projects:\n\n"
+        result = f"Found {len(projects)} {descriptor}:\n\n"
     for proj in projects:
         result += _format_project(proj, truncate_notes=(not include_full_notes))
         result += "\n"

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -128,7 +128,7 @@ class TestGetProjectsEdgeCases:
     def test_query_no_results(self, mock_gc):
         mock_gc.return_value.get_projects.return_value = []
         result = server.get_projects(query="nonexistent")
-        assert "No projects found matching 'nonexistent'" in result
+        assert "No active projects found matching 'nonexistent'" in result
         mock_gc.return_value.get_projects.assert_called_once()
         call_kwargs = mock_gc.return_value.get_projects.call_args[1]
         assert call_kwargs["query"] == "nonexistent"
@@ -139,7 +139,7 @@ class TestGetProjectsEdgeCases:
             {"id": "p1", "name": "Match", "status": "active"},
         ]
         result = server.get_projects(query="Match")
-        assert "Found 1 projects matching 'Match':" in result
+        assert "Found 1 active projects matching 'Match':" in result
         mock_gc.return_value.get_projects.assert_called_once()
         call_kwargs = mock_gc.return_value.get_projects.call_args[1]
         assert call_kwargs["query"] == "Match"


### PR DESCRIPTION
## Summary

Closes #471

Response text was always "Found N active projects" regardless of filter. Now uses the correct descriptor based on which filter is active:
- `on_hold_only=True` → "on-hold projects"
- `stalled_only=True` → "stalled projects"
- `project_id` set → "project"
- default → "active projects"

## Test plan

- [x] 893 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)