### PR TITLE
feat: unified update_tasks with per-item values via Pydantic model

### DIFF
--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -724,6 +724,29 @@ class TaskCreate(BaseModel):
     completed_by_children: bool = False
 
 
+class TaskUpdate(BaseModel):
+    """Input model for updating a task."""
+    id: str
+    task_name: Optional[str] = None
+    project_id: Optional[str] = None
+    parent_task_id: Optional[str] = None
+    note: Optional[str] = None
+    due_date: Optional[str] = None
+    defer_date: Optional[str] = None
+    planned_date: Optional[str] = None
+    flagged: Optional[bool] = None
+    tags: Optional[list[str]] = None
+    add_tags: Optional[list[str]] = None
+    remove_tags: Optional[list[str]] = None
+    estimated_minutes: Optional[int] = None
+    completed: Optional[bool] = None
+    status: Optional[str] = None
+    recurrence: Optional[str] = None
+    repetition_method: Optional[str] = None
+    sequential: Optional[bool] = None
+    completed_by_children: Optional[bool] = None
+
+
 @mcp.tool()
 def create_tasks(tasks: list[TaskCreate]) -> str:
     """Create one or more tasks in OmniFocus.
@@ -826,203 +849,120 @@ def update_task(
     sequential: Optional[bool] = None,
     completed_by_children: Optional[bool] = None,
 ) -> str:
-    """Update an existing task in OmniFocus.
+    """DEPRECATED: Use update_tasks instead. Update a single task in OmniFocus.
+
+    Delegates to update_tasks with a single-item list.
 
     Args:
         task_id: The ID of the task to update
         task_name: New task name (optional)
-        project_id: Move task to this project (optional). Mutually exclusive with
-            parent_task_id — a subtask inherits its parent's project.
-        parent_task_id: Make task a subtask of this parent (optional). Mutually exclusive
-            with project_id — a subtask inherits its parent's project.
-        note: New note content (optional). WARNING: Removes rich text formatting
-        due_date: New due date in ISO 8601 format, or empty string to clear.
-            Omitting means no change. (optional)
-        defer_date: New defer date in ISO 8601 format (when task becomes available), or
-            empty string to clear. Omitting means no change. (optional)
-        planned_date: Planned date in ISO 8601 format, or empty string to clear.
-            When you plan to work on the task — purely a scheduling signal, no behavioral
-            constraints (unlike defer/due). Omitting means no change. (optional)
-        flagged: Flag marks a task as a priority — typically 'I want to work on this today.'
-            Pass True to flag, False to unflag. (optional)
-        tags: Full replacement — set exact tag list as a native list (optional, conflicts
-            with add_tags/remove_tags).
-        add_tags: Add these tags incrementally (optional, conflicts with tags)
-        remove_tags: Remove these tags (optional, conflicts with tags)
+        project_id: Move task to this project (optional)
+        parent_task_id: Make task a subtask of this parent (optional)
+        note: New note content (optional)
+        due_date: New due date in ISO 8601 format, or empty string to clear (optional)
+        defer_date: New defer date in ISO 8601 format, or empty string to clear (optional)
+        planned_date: Planned date in ISO 8601 format, or empty string to clear (optional)
+        flagged: Flag/unflag the task (optional)
+        tags: Full replacement tag list (optional)
+        add_tags: Add these tags incrementally (optional)
+        remove_tags: Remove these tags (optional)
         estimated_minutes: Estimated time in minutes (optional)
-        completed: Mark task complete/incomplete (optional). Uses `mark complete` internally,
-            which correctly handles recurring tasks by spawning the next occurrence.
-        status: Task status — "active" or "dropped" (optional). WARNING: Dropping is
-            one-way via the API — dropped tasks cannot be undropped through automation,
-            only through the OmniFocus UI. To drop an entire recurring series (not just
-            the current occurrence), pass both recurrence="" and status="dropped".
-        recurrence: iCalendar RRULE string (e.g., "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"),
-            or empty string to remove recurrence. Omitting means no change. (optional)
-        repetition_method: How the next occurrence is calculated (optional). Only meaningful
-            when recurrence is set. Values: "fixed" (next occurrence on the original schedule
-            regardless of when completed), "start_after_completion" (next defer date =
-            completion date + interval), "due_after_completion" (next due date = completion
-            date + interval). Use due_after_completion when you want the deadline to shift
-            based on completion; use start_after_completion when you want the availability
-            window (defer date) to shift instead.
-        sequential: If True, subtasks of this task (action group) must be completed in order.
-            If False, subtasks are parallel (all available). Omitting means no change. (optional)
-        completed_by_children: If True, this task (action group) is automatically marked complete
-            when all its subtasks are completed. If False, requires manual completion. Omitting
-            means no change. (optional)
-        name: DEPRECATED - Use task_name instead (optional, for backward compatibility)
+        completed: Mark task complete/incomplete (optional)
+        status: Task status — "active" or "dropped" (optional)
+        recurrence: iCalendar RRULE string, or empty string to remove (optional)
+        repetition_method: "fixed", "start_after_completion", or "due_after_completion" (optional)
+        sequential: If True, subtasks must be completed in order (optional)
+        completed_by_children: If True, auto-complete when subtasks done (optional)
 
     Returns:
         Success message with updated fields, or error message
-
-    Examples:
-        update_task("task-123", completed=True)  # Mark complete
-        update_task("task-123", status="dropped")  # Drop task
-        update_task("task-123", project_id="proj-456")  # Move to project
-        update_task("task-123", add_tags=["urgent"])  # Add tag
-        update_task("task-123", task_name="New Name", flagged=True, due_date="2025-12-31")
-        update_task("task-123", recurrence="FREQ=WEEKLY;BYDAY=MO,WE,FR", repetition_method="fixed")
-        update_task("task-123", recurrence="")  # Remove recurrence
-        update_task("task-123", recurrence="", status="dropped")  # Drop entire recurring series
     """
-    client = get_client()
-    try:
-        result = client.update_task(
-            task_id=task_id,
-            task_name=task_name,
-            project_id=project_id,
-            parent_task_id=parent_task_id,
-            note=note,
-            due_date=due_date,
-            defer_date=defer_date,
-            planned_date=planned_date,
-            flagged=flagged,
-            tags=tags,
-            add_tags=add_tags,
-            remove_tags=remove_tags,
-            estimated_minutes=estimated_minutes,
-            completed=completed,
-            status=status,
-            recurrence=recurrence,
-            repetition_method=repetition_method,
-            sequential=sequential,
-            completed_by_children=completed_by_children,
-        )
-    except ValueError as e:
-        return f"Error: {str(e)}"
-
-    # Handle dict return from client (NEW API)
-    if result["success"]:
-        fields = result["updated_fields"]
-        if len(fields) == 0:
-            return f"Successfully updated task {task_id} (no changes detected)"
-        elif len(fields) == 1:
-            return f"Successfully updated task {task_id}: {fields[0]}"
-        else:
-            fields_str = ", ".join(fields)
-            return f"Successfully updated task {task_id}: {fields_str}"
-    else:
-        error_msg = result.get("error", "Unknown error")
-        return f"Error updating task {task_id}: {error_msg}"
+    # Build task dict from non-None params
+    params = locals()
+    task_dict = {"id": params.pop("task_id")}
+    for k, v in params.items():
+        if v is not None:
+            task_dict[k] = v
+    return update_tasks(tasks=[task_dict])
 
 
 @mcp.tool()
-def update_tasks(
-    task_ids: Union[str, list[str]],
-    flagged: Optional[bool] = None,
-    status: Optional[str] = None,
-    completed: Optional[bool] = None,
-    project_id: Optional[str] = None,
-    parent_task_id: Optional[str] = None,
-    tags: Optional[list[str]] = None,
-    add_tags: Optional[list[str]] = None,
-    remove_tags: Optional[list[str]] = None,
-    due_date: Optional[str] = None,
-    defer_date: Optional[str] = None,
-    planned_date: Optional[str] = None,
-    estimated_minutes: Optional[int] = None
-) -> str:
-    """Update multiple tasks with the same field values.
+def update_tasks(tasks: list[TaskUpdate]) -> str:
+    """Update one or more tasks in OmniFocus.
 
-    This is the batch version of update_task(). It applies uniform changes to
-    multiple tasks simultaneously.
-
-    Key differences from update_task():
-    - Accepts Union[str, list[str]] for task_ids (single or multiple)
-    - Does NOT accept task_name or note (require unique values per task)
-    - Returns count-based summary instead of single success/failure
-    - Continues processing when individual tasks fail
+    Pass a list of task update objects. Each must have an id field.
+    Only the specified fields will be updated — omitted fields are unchanged.
 
     Args:
-        task_ids: Single task ID (str) or list of task IDs to update
-        flagged: Flag/unflag all tasks (optional)
-        status: Set status for all tasks - "active" or "dropped" (optional)
-        completed: Mark all tasks complete/incomplete (optional)
-        project_id: Move all tasks to this project (optional). Mutually exclusive with
-            parent_task_id — a subtask inherits its parent's project.
-        parent_task_id: Make all tasks subtasks of this parent (optional). Mutually exclusive
-            with project_id — a subtask inherits its parent's project.
-        tags: Full replacement - set exact tag list for all tasks (optional, conflicts with add_tags)
-        add_tags: Add these tags to all tasks (optional, conflicts with tags)
-        remove_tags: Remove these tags from all tasks (optional)
-        due_date: Set due date for all tasks in ISO 8601 format, or empty string to clear.
-            Omitting means no change. (optional)
-        defer_date: Set defer date for all tasks in ISO 8601 format, or empty string to clear.
-            Omitting means no change. (optional)
-        planned_date: Set planned date for all tasks in ISO 8601 format, or empty string to clear.
-            When you plan to work on the tasks — purely a scheduling signal. (optional)
-        estimated_minutes: Set estimated time in minutes for all tasks (optional)
+        tasks: List of task update objects. Each must have:
+            id (required), plus any fields to update: task_name, project_id,
+            parent_task_id, note, due_date, defer_date, planned_date, flagged,
+            tags, add_tags, remove_tags, estimated_minutes, completed, status,
+            recurrence, repetition_method, sequential, completed_by_children.
 
     Returns:
-        Summary message with counts of successful/failed updates
+        For single task: success message with updated fields.
+        For multiple tasks: summary with per-item results.
 
     Examples:
-        update_tasks(["task-001", "task-002"], flagged=True)  # Flag multiple tasks
-        update_tasks("task-123", completed=True)  # Complete single task (Union type)
-        update_tasks(["task-001", "task-002", "task-003"], status="dropped")  # Drop multiple
+        update_tasks([{"id": "t1", "flagged": true}])
+        update_tasks([
+            {"id": "t1", "flagged": true},
+            {"id": "t2", "task_name": "Renamed", "due_date": "2026-04-01"}
+        ])
     """
     client = get_client()
+
+    # Coerce dicts to TaskUpdate
     try:
-        result = client.update_tasks(
-            task_ids=task_ids,
-            flagged=flagged,
-            status=status,
-            completed=completed,
-            project_id=project_id,
-            parent_task_id=parent_task_id,
-            tags=tags,
-            add_tags=add_tags,
-            remove_tags=remove_tags,
-            due_date=due_date,
-            defer_date=defer_date,
-            planned_date=planned_date,
-            estimated_minutes=estimated_minutes
-        )
-    except ValueError as e:
-        return f"Error: {str(e)}"
+        tasks = [TaskUpdate(**t) if isinstance(t, dict) else t for t in tasks]
+    except Exception as e:
+        return f"Error: Invalid task input: {e}"
 
-    # Handle dict return with counts
-    updated_count = result["updated_count"]
-    failed_count = result["failed_count"]
+    results = []
+    for task in tasks:
+        try:
+            # Build kwargs, excluding None values and the id field
+            kwargs = task.model_dump(exclude_none=True, exclude={"id"})
+            result = client.update_task(task_id=task.id, **kwargs)
+            results.append({
+                "id": task.id,
+                "success": result["success"],
+                "updated_fields": result.get("updated_fields", []),
+                "error": result.get("error"),
+            })
+        except (ValueError, Exception) as e:
+            results.append({
+                "id": task.id,
+                "success": False,
+                "updated_fields": [],
+                "error": str(e),
+            })
 
-    # Build response message
-    if failed_count == 0:
-        # All succeeded
-        if updated_count == 1:
-            return f"Successfully updated 1 task"
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    # Single task: match old update_task format
+    if len(tasks) == 1:
+        r = results[0]
+        if r["success"]:
+            fields = r["updated_fields"]
+            if len(fields) == 0:
+                return f"Successfully updated task {r['id']} (no changes detected)"
+            elif len(fields) == 1:
+                return f"Successfully updated task {r['id']}: {fields[0]}"
+            else:
+                return f"Successfully updated task {r['id']}: {', '.join(fields)}"
         else:
-            return f"Successfully updated {updated_count} tasks"
-    elif updated_count == 0:
-        # All failed
-        failures = result.get("failures", [])
-        if len(failures) == 1:
-            error = failures[0].get("error", "Unknown error")
-            return f"Failed to update task: {error}"
-        else:
-            return f"Failed to update all {failed_count} tasks"
-    else:
-        # Partial success
-        return f"Updated {updated_count} tasks successfully, {failed_count} failed"
+            return f"Error updating task {r['id']}: {r['error']}"
+
+    # Multiple tasks: summary
+    lines = [f"Updated {len(succeeded)} of {len(tasks)} tasks:"]
+    for r in succeeded:
+        lines.append(f"  - {r['id']}: {', '.join(r['updated_fields'])}")
+    for r in failed:
+        lines.append(f"  - {r['id']}: FAILED — {r['error']}")
+    return "\n".join(lines)
 
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -261,16 +261,17 @@ class TestUpdateTasksEdgeCases:
 
     @mock.patch("omnifocus_mcp.server_fastmcp.get_client")
     def test_single_failure(self, mock_gc):
-        mock_gc.return_value.update_tasks.return_value = {
-            "updated_count": 0,
-            "failed_count": 1,
-            "failures": [{"task_id": "t1", "error": "not found"}],
+        mock_gc.return_value.update_task.return_value = {
+            "success": False,
+            "task_id": "t1",
+            "updated_fields": [],
+            "error": "not found",
         }
-        result = server.update_tasks(task_ids="t1", flagged=True)
-        assert "Failed to update task: not found" in result
-        mock_gc.return_value.update_tasks.assert_called_once()
-        call_kwargs = mock_gc.return_value.update_tasks.call_args[1]
-        assert call_kwargs["task_ids"] == "t1"
+        result = server.update_tasks([{"id": "t1", "flagged": True}])
+        assert "Error updating task t1: not found" in result
+        mock_gc.return_value.update_task.assert_called_once()
+        call_kwargs = mock_gc.return_value.update_task.call_args.kwargs
+        assert call_kwargs["task_id"] == "t1"
         assert call_kwargs["flagged"] is True
 
 

--- a/tests/test_server_fastmcp.py
+++ b/tests/test_server_fastmcp.py
@@ -711,9 +711,9 @@ class TestHierarchyFieldFormatting:
 
             result = update_task("task-001", task_name="New Name")
 
-            # Verify the client was called with flagged=None
+            # Verify the client was called without flagged (excluded as None)
             call_kwargs = mock_client.update_task.call_args.kwargs
-            assert call_kwargs["flagged"] is None
+            assert "flagged" not in call_kwargs
             assert "Successfully updated task" in result
 
     def test_update_project_sequential_with_string_true(self):

--- a/tests/test_server_redesign_update.py
+++ b/tests/test_server_redesign_update.py
@@ -12,6 +12,7 @@ import omnifocus_mcp.server_fastmcp as server
 # Extract tool functions (FastMCP @mcp.tool() returns the function directly)
 update_task = server.update_task
 update_tasks = server.update_tasks
+TaskUpdate = server.TaskUpdate
 
 
 class TestUpdateTaskServerRedesign:
@@ -279,171 +280,164 @@ class TestUpdateTaskServerRedesign:
             assert "task_name" in result or "3 fields" in result or "updated" in result.lower()
 
 class TestUpdateTasksServerRedesign:
-    """Tests for new update_tasks() MCP tool (batch operations).
+    """Tests for update_tasks() MCP tool (batch operations via unified API).
 
-    The new server tool should:
-    - Accept Union[str, list[str]] for task_ids
-    - Pass all parameters to client.update_tasks()
-    - Handle dict return with counts
-    - Return structured response showing updated_count and failures
+    The unified update_tasks accepts list[TaskUpdate] and iterates over them,
+    calling client.update_task for each item individually.
     """
 
     # ========================================================================
-    # Union Type Handling
+    # Batch with Uniform Values (replaces old update_tasks API)
     # ========================================================================
 
-    def test_update_tasks_with_single_id_string(self):
-        """NEW API: Server handles single task ID as string."""
+    def test_update_tasks_single_id_via_list(self):
+        """Unified API: Single task update via list with one item."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 1,
-                "failed_count": 0,
-                "updated_ids": ["task-001"],
-                "failures": []
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "task-001",
+                "updated_fields": ["flagged"],
+                "error": None,
             }
             mock_get_client.return_value = mock_client
 
-            result = update_tasks("task-001", flagged=True)
+            result = update_tasks([{"id": "task-001", "flagged": True}])
 
-            # Verify client was called
-            mock_client.update_tasks.assert_called_once()
-            call_kwargs = mock_client.update_tasks.call_args.kwargs
-            assert call_kwargs["task_ids"] == "task-001"
+            mock_client.update_task.assert_called_once()
+            call_kwargs = mock_client.update_task.call_args.kwargs
+            assert call_kwargs["task_id"] == "task-001"
             assert call_kwargs["flagged"] is True
+            assert "Successfully" in result
 
-            # Verify response
-            assert "1 task" in result or "Successfully" in result
-
-    def test_update_tasks_with_list_of_ids(self):
-        """NEW API: Server handles list of task IDs."""
+    def test_update_tasks_multiple_ids_same_value(self):
+        """Unified API: Multiple tasks with same flagged value."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 3,
-                "failed_count": 0,
-                "updated_ids": ["task-001", "task-002", "task-003"],
-                "failures": []
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "any",
+                "updated_fields": ["flagged"],
+                "error": None,
             }
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(["task-001", "task-002", "task-003"], flagged=True)
+            result = update_tasks([
+                {"id": "task-001", "flagged": True},
+                {"id": "task-002", "flagged": True},
+                {"id": "task-003", "flagged": True},
+            ])
 
-            call_kwargs = mock_client.update_tasks.call_args.kwargs
-            assert call_kwargs["task_ids"] == ["task-001", "task-002", "task-003"]
-            assert "3 tasks" in result
+            assert mock_client.update_task.call_count == 3
+            assert "3 of 3 tasks" in result
 
-    # ========================================================================
-    # Batch Operations
-    # ========================================================================
-
-    def test_update_tasks_with_flagged(self):
-        """NEW API: Server handles flagged parameter for batch update."""
+    def test_update_tasks_batch_with_flagged(self):
+        """Unified API: Flagged parameter passed through for each task."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 2,
-                "failed_count": 0,
-                "updated_ids": ["task-001", "task-002"],
-                "failures": []
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "any",
+                "updated_fields": ["flagged"],
+                "error": None,
             }
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(["task-001", "task-002"], flagged=True)
+            result = update_tasks([
+                {"id": "task-001", "flagged": True},
+                {"id": "task-002", "flagged": True},
+            ])
 
-            call_kwargs = mock_client.update_tasks.call_args.kwargs
-            assert call_kwargs["flagged"] is True
-            assert "2 tasks" in result
+            for call in mock_client.update_task.call_args_list:
+                assert call.kwargs["flagged"] is True
+            assert "2 of 2 tasks" in result
 
-    def test_update_tasks_with_completed(self):
-        """NEW API: Server handles completed parameter for batch update."""
+    def test_update_tasks_batch_with_completed(self):
+        """Unified API: Completed parameter for batch update."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 3,
-                "failed_count": 0,
-                "updated_ids": ["task-001", "task-002", "task-003"],
-                "failures": []
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "any",
+                "updated_fields": ["completed"],
+                "error": None,
             }
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(
-                ["task-001", "task-002", "task-003"],
-                completed=True
-            )
+            result = update_tasks([
+                {"id": "task-001", "completed": True},
+                {"id": "task-002", "completed": True},
+                {"id": "task-003", "completed": True},
+            ])
 
-            call_kwargs = mock_client.update_tasks.call_args.kwargs
-            assert call_kwargs["completed"] is True
-            assert "3 tasks" in result
+            for call in mock_client.update_task.call_args_list:
+                assert call.kwargs["completed"] is True
+            assert "3 of 3 tasks" in result
 
     # ========================================================================
     # Return Format and Error Handling
     # ========================================================================
 
     def test_update_tasks_shows_success_count(self):
-        """NEW API: Server response includes success count."""
+        """Unified API: Response includes success count for multiple tasks."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 5,
-                "failed_count": 0,
-                "updated_ids": ["task-001", "task-002", "task-003", "task-004", "task-005"],
-                "failures": []
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "any",
+                "updated_fields": ["flagged"],
+                "error": None,
             }
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(
-                ["task-001", "task-002", "task-003", "task-004", "task-005"],
-                flagged=True
-            )
+            result = update_tasks([
+                {"id": f"task-{i:03d}", "flagged": True} for i in range(5)
+            ])
 
-            assert "5" in result or "5 tasks" in result
+            assert "5 of 5 tasks" in result
 
     def test_update_tasks_handles_partial_failures(self):
-        """NEW API: Server shows both successes and failures."""
+        """Unified API: Shows both successes and failures."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 2,
-                "failed_count": 1,
-                "updated_ids": ["task-001", "task-002"],
-                "failures": [
-                    {"task_id": "task-invalid", "error": "Task not found"}
-                ]
-            }
+            mock_client.update_task.side_effect = [
+                {"success": True, "task_id": "task-001", "updated_fields": ["flagged"], "error": None},
+                {"success": True, "task_id": "task-002", "updated_fields": ["flagged"], "error": None},
+                {"success": False, "task_id": "task-invalid", "updated_fields": [], "error": "Task not found"},
+            ]
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(
-                ["task-001", "task-002", "task-invalid"],
-                flagged=True
-            )
+            result = update_tasks([
+                {"id": "task-001", "flagged": True},
+                {"id": "task-002", "flagged": True},
+                {"id": "task-invalid", "flagged": True},
+            ])
 
-            # Should mention both successes and failures
-            assert "2" in result  # updated count
-            assert "1" in result or "failed" in result.lower()
+            assert "2 of 3 tasks" in result
+            assert "FAILED" in result
 
     def test_update_tasks_handles_all_failures(self):
-        """NEW API: Server handles case where all tasks fail."""
+        """Unified API: Handles case where all tasks fail."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.return_value = {
-                "updated_count": 0,
-                "failed_count": 2,
-                "updated_ids": [],
-                "failures": [
-                    {"task_id": "task-001", "error": "Task not found"},
-                    {"task_id": "task-002", "error": "Task not found"}
-                ]
+            mock_client.update_task.return_value = {
+                "success": False,
+                "task_id": "any",
+                "updated_fields": [],
+                "error": "Task not found",
             }
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(["task-001", "task-002"], flagged=True)
+            result = update_tasks([
+                {"id": "task-001", "flagged": True},
+                {"id": "task-002", "flagged": True},
+            ])
 
-            assert "failed" in result.lower() or "Failed" in result
-            assert "2" in result  # 2 failed
+            assert "FAILED" in result
+            assert "0 of 2 tasks" in result
 
     def test_update_task_handles_value_error(self):
-        """Server: update_task() catches ValueError and returns error string."""
+        """Server: update_task() catches ValueError via update_tasks delegation."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
             mock_client.update_task.side_effect = ValueError("Empty task_id")
@@ -457,9 +451,341 @@ class TestUpdateTasksServerRedesign:
         """Server: update_tasks() catches ValueError and returns error string."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_tasks.side_effect = ValueError("task_name is not allowed")
+            mock_client.update_task.side_effect = ValueError("Invalid task")
             mock_get_client.return_value = mock_client
 
-            result = update_tasks(["task-001"], flagged=True)
+            result = update_tasks([{"id": "task-001", "flagged": True}])
             assert isinstance(result, str)
             assert "error" in result.lower()
+
+
+class TestUpdateTasksUnified:
+    """Tests for unified update_tasks() with Pydantic TaskUpdate model (#492).
+
+    The new update_tasks accepts list[TaskUpdate], where each item can have
+    different fields. This replaces both update_task (single) and the old
+    update_tasks (batch with uniform values).
+    """
+
+    # ========================================================================
+    # TaskUpdate Model
+    # ========================================================================
+
+    def test_task_update_model_requires_id(self):
+        """TaskUpdate model requires id field."""
+        with pytest.raises(Exception):
+            TaskUpdate(flagged=True)  # Missing id
+
+    def test_task_update_model_defaults_to_none(self):
+        """TaskUpdate model defaults all optional fields to None."""
+        task = TaskUpdate(id="t1")
+        assert task.id == "t1"
+        assert task.task_name is None
+        assert task.flagged is None
+        assert task.due_date is None
+        assert task.tags is None
+
+    def test_task_update_model_dump_exclude_none(self):
+        """model_dump(exclude_none=True) excludes unset fields but keeps False/0."""
+        task = TaskUpdate(id="t1", flagged=False, estimated_minutes=0)
+        dumped = task.model_dump(exclude_none=True, exclude={"id"})
+        assert dumped == {"flagged": False, "estimated_minutes": 0}
+
+    # ========================================================================
+    # Single Task Update (via list with one item)
+    # ========================================================================
+
+    def test_update_tasks_single_item(self):
+        """Unified update_tasks with single item delegates to client.update_task."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "t1",
+                "updated_fields": ["flagged"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{"id": "t1", "flagged": True}])
+
+            mock_client.update_task.assert_called_once()
+            call_kwargs = mock_client.update_task.call_args.kwargs
+            assert call_kwargs["task_id"] == "t1"
+            assert call_kwargs["flagged"] is True
+            assert "Successfully updated task t1" in result
+            assert "flagged" in result
+
+    def test_update_tasks_single_item_no_changes(self):
+        """Single item with no changes detected."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "t1",
+                "updated_fields": [],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{"id": "t1", "flagged": True}])
+            assert "no changes detected" in result
+
+    def test_update_tasks_single_item_error(self):
+        """Single item error returns error message."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": False,
+                "task_id": "t1",
+                "updated_fields": [],
+                "error": "Task not found",
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{"id": "t1", "flagged": True}])
+            assert "Error updating task t1" in result
+            assert "Task not found" in result
+
+    # ========================================================================
+    # Multiple Tasks with Different Fields
+    # ========================================================================
+
+    def test_update_tasks_multiple_items_different_fields(self):
+        """Multiple items, each with different fields."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.side_effect = [
+                {
+                    "success": True,
+                    "task_id": "t1",
+                    "updated_fields": ["flagged"],
+                    "error": None,
+                },
+                {
+                    "success": True,
+                    "task_id": "t2",
+                    "updated_fields": ["task_name", "due_date"],
+                    "error": None,
+                },
+            ]
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([
+                {"id": "t1", "flagged": True},
+                {"id": "t2", "task_name": "Renamed", "due_date": "2026-04-01"},
+            ])
+
+            assert mock_client.update_task.call_count == 2
+            # First call: flagged only
+            call1 = mock_client.update_task.call_args_list[0].kwargs
+            assert call1["task_id"] == "t1"
+            assert call1["flagged"] is True
+            assert "task_name" not in call1
+            # Second call: task_name + due_date
+            call2 = mock_client.update_task.call_args_list[1].kwargs
+            assert call2["task_id"] == "t2"
+            assert call2["task_name"] == "Renamed"
+            assert call2["due_date"] == "2026-04-01"
+
+            assert "Updated 2 of 2 tasks" in result
+
+    def test_update_tasks_partial_failure(self):
+        """One succeeds, one fails — summary includes both."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.side_effect = [
+                {
+                    "success": True,
+                    "task_id": "t1",
+                    "updated_fields": ["flagged"],
+                    "error": None,
+                },
+                {
+                    "success": False,
+                    "task_id": "t2",
+                    "updated_fields": [],
+                    "error": "Task not found",
+                },
+            ]
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([
+                {"id": "t1", "flagged": True},
+                {"id": "t2", "flagged": True},
+            ])
+
+            assert "Updated 1 of 2 tasks" in result
+            assert "t1" in result
+            assert "FAILED" in result
+            assert "Task not found" in result
+
+    def test_update_tasks_with_exception(self):
+        """Client raises exception for one task — caught and reported."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.side_effect = [
+                {
+                    "success": True,
+                    "task_id": "t1",
+                    "updated_fields": ["flagged"],
+                    "error": None,
+                },
+                ValueError("Invalid task_id"),
+            ]
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([
+                {"id": "t1", "flagged": True},
+                {"id": "t2", "completed": True},
+            ])
+
+            assert "Updated 1 of 2 tasks" in result
+            assert "FAILED" in result
+            assert "Invalid task_id" in result
+
+    # ========================================================================
+    # All Fields Passed Through
+    # ========================================================================
+
+    def test_update_tasks_with_all_fields(self):
+        """Verify all TaskUpdate fields are passed through to client."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "t1",
+                "updated_fields": ["task_name", "flagged"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{
+                "id": "t1",
+                "task_name": "New Name",
+                "project_id": "proj-1",
+                "parent_task_id": "parent-1",
+                "note": "A note",
+                "due_date": "2026-04-01",
+                "defer_date": "2026-03-25",
+                "planned_date": "2026-03-26",
+                "flagged": True,
+                "tags": ["work"],
+                "add_tags": ["urgent"],
+                "remove_tags": ["old"],
+                "estimated_minutes": 30,
+                "completed": False,
+                "status": "active",
+                "recurrence": "FREQ=WEEKLY",
+                "repetition_method": "fixed",
+                "sequential": True,
+                "completed_by_children": True,
+            }])
+
+            call_kwargs = mock_client.update_task.call_args.kwargs
+            assert call_kwargs["task_id"] == "t1"
+            assert call_kwargs["task_name"] == "New Name"
+            assert call_kwargs["project_id"] == "proj-1"
+            assert call_kwargs["parent_task_id"] == "parent-1"
+            assert call_kwargs["note"] == "A note"
+            assert call_kwargs["due_date"] == "2026-04-01"
+            assert call_kwargs["defer_date"] == "2026-03-25"
+            assert call_kwargs["planned_date"] == "2026-03-26"
+            assert call_kwargs["flagged"] is True
+            assert call_kwargs["tags"] == ["work"]
+            assert call_kwargs["add_tags"] == ["urgent"]
+            assert call_kwargs["remove_tags"] == ["old"]
+            assert call_kwargs["estimated_minutes"] == 30
+            assert call_kwargs["completed"] is False
+            assert call_kwargs["status"] == "active"
+            assert call_kwargs["recurrence"] == "FREQ=WEEKLY"
+            assert call_kwargs["repetition_method"] == "fixed"
+            assert call_kwargs["sequential"] is True
+            assert call_kwargs["completed_by_children"] is True
+
+    def test_update_tasks_excludes_none_fields(self):
+        """Fields not set by user (None) should not be passed to client."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "t1",
+                "updated_fields": ["flagged"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{"id": "t1", "flagged": True}])
+
+            call_kwargs = mock_client.update_task.call_args.kwargs
+            # Only task_id and flagged should be present
+            assert set(call_kwargs.keys()) == {"task_id", "flagged"}
+
+    def test_update_tasks_keeps_false_and_zero(self):
+        """False and 0 values should be passed through (not treated as None)."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "t1",
+                "updated_fields": ["flagged", "estimated_minutes"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{"id": "t1", "flagged": False, "estimated_minutes": 0}])
+
+            call_kwargs = mock_client.update_task.call_args.kwargs
+            assert call_kwargs["flagged"] is False
+            assert call_kwargs["estimated_minutes"] == 0
+
+    # ========================================================================
+    # Invalid Input
+    # ========================================================================
+
+    def test_update_tasks_invalid_input(self):
+        """Invalid dict (missing id) returns error."""
+        result = update_tasks([{"flagged": True}])
+        assert "Error" in result
+
+    def test_update_tasks_with_pydantic_objects(self):
+        """TaskUpdate objects (not just dicts) are accepted."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "t1",
+                "updated_fields": ["flagged"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            task = TaskUpdate(id="t1", flagged=True)
+            result = update_tasks([task])
+
+            mock_client.update_task.assert_called_once()
+            assert "Successfully updated task t1" in result
+
+    # ========================================================================
+    # update_task delegates to update_tasks
+    # ========================================================================
+
+    def test_update_task_delegates_to_update_tasks(self):
+        """update_task (single) delegates to the new update_tasks."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.return_value = {
+                "success": True,
+                "task_id": "task-001",
+                "updated_fields": ["flagged"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_task("task-001", flagged=True)
+
+            mock_client.update_task.assert_called_once()
+            call_kwargs = mock_client.update_task.call_args.kwargs
+            assert call_kwargs["task_id"] == "task-001"
+            assert call_kwargs["flagged"] is True
+            assert "Successfully updated task task-001" in result


### PR DESCRIPTION
## Summary

Closes #492

New `update_tasks(tasks: list[TaskUpdate])` replaces both old functions:
- `update_task` (single item, flat params) → now delegates to update_tasks
- `update_tasks` (batch, same values for all) → replaced by per-item values

Each item has its own id + fields. No more "batch excludes name/note" limitation — every field is available on every item.

Uses `model_dump(exclude_none=True)` to only pass explicitly-set fields. Preserves False/0 values correctly (e.g., `flagged=False` is passed through, `flagged=None` is excluded).

## Test plan

- [x] 937 tests passing (14 new, existing tests updated to new signature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)