### PR TITLE
feat: add include_dropped parameter to get_projects

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -38,7 +38,7 @@ REVIEW: Projects have review intervals. Use get_projects() to find projects due 
 
 ### get_projects
 
-Retrieve ALL active projects with full details and hierarchy, optionally filtered by search query.
+Retrieve projects from OmniFocus with optional filtering.
 
 **Parameters:**
 - `project_id: str` (optional) — Filter to specific project by ID
@@ -48,6 +48,7 @@ Retrieve ALL active projects with full details and hierarchy, optionally filtere
 - `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
 - `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
 - `stalled_only: bool` (default: False) — Only return active projects with no available actions (implies include_task_health=True)
+- `include_dropped: bool` (default: False) — Include dropped projects in results (hidden by default)
 
 **Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, creationDate, modificationDate, completionDate (null if not completed), droppedDate (null if not dropped), dueDate, deferDate, plannedDate, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalWeeks. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. `dueDate`, `deferDate`, `plannedDate` — project-level dates in ISO format (empty string if not set). Tasks inherit effective dates from their containing project. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status. `stalled` (boolean) — true when availableCount=0 and tasks are not just deferred (project needs attention). With include_last_activity: lastActivityDate.
 

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -910,14 +910,16 @@ class OmniFocusConnector:
         include_task_health: bool = False,
         include_last_activity: bool = False,
         stalled_only: bool = False,
+        include_dropped: bool = False,
         timeout: int = 90
     ) -> list[dict[str, Any]]:
         """Get projects with their folder/hierarchy information using AppleScript.
 
         Args:
-            project_id: NEW (Phase 3.2) - Filter to specific project by ID (consolidates get_project())
-            include_full_notes: NEW (Phase 3.2) - Return full note content (consolidates get_note())
+            project_id: Filter to specific project by ID (optional)
+            include_full_notes: Return full note content (default: False)
             on_hold_only: Only return projects with "on hold" status (default: False)
+            include_dropped: Include dropped projects in results (default: False)
             modified_after: Only return projects modified after this ISO date
             modified_before: Only return projects modified before this ISO date
             min_task_count: Only return projects with at least this many tasks
@@ -956,10 +958,18 @@ class OmniFocusConnector:
         task_ops_preamble, task_ops_block, health_init, task_health_json_fields = \
             self._build_task_ops_blocks(include_task_health, include_last_activity)
 
-        # Build on_hold filter condition
-        on_hold_condition = ""
+        # Build status filter condition
+        # Default: skip dropped projects. on_hold_only also skips non-on-hold.
+        # include_dropped removes the dropped filter.
+        skip_conditions = []
+        if not include_dropped:
+            skip_conditions.append('projStatus is "dropped status"')
         if on_hold_only:
-            on_hold_condition = ' or projStatus is not "on hold status"'
+            skip_conditions.append('projStatus is not "on hold status"')
+        if skip_conditions:
+            status_filter_condition = f'if {" or ".join(skip_conditions)} then\n                            error "skip project"\n                        end if'
+        else:
+            status_filter_condition = ""
 
         script = '''
         use AppleScript version "2.4"
@@ -1028,10 +1038,8 @@ class OmniFocusConnector:
                     try
                         set projStatus to item i of statuses as text
 
-                        -- Skip dropped projects (and on_hold filter)
-                        if projStatus is "dropped status"{on_hold_condition} then
-                            error "skip project"
-                        end if
+                        -- Status filter (skip dropped/non-matching projects)
+                        {status_filter_condition}
 
                         -- Look up folder path from cache
                         set folderPath to ""
@@ -1154,7 +1162,7 @@ class OmniFocusConnector:
 
         script = script.format(
             project_source=project_source,
-            on_hold_condition=on_hold_condition,
+            status_filter_condition=status_filter_condition,
             task_ops_preamble=task_ops_preamble,
             health_init=health_init,
             task_ops_block=task_ops_block,

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -222,9 +222,10 @@ def get_projects(
     query: Optional[str] = None,
     include_task_health: bool = False,
     include_last_activity: bool = False,
-    stalled_only: bool = False
+    stalled_only: bool = False,
+    include_dropped: bool = False
 ) -> str:
-    """Retrieve ALL active projects with full details and hierarchy, optionally filtered by search query.
+    """Retrieve projects from OmniFocus with optional filtering.
 
     Args:
         project_id: Filter to specific project by ID (optional)
@@ -234,6 +235,7 @@ def get_projects(
         include_task_health: If True, include per-project task health counts (remaining, available, overdue, deferred)
         include_last_activity: If True, compute lastActivityDate (most recent task creation/completion)
         stalled_only: If True, only return active projects with no available actions — projects that need attention (implies include_task_health=True)
+        include_dropped: If True, include dropped projects in results (default: False — dropped projects are hidden)
 
     Returns:
         Each project includes: id, name, folderPath, status, projectType, sequential,
@@ -256,6 +258,7 @@ def get_projects(
             include_task_health=include_task_health,
             include_last_activity=include_last_activity,
             stalled_only=stalled_only,
+            include_dropped=include_dropped,
         )
     except ValueError as e:
         return f"Error: {str(e)}"
@@ -267,6 +270,8 @@ def get_projects(
         descriptor = "on-hold projects"
     elif stalled_only:
         descriptor = "stalled projects"
+    elif include_dropped:
+        descriptor = "projects (including dropped)"
     else:
         descriptor = "active projects"
 


### PR DESCRIPTION
## Summary

Closes #460

Added `include_dropped` parameter to `get_projects()` (default False). Dropped projects were previously always filtered out. Now they can be included for verification of drop operations and taxonomy audits.

### Integration tested
- Without include_dropped: dropped project NOT returned ✅
- With include_dropped=True: dropped project returned with status "dropped status" ✅

## Test plan

- [x] 893 unit tests passing
- [x] Integration tested against real OmniFocus
- [x] Eval tool descriptions updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)