### PR TITLE
chore: remove legacy name parameter from update_task

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -3224,7 +3224,6 @@ class OmniFocusConnector:
         *,
         task_id: str,
         task_name: Optional[str],
-        name: Optional[str],
         project_id: Optional[str],
         parent_task_id: Optional[str],
         tags: Optional[list[str]],
@@ -3245,15 +3244,10 @@ class OmniFocusConnector:
     ) -> tuple[Optional[str], Optional[TaskStatus]]:
         """Validate update_task parameters, raising ValueError for invalid values.
 
-        Returns (resolved_task_name, resolved_status) after legacy name support
-        and status enum normalization.
+        Returns (resolved_task_name, resolved_status) after status enum normalization.
         """
         if not task_id:
             raise ValueError("task_id is required")
-
-        # Support legacy 'name' parameter
-        if name is not None and task_name is None:
-            task_name = name
 
         if project_id is not None and parent_task_id is not None:
             raise ValueError("Cannot specify both parent_task_id and project_id - parent task already determines the project.")
@@ -3525,7 +3519,6 @@ class OmniFocusConnector:
         status: Optional[Union[TaskStatus, str]] = None,
         recurrence: Optional[str] = None,
         repetition_method: Optional[str] = None,
-        name: Optional[str] = None  # Deprecated: use task_name
     ) -> dict:
         """Update properties of an existing task (NEW API - Redesign).
 
@@ -3579,7 +3572,7 @@ class OmniFocusConnector:
 
         # Validate parameters
         task_name, status = self._validate_update_task_params(
-            task_id=task_id, task_name=task_name, name=name,
+            task_id=task_id, task_name=task_name,
             project_id=project_id, parent_task_id=parent_task_id,
             tags=tags, add_tags=add_tags, remove_tags=remove_tags,
             status=status, repetition_method=repetition_method,
@@ -3680,7 +3673,7 @@ class OmniFocusConnector:
         kwargs: dict,
     ) -> list[str]:
         """Validate update_tasks parameters. Returns normalized ids_list."""
-        if 'task_name' in kwargs or 'name' in kwargs:
+        if 'task_name' in kwargs:
             raise ValueError("task_name is not allowed in batch updates (requires unique values per task)")
         if 'note' in kwargs:
             raise ValueError("note is not allowed in batch updates (requires unique values per task)")

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -789,8 +789,6 @@ def update_task(
     repetition_method: Optional[str] = None,
     sequential: Optional[bool] = None,
     completed_by_children: Optional[bool] = None,
-    # Legacy parameters (backward compatibility)
-    name: Optional[str] = None
 ) -> str:
     """Update an existing task in OmniFocus.
 
@@ -850,10 +848,6 @@ def update_task(
         update_task("task-123", recurrence="")  # Remove recurrence
         update_task("task-123", recurrence="", status="dropped")  # Drop entire recurring series
     """
-    # Support legacy 'name' parameter for backward compatibility
-    if name is not None and task_name is None:
-        task_name = name
-
     client = get_client()
     try:
         result = client.update_task(
@@ -876,7 +870,6 @@ def update_task(
             repetition_method=repetition_method,
             sequential=sequential,
             completed_by_children=completed_by_children,
-            name=name  # Pass to client for its own backward compat handling
         )
     except ValueError as e:
         return f"Error: {str(e)}"

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -1033,7 +1033,7 @@ class TestUpdateTask:
         """Test updating task name (LEGACY TEST - updated for new API return format)."""
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = "true"
-            result = client.update_task("task-001", name="Updated Task Name")
+            result = client.update_task("task-001", task_name="Updated Task Name")
             # NEW API: Returns dict instead of bool
             assert result["success"] is True
             assert result["task_id"] == "task-001"
@@ -1127,7 +1127,7 @@ class TestUpdateTask:
             mock_run.return_value = "true"
             result = client.update_task(
                 "task-001",
-                name="New Name",
+                task_name="New Name",
                 note="New note",
                 due_date="2025-12-25T17:00:00",
                 flagged=True
@@ -1150,7 +1150,7 @@ class TestUpdateTask:
     def test_update_task_empty_id(self, client):
         """Test updating task with empty ID raises error."""
         with pytest.raises(ValueError) as exc_info:
-            client.update_task("", name="New Name")
+            client.update_task("", task_name="New Name")
         assert "task_id is required" in str(exc_info.value)
 
     def test_update_task_failure(self, client):
@@ -1158,7 +1158,7 @@ class TestUpdateTask:
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.return_value = "false: Task not found"
             # NEW API: Returns error dict instead of raising exception
-            result = client.update_task("invalid-id", name="New Name")
+            result = client.update_task("invalid-id", task_name="New Name")
             assert result["success"] is False
             assert "error" in result
 
@@ -1167,7 +1167,7 @@ class TestUpdateTask:
         with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_run:
             mock_run.side_effect = subprocess.CalledProcessError(1, 'osascript', stderr="error")
             # NEW API: Returns error dict instead of raising exception
-            result = client.update_task("task-001", name="New Name")
+            result = client.update_task("task-001", task_name="New Name")
             assert result["success"] is False
             assert "error" in result
 

--- a/tests/test_server_fastmcp.py
+++ b/tests/test_server_fastmcp.py
@@ -709,7 +709,7 @@ class TestHierarchyFieldFormatting:
             }
             mock_get_client.return_value = mock_client
 
-            result = update_task("task-001", name="New Name")
+            result = update_task("task-001", task_name="New Name")
 
             # Verify the client was called with flagged=None
             call_kwargs = mock_client.update_task.call_args.kwargs

--- a/tests/test_server_redesign_update.py
+++ b/tests/test_server_redesign_update.py
@@ -278,31 +278,6 @@ class TestUpdateTaskServerRedesign:
             # Response should mention what was updated
             assert "task_name" in result or "3 fields" in result or "updated" in result.lower()
 
-    # ========================================================================
-    # Backward Compatibility (Legacy Parameters)
-    # ========================================================================
-
-    def test_update_task_accepts_legacy_name_parameter(self):
-        """NEW API: Server still accepts legacy 'name' parameter for backward compat."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_task.return_value = {
-                "success": True,
-                "task_id": "task-001",
-                "updated_fields": ["task_name"],
-                "error": None
-            }
-            mock_get_client.return_value = mock_client
-
-            # Use legacy 'name' parameter
-            result = update_task("task-001", name="Legacy Name")
-
-            # Should still work
-            call_kwargs = mock_client.update_task.call_args.kwargs
-            assert call_kwargs.get("name") == "Legacy Name" or call_kwargs.get("task_name") == "Legacy Name"
-            assert "Successfully updated task" in result
-
-
 class TestUpdateTasksServerRedesign:
     """Tests for new update_tasks() MCP tool (batch operations).
 

--- a/tests/test_update_task_helpers.py
+++ b/tests/test_update_task_helpers.py
@@ -20,7 +20,7 @@ class TestValidateUpdateTaskParams:
 
     def _call(self, client, **overrides):
         defaults = dict(
-            task_id="t1", task_name=None, name=None,
+            task_id="t1", task_name=None,
             project_id=None, parent_task_id=None,
             tags=None, add_tags=None, remove_tags=None,
             status=None, repetition_method=None,
@@ -35,14 +35,6 @@ class TestValidateUpdateTaskParams:
     def test_empty_task_id_raises(self, client):
         with pytest.raises(ValueError, match="task_id is required"):
             self._call(client, task_id="", flagged=True)
-
-    def test_legacy_name_resolved(self, client):
-        task_name, _ = self._call(client, name="legacy", task_name=None, flagged=True)
-        assert task_name == "legacy"
-
-    def test_task_name_takes_precedence_over_name(self, client):
-        task_name, _ = self._call(client, name="legacy", task_name="new", flagged=True)
-        assert task_name == "new"
 
     def test_project_and_parent_conflict(self, client):
         with pytest.raises(ValueError, match="Cannot specify both"):


### PR DESCRIPTION
## Summary

Closes #476

Removed the deprecated `name` parameter from `update_task` in both the server and connector layers. All callers should use `task_name` instead. Cleans up the MCP schema — LLMs no longer see a confusing `name` alias alongside `task_name`.

- Removed from server signature + legacy handling block
- Removed from connector signature + legacy handling block  
- Removed from `_validate_update_task_params` signature
- Removed `'name' in kwargs` check from `_validate_update_tasks_params`
- Updated all tests using `name=` to `task_name=`
- Deleted legacy-specific tests (2 removed)

Net: -47 lines.

## Test plan

- [x] 890 tests passing (-3: removed legacy tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)