### PR TITLE
feat: unified create_projects with Pydantic model input

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -57,21 +57,39 @@ Retrieve projects from OmniFocus with optional filtering.
 
 ### create_project
 
-Create a new project in OmniFocus.
+DEPRECATED: Use create_projects instead. Creates a single project by delegating to create_projects.
+
+---
+
+### create_projects
+
+Create one or more projects in OmniFocus.
+
+Pass a list of project objects. Each must have a name; all other fields optional.
 
 **Parameters:**
-- `name: str` (required) — The name of the project
-- `note: str` (optional) — Note/description (plain text only - rich text not supported via automation APIs)
-- `folder_path: str` (optional) — Folder path (e.g., "Work > Clients") - folder must exist
-- `project_type: str` (optional) — Project type: "parallel" (default, all tasks available simultaneously), "sequential" (tasks completed in order, only first available), or "single_actions" (grab-bag list with no completion goal, cannot auto-complete). Overrides `sequential` when provided.
-- `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
-- `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
-- `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
-- `due_date: str` (optional) — Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00"). Tasks inherit this as their effective due date.
-- `defer_date: str` (optional) — Defer date in ISO 8601 format (when project becomes available)
-- `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on the project)
+- `projects: list[ProjectCreate]` (required) — List of project objects. Each supports:
+  - `name: str` (required) — The name of the project
+  - `note: str` (optional) — Note/description (plain text only - rich text not supported via automation APIs)
+  - `folder_path: str` (optional) — Folder path (e.g., "Work > Clients") - folder must exist
+  - `project_type: str` (optional) — Project type: "parallel" (default, all tasks available simultaneously), "sequential" (tasks completed in order, only first available), or "single_actions" (grab-bag list with no completion goal, cannot auto-complete). Overrides `sequential` when provided.
+  - `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
+  - `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
+  - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
+  - `due_date: str` (optional) — Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00"). Tasks inherit this as their effective due date.
+  - `defer_date: str` (optional) — Defer date in ISO 8601 format (when project becomes available)
+  - `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on the project)
 
-**Returns:** Success message with project ID and configuration details
+**Returns:** For single project: success message with project ID and configuration details. For multiple: summary with per-item results.
+
+**Examples:**
+```
+create_projects([{"name": "Website Redesign"}])
+create_projects([
+    {"name": "Project A", "folder_path": "Work", "project_type": "sequential"},
+    {"name": "Project B", "due_date": "2026-04-01"}
+])
+```
 
 ---
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -309,61 +309,23 @@ def create_project(
     defer_date: Optional[str] = None,
     planned_date: Optional[str] = None,
 ) -> str:
-    """Create a new project in OmniFocus.
+    """DEPRECATED: Use create_projects instead. Creates a single project in OmniFocus.
 
-    Args:
-        name: The name of the project
-        note: Optional note/description for the project (plain text only - rich text formatting is not supported via automation APIs)
-        folder_path: Optional folder path (e.g., "Work > Clients") - folder must exist in OmniFocus
-        project_type: Project type — "parallel" (default, all tasks available simultaneously),
-            "sequential" (tasks completed in order, only first available), or "single_actions"
-            (grab-bag list with no completion goal, cannot auto-complete). Overrides sequential
-            when provided.
-        sequential: DEPRECATED — use project_type instead. If True, creates a sequential project.
-            Ignored when project_type is provided. (default: False)
-        review_interval_weeks: Optional review interval in weeks for GTD review cycle
-        completed_by_children: Auto-complete the project when its last remaining action is completed. (optional)
-        due_date: Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00")
-        defer_date: Defer date in ISO 8601 format (when project becomes available)
-        planned_date: Planned date in ISO 8601 format (when you plan to work on the project)
-
-    Returns:
-        Success message with project ID and configuration details
+    This function is kept for backward compatibility. It delegates to
+    create_projects([{...}]) internally. Prefer create_projects for new code.
     """
-    client = get_client()
-    try:
-        project_id = client.create_project(
-            name=name,
-            note=note,
-            folder_path=folder_path,
-            sequential=sequential,
-            project_type=project_type,
-            review_interval_weeks=review_interval_weeks,
-            completed_by_children=completed_by_children,
-            due_date=due_date,
-            defer_date=defer_date,
-            planned_date=planned_date,
-        )
-    except ValueError as e:
-        return f"Error: {str(e)}"
-
-    effective_type = project_type or ("sequential" if sequential else "parallel")
-    type_labels = {
-        "sequential": "Sequential (tasks completed in order)",
-        "parallel": "Parallel (tasks can be done in any order)",
-        "single_actions": "Single Actions List (grab-bag, no completion goal)",
-    }
-    result = f"Successfully created project '{name}'"
-    result += f"\nProject ID: {project_id}"
-    if folder_path:
-        result += f"\nFolder: {folder_path}"
-    result += f"\nType: {type_labels.get(effective_type, effective_type)}"
-    if review_interval_weeks:
-        result += f"\nReview Interval: Every {review_interval_weeks} week(s)"
-    if note:
-        result += f"\nNote: {_truncate_note(note)}"
-
-    return result
+    return create_projects(projects=[{
+        "name": name,
+        "note": note,
+        "folder_path": folder_path,
+        "project_type": project_type,
+        "sequential": sequential,
+        "review_interval_weeks": review_interval_weeks,
+        "completed_by_children": completed_by_children,
+        "due_date": due_date,
+        "defer_date": defer_date,
+        "planned_date": planned_date,
+    }])
 
 
 @mcp.tool()
@@ -749,6 +711,20 @@ class TaskCreate(BaseModel):
     completed_by_children: bool = False
 
 
+class ProjectCreate(BaseModel):
+    """Input model for creating a project."""
+    name: str
+    note: Optional[str] = None
+    folder_path: Optional[str] = None
+    project_type: Optional[str] = None
+    sequential: bool = False
+    review_interval_weeks: Optional[int] = None
+    completed_by_children: Optional[bool] = None
+    due_date: Optional[str] = None
+    defer_date: Optional[str] = None
+    planned_date: Optional[str] = None
+
+
 class TaskUpdate(BaseModel):
     """Input model for updating a task."""
     id: str
@@ -849,6 +825,95 @@ def create_tasks(tasks: list[TaskCreate]) -> str:
         lines.append(f"  - {r['task_name']}: {r['task_id']}")
     for r in failed:
         lines.append(f"  - {r['task_name']}: FAILED — {r['error']}")
+    return "\n".join(lines)
+
+
+# ============================================================================
+# Unified Batch Create Projects (v0.11.0)
+# ============================================================================
+
+
+@mcp.tool()
+def create_projects(projects: list[ProjectCreate]) -> str:
+    """Create one or more projects in OmniFocus.
+
+    Pass a list of project objects. Each must have a name; all other fields optional.
+
+    Args:
+        projects: List of project objects to create. Each object supports:
+            name (required), note, folder_path, project_type, sequential,
+            review_interval_weeks, completed_by_children, due_date,
+            defer_date, planned_date.
+
+    Returns:
+        For single project: success message with project ID.
+        For multiple projects: summary with per-item results.
+
+    Examples:
+        create_projects([{"name": "Website Redesign"}])
+        create_projects([
+            {"name": "Project A", "folder_path": "Work", "project_type": "sequential"},
+            {"name": "Project B", "due_date": "2026-04-01"}
+        ])
+    """
+    client = get_client()
+
+    # Coerce dicts to ProjectCreate (MCP protocol does this automatically,
+    # but direct Python calls from tests pass raw dicts)
+    try:
+        projects = [ProjectCreate(**p) if isinstance(p, dict) else p for p in projects]
+    except Exception as e:
+        return f"Error: Invalid project input: {e}"
+
+    results = []
+    for project in projects:
+        try:
+            project_id = client.create_project(**project.model_dump())
+            results.append({
+                "name": project.name,
+                "project_id": project_id,
+                "success": True,
+            })
+        except (ValueError, Exception) as e:
+            results.append({
+                "name": project.name,
+                "success": False,
+                "error": str(e),
+            })
+
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    # Single project: match old create_project format
+    if len(projects) == 1:
+        r = results[0]
+        if r["success"]:
+            proj = projects[0]
+            effective_type = proj.project_type or ("sequential" if proj.sequential else "parallel")
+            type_labels = {
+                "sequential": "Sequential (tasks completed in order)",
+                "parallel": "Parallel (tasks can be done in any order)",
+                "single_actions": "Single Actions List (grab-bag, no completion goal)",
+            }
+            result = f"Successfully created project '{proj.name}'"
+            result += f"\nProject ID: {r['project_id']}"
+            if proj.folder_path:
+                result += f"\nFolder: {proj.folder_path}"
+            result += f"\nType: {type_labels.get(effective_type, effective_type)}"
+            if proj.review_interval_weeks:
+                result += f"\nReview Interval: Every {proj.review_interval_weeks} week(s)"
+            if proj.note:
+                result += f"\nNote: {_truncate_note(proj.note)}"
+            return result
+        else:
+            return f"Error: {r['error']}"
+
+    # Multiple projects: summary
+    lines = [f"Created {len(succeeded)} of {len(projects)} projects:"]
+    for r in succeeded:
+        lines.append(f"  - {r['name']}: {r['project_id']}")
+    for r in failed:
+        lines.append(f"  - {r['name']}: FAILED — {r['error']}")
     return "\n".join(lines)
 
 

--- a/tests/test_server_redesign_create.py
+++ b/tests/test_server_redesign_create.py
@@ -308,3 +308,142 @@ class TestCreateProjectServerRedesign:
             result = server.create_project(name="")
             assert isinstance(result, str)
             assert "error" in result.lower()
+
+
+class TestCreateProjectsUnified:
+    """Tests for unified create_projects() with Pydantic model input."""
+
+    def test_create_projects_single_item(self):
+        """create_projects with a single project returns detailed format."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.return_value = "proj-001"
+            mock_get_client.return_value = mock_client
+
+            create_projects = server.create_projects
+            result = create_projects(projects=[{"name": "Test Project"}])
+
+            assert isinstance(result, str)
+            assert "proj-001" in result
+            assert "Successfully" in result
+            mock_client.create_project.assert_called_once()
+            call_kwargs = mock_client.create_project.call_args[1]
+            assert call_kwargs["name"] == "Test Project"
+
+    def test_create_projects_multiple_items(self):
+        """create_projects with multiple projects returns summary."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.side_effect = ["proj-001", "proj-002", "proj-003"]
+            mock_get_client.return_value = mock_client
+
+            create_projects = server.create_projects
+            result = create_projects(projects=[
+                {"name": "Project A"},
+                {"name": "Project B", "sequential": True},
+                {"name": "Project C", "folder_path": "Work"},
+            ])
+
+            assert isinstance(result, str)
+            assert "3" in result
+            assert mock_client.create_project.call_count == 3
+
+    def test_create_projects_partial_failure(self):
+        """create_projects with one failure returns mixed results."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.side_effect = [
+                "proj-001",
+                ValueError("Folder not found"),
+                "proj-003",
+            ]
+            mock_get_client.return_value = mock_client
+
+            create_projects = server.create_projects
+            result = create_projects(projects=[
+                {"name": "Good Project"},
+                {"name": "Bad Project", "folder_path": "Nonexistent"},
+                {"name": "Also Good"},
+            ])
+
+            assert isinstance(result, str)
+            assert "2" in result  # 2 succeeded
+            assert "Bad Project" in result
+            assert "FAILED" in result
+
+    def test_create_projects_with_all_fields(self):
+        """create_projects passes all fields through to connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.return_value = "proj-001"
+            mock_get_client.return_value = mock_client
+
+            create_projects = server.create_projects
+            result = create_projects(projects=[{
+                "name": "Full Project",
+                "note": "A note",
+                "folder_path": "Work > Clients",
+                "project_type": "sequential",
+                "sequential": True,
+                "review_interval_weeks": 2,
+                "completed_by_children": True,
+                "due_date": "2026-04-01",
+                "defer_date": "2026-03-25",
+                "planned_date": "2026-03-28",
+            }])
+
+            call_kwargs = mock_client.create_project.call_args[1]
+            assert call_kwargs["name"] == "Full Project"
+            assert call_kwargs["note"] == "A note"
+            assert call_kwargs["folder_path"] == "Work > Clients"
+            assert call_kwargs["project_type"] == "sequential"
+            assert call_kwargs["sequential"] is True
+            assert call_kwargs["review_interval_weeks"] == 2
+            assert call_kwargs["completed_by_children"] is True
+            assert call_kwargs["due_date"] == "2026-04-01"
+            assert call_kwargs["defer_date"] == "2026-03-25"
+            assert call_kwargs["planned_date"] == "2026-03-28"
+
+    def test_create_project_delegates_to_create_projects(self):
+        """Old create_project should delegate to create_projects."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.return_value = "proj-delegated"
+            mock_get_client.return_value = mock_client
+
+            result = server.create_project(
+                name="Delegated Project",
+                folder_path="Work",
+                review_interval_weeks=4,
+            )
+
+            assert "proj-delegated" in result
+            assert "Successfully" in result
+            mock_client.create_project.assert_called_once()
+
+    def test_create_projects_single_shows_type_info(self):
+        """Single project creation shows type label in result."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.return_value = "proj-seq"
+            mock_get_client.return_value = mock_client
+
+            result = server.create_projects(projects=[{
+                "name": "Sequential Project",
+                "project_type": "sequential",
+            }])
+
+            assert "Sequential" in result
+            assert "tasks completed in order" in result.lower()
+
+    def test_create_projects_single_error(self):
+        """Single project failure returns error string."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_project.side_effect = ValueError("Bad input")
+            mock_get_client.return_value = mock_client
+
+            result = server.create_projects(projects=[{"name": "Bad"}])
+
+            assert "Error" in result
+            assert "Bad input" in result


### PR DESCRIPTION
## Summary

Closes #513

New `create_projects(projects: list[ProjectCreate])` replaces `create_project`. Same pattern as `create_tasks` (#489): per-item values, single-item detailed format, multi-item summary with partial failure handling.

Old `create_project` delegates internally, marked DEPRECATED.

## Test plan

- [x] 956 tests passing (7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)