### PR TITLE
release: v0.11.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.10.5 | **Tests:** 895 unit, 158 integration/E2E, 26 benchmark/profiling | **Coverage:** 93%
+**Version:** v0.11.0 | **Tests:** 918 unit, 158 integration/E2E, 26 benchmark/profiling | **Coverage:** 93%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-03-22
+
+API quality release — driven by adversarial API review (#451). Standardized types, cleaned up descriptions, added new features, and improved documentation clarity for LLM clients.
+
+### Added
+
+- **`include_dropped` parameter on `get_projects()`** (#460, #481)
+  - Dropped projects were previously always filtered out; now retrievable for verification and audits
+
+- **Per-method AppleScript tell/end-tell balance tests** (#459, #486)
+  - 28 parametrized tests checking balance per connector method (tolerance 2)
+
+- **Dropped project state verification** (#438, #485)
+  - Integration test now verifies dropped status via read-back using include_dropped
+
+### Changed
+
+- **Standardized `sequential` parameter to `bool`** across all functions (#470, #478)
+  - `update_project` and `update_projects` accepted `str`; now `bool` everywhere
+
+- **Stripped development-history noise from docstrings** (#467, #480)
+  - Removed ~300 tokens of "NEW (Phase X.Y)", "Redesign", consolidation lists
+
+- **Removed legacy `name` parameter from `update_task`** (#476, #483)
+  - Use `task_name` instead; `name` alias no longer in the MCP schema
+
+- **Improved reorder descriptions** with worked-order examples (#472, #487)
+  - `reorder_task("C", before_task_id="A") → [..., C, A, ...]`
+
+- **Clarified `parent_tag` is by-name, not by-ID** (#474, #487)
+  - Cross-references between `get_tags()` output (parentTagId) and set operations
+
+- **Strengthened `status="dropped"` one-way warning** (#475, #487)
+
+### Fixed
+
+- **`get_projects` response text** now reflects active filter (#471, #479)
+  - Was always "Found N active projects" even with `on_hold_only=True`
+
 ## [0.10.5] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 ```bash
 git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
-git checkout v0.10.5  # Latest stable release
+git checkout v0.11.0  # Latest stable release
 
 # Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.10.5"
+version = "0.11.0"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.10.5"
+__version__ = "0.11.0"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Release v0.11.0

API quality release — driven by adversarial API review (#451).

### Changes (8 PRs)

**Added**
- `include_dropped` parameter on `get_projects()` (#460)
- Per-method AppleScript tell/end-tell balance tests (#459)
- Dropped project state verification via read-back (#438)

**Changed**
- Standardized `sequential` to `bool` everywhere (#470)
- Stripped dev-history noise from docstrings (#467)
- Removed legacy `name` parameter from `update_task` (#476)
- Improved reorder descriptions with worked-order examples (#472)
- Clarified `parent_tag` by-name vs by-ID (#474)
- Strengthened `status=dropped` one-way warning (#475)

**Fixed**
- `get_projects` response text reflects active filter (#471)

### Validation

- [x] Version sync
- [x] Client-server parity (23 functions)
- [x] Complexity check
- [x] Unit tests (918 passed)
- [x] Coverage (92.52%, threshold 90%)
- [x] Dependency audit
- [x] AppleScript safety audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)