### PR TITLE
feat: unified create_tasks with Pydantic model input

### DIFF
--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -4,6 +4,7 @@ import os
 from typing import Optional, Union
 
 from fastmcp import FastMCP
+from pydantic import BaseModel
 
 from .omnifocus_connector import OmniFocusConnector
 
@@ -766,6 +767,103 @@ def create_task(
 
     return result
 
+
+# ============================================================================
+# Unified Batch Create (v0.12.0)
+# ============================================================================
+
+
+class TaskCreate(BaseModel):
+    """Input model for creating a task."""
+    task_name: str
+    project_id: Optional[str] = None
+    parent_task_id: Optional[str] = None
+    note: Optional[str] = None
+    due_date: Optional[str] = None
+    defer_date: Optional[str] = None
+    planned_date: Optional[str] = None
+    flagged: bool = False
+    tags: Optional[list[str]] = None
+    estimated_minutes: Optional[int] = None
+    sequential: bool = False
+    completed_by_children: bool = False
+
+
+@mcp.tool()
+def create_tasks(tasks: list[TaskCreate]) -> str:
+    """Create one or more tasks in OmniFocus.
+
+    Pass a list of task objects. Each task must have a task_name; all other
+    fields are optional. For a single task, pass a list with one item.
+
+    Args:
+        tasks: List of task objects to create. Each object supports:
+            task_name (required), project_id, parent_task_id, note, due_date,
+            defer_date, planned_date, flagged, tags, estimated_minutes,
+            sequential, completed_by_children.
+
+    Returns:
+        For single task: success message with task ID.
+        For multiple tasks: summary with per-item results.
+
+    Examples:
+        create_tasks([{"task_name": "Buy groceries"}])
+        create_tasks([
+            {"task_name": "Task A", "project_id": "proj-1", "flagged": true},
+            {"task_name": "Task B", "tags": ["work"], "due_date": "2026-04-01"}
+        ])
+    """
+    client = get_client()
+    results = []
+
+    # Coerce dicts to TaskCreate (MCP protocol does this automatically,
+    # but direct Python calls from tests pass raw dicts)
+    tasks = [TaskCreate(**t) if isinstance(t, dict) else t for t in tasks]
+
+    for task in tasks:
+        try:
+            task_id = client.create_task(**task.model_dump())
+            results.append({
+                "task_name": task.task_name,
+                "task_id": task_id,
+                "success": True,
+            })
+        except (ValueError, Exception) as e:
+            results.append({
+                "task_name": task.task_name,
+                "success": False,
+                "error": str(e),
+            })
+
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    # Single task: match old create_task format
+    if len(tasks) == 1:
+        r = results[0]
+        if r["success"]:
+            task = tasks[0]
+            location = f"in project {task.project_id}" if task.project_id else \
+                       f"as subtask of {task.parent_task_id}" if task.parent_task_id else \
+                       "in inbox"
+            result = f"Successfully created task '{task.task_name}' {location}\nTask ID: {r['task_id']}"
+            if task.due_date:
+                result += f"\nDue date: {task.due_date}"
+            if task.flagged:
+                result += "\nFlagged: Yes"
+            if task.tags:
+                result += f"\nTags: {', '.join(task.tags)}"
+            return result
+        else:
+            return f"Error: {r['error']}"
+
+    # Multiple tasks: summary
+    lines = [f"Created {len(succeeded)} of {len(tasks)} tasks:"]
+    for r in succeeded:
+        lines.append(f"  - {r['task_name']}: {r['task_id']}")
+    for r in failed:
+        lines.append(f"  - {r['task_name']}: FAILED — {r['error']}")
+    return "\n".join(lines)
 
 
 @mcp.tool()

--- a/tests/test_server_redesign_create.py
+++ b/tests/test_server_redesign_create.py
@@ -204,6 +204,97 @@ class TestCreateTaskServerRedesign:
             assert len(result) > len("task-new-id")
 
 
+class TestCreateTasksUnified:
+    """Tests for unified create_tasks() with Pydantic model input."""
+
+    def test_create_tasks_single_item(self):
+        """create_tasks with a single task returns same format as create_task."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_task.return_value = "task-001"
+            mock_get_client.return_value = mock_client
+
+            create_tasks = server.create_tasks
+            result = create_tasks(tasks=[{"task_name": "Test Task", "project_id": "proj-1"}])
+
+            assert isinstance(result, str)
+            assert "task-001" in result
+            assert "Successfully" in result
+            mock_client.create_task.assert_called_once()
+            call_kwargs = mock_client.create_task.call_args[1]
+            assert call_kwargs["task_name"] == "Test Task"
+            assert call_kwargs["project_id"] == "proj-1"
+
+    def test_create_tasks_multiple_items(self):
+        """create_tasks with multiple tasks returns summary."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_task.side_effect = ["task-001", "task-002", "task-003"]
+            mock_get_client.return_value = mock_client
+
+            create_tasks = server.create_tasks
+            result = create_tasks(tasks=[
+                {"task_name": "Task A"},
+                {"task_name": "Task B", "flagged": True},
+                {"task_name": "Task C", "tags": ["work"]},
+            ])
+
+            assert isinstance(result, str)
+            assert "3" in result
+            assert mock_client.create_task.call_count == 3
+
+    def test_create_tasks_partial_failure(self):
+        """create_tasks with one failure returns mixed results."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_task.side_effect = [
+                "task-001",
+                ValueError("Both project_id and parent_task_id"),
+                "task-003",
+            ]
+            mock_get_client.return_value = mock_client
+
+            create_tasks = server.create_tasks
+            result = create_tasks(tasks=[
+                {"task_name": "Good Task"},
+                {"task_name": "Bad Task", "project_id": "p1", "parent_task_id": "t1"},
+                {"task_name": "Also Good"},
+            ])
+
+            assert isinstance(result, str)
+            assert "2" in result  # 2 succeeded
+            assert "1" in result  # 1 failed
+            assert "Bad Task" in result or "failed" in result.lower()
+
+    def test_create_tasks_with_all_fields(self):
+        """create_tasks passes all fields through to connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_task.return_value = "task-001"
+            mock_get_client.return_value = mock_client
+
+            create_tasks = server.create_tasks
+            result = create_tasks(tasks=[{
+                "task_name": "Full Task",
+                "project_id": "proj-1",
+                "note": "A note",
+                "due_date": "2026-04-01",
+                "defer_date": "2026-03-25",
+                "planned_date": "2026-03-28",
+                "flagged": True,
+                "tags": ["work", "urgent"],
+                "estimated_minutes": 30,
+                "sequential": True,
+                "completed_by_children": True,
+            }])
+
+            call_kwargs = mock_client.create_task.call_args[1]
+            assert call_kwargs["task_name"] == "Full Task"
+            assert call_kwargs["flagged"] is True
+            assert call_kwargs["tags"] == ["work", "urgent"]
+            assert call_kwargs["estimated_minutes"] == 30
+
+
 class TestCreateProjectServerRedesign:
     """Tests for create_project() MCP tool ValueError handling."""
 


### PR DESCRIPTION
## Summary

Closes #489

New `create_tasks(tasks: list[TaskCreate])` function that accepts a list of task objects with per-item values. Single item = list of 1.

- `TaskCreate` is a Pydantic BaseModel generating clean MCP JSON schemas
- Single task returns same human-readable format as old `create_task`
- Multiple tasks returns summary with per-item results (including partial failures)
- Old `create_task` stays for backward compatibility (#491 handles deprecation)
- Dict inputs are coerced to `TaskCreate` for direct Python calls

## Test plan

- [x] 922 tests passing (4 new)
- [x] Old create_task tests still pass (backward compat)
- [x] Client-server parity check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)