### PR TITLE
feat: unified update_projects with per-item values via Pydantic model

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -20,7 +20,7 @@ INHERITED STATUS: Task-level fields like `completed` and `dropped` reflect the t
 
 EFFECTIVE DATES: Date fields (dueDate, deferDate, plannedDate) returned by get_tasks are EFFECTIVE dates — they include dates inherited from the containing project. A task with no direct due date in a project with dueDate=April 15 will return dueDate="2026-04-15T17:00:00" (not empty). Do not assume an empty due date on a task means the project has no due date either. Write operations (update_task) set the task's own date directly.
 
-BATCH OPERATIONS: When applying the same change to multiple items, prefer the batch tools (update_tasks, update_projects) over multiple individual calls. Batch tools accept a list of IDs and are more efficient.
+BATCH OPERATIONS: When updating multiple items, prefer the unified tools (update_tasks, update_projects) which accept a list of update objects — each item can have different fields. More efficient than multiple individual calls.
 
 RECURRING TASKS: Setting completed=True on a recurring task uses OmniFocus's 'mark complete' command, which automatically creates the next occurrence. This is guaranteed behavior — do not hedge or warn that recurrence might stop.
 
@@ -95,65 +95,48 @@ create_projects([
 
 ### update_project
 
-Update an existing project in OmniFocus.
-
-Consolidates: set_project_status(), drop_project(), set_review_interval(), mark_project_reviewed()
-
-**Parameters:**
-- `project_id: str` (required) — The ID of the project to update
-- `project_name: str` (optional) — New project name
-- `folder_path: str` (optional) — Folder path to move project to (e.g., "Work : Projects")
-- `note: str` (optional) — New note content. WARNING: Removes rich text formatting.
-- `project_type: str` (optional) — Change project type: "parallel", "sequential", or "single_actions"
-- `sequential: bool` (optional, DEPRECATED) — Use project_type instead.
-- `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
-- `review_interval_weeks: int` (optional) — Review interval in weeks (0 to clear)
-- `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
-- `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
-- `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
-- `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
-- `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
-- `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
-- `flagged: bool` (optional) — Flag marks a project as a priority. Pass True to flag, False to unflag.
-- `estimated_minutes: int` (optional) — Estimated time in minutes for the project
-- `tags: list[str]` (optional) — Full replacement — set exact tag list. Conflicts with add_tags/remove_tags.
-- `add_tags: list[str]` (optional) — Add these tags incrementally. Conflicts with tags.
-- `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
-- `recurrence: str` (optional) — iCalendar RRULE string, or empty string to remove recurrence.
-- `repetition_method: str` (optional) — "fixed", "start_after_completion", or "due_after_completion". Only meaningful when recurrence is set.
-
-**Returns:** Success message with project ID and updated fields, or error message
-
-**Examples:**
-- `update_project("proj-123", flagged=True)` — Flag project
-- `update_project("proj-123", add_tags=["High Priority"])` — Add tag to project
-- `update_project("proj-123", tags=[])` — Clear all tags from project
+DEPRECATED: Use update_projects instead. Delegates to update_projects with a single-item list.
 
 ---
 
 ### update_projects
 
-Update multiple projects with the same properties (batch version of update_project).
-
-IMPORTANT: This function does NOT accept project_name or note parameters because those require unique values for each project.
+Update one or more projects in OmniFocus. Pass a list of project update objects — each must have an `id` field, plus any fields to change. Each project can have different fields updated.
 
 **Parameters:**
-- `project_ids: str | list[str]` (required) — Single project ID or list of project IDs
-- `folder_path: str` (optional) — Folder path to move projects to
-- `sequential: bool` (optional) — Sequential setting
-- `status: str` (optional) — Project status - "active", "on_hold", "done", "dropped"
-- `review_interval_weeks: int` (optional) — Review interval in weeks
-- `last_reviewed: str` (optional) — Last review date ("now" or ISO format)
-- `next_review_date: str` (optional) — Explicit next review date in ISO format
-- `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
-- `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
-- `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
-- `flagged: bool` (optional) — Flag/unflag all specified projects
-- `estimated_minutes: int` (optional) — Set estimated time for all specified projects
-- `add_tags: list[str]` (optional) — Add these tags to all specified projects
-- `remove_tags: list[str]` (optional) — Remove these tags from all specified projects
+- `projects: list[object]` (required) — List of project update objects. Each object has:
+  - `id: str` (required) — The project ID to update
+  - `project_name: str` (optional) — New project name
+  - `folder_path: str` (optional) — Folder path to move project to (e.g., "Work : Projects")
+  - `note: str` (optional) — New note content. WARNING: Removes rich text formatting.
+  - `project_type: str` (optional) — Change project type: "parallel", "sequential", or "single_actions"
+  - `sequential: bool` (optional, DEPRECATED) — Use project_type instead.
+  - `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
+  - `review_interval_weeks: int` (optional) — Review interval in weeks (0 to clear)
+  - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
+  - `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
+  - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
+  - `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
+  - `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
+  - `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
+  - `flagged: bool` (optional) — Flag marks a project as a priority. Pass True to flag, False to unflag.
+  - `estimated_minutes: int` (optional) — Estimated time in minutes for the project
+  - `tags: list[str]` (optional) — Full replacement — set exact tag list. Conflicts with add_tags/remove_tags.
+  - `add_tags: list[str]` (optional) — Add these tags incrementally. Conflicts with tags.
+  - `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
+  - `recurrence: str` (optional) — iCalendar RRULE string, or empty string to remove recurrence.
+  - `repetition_method: str` (optional) — "fixed", "start_after_completion", or "due_after_completion". Only meaningful when recurrence is set.
 
-**Returns:** Success message with updated and failed counts
+**Returns:** For single project: success message with updated fields. For multiple: summary with per-item results.
+
+**Examples:**
+```
+update_projects([{"id": "proj-123", "flagged": true}])
+update_projects([
+    {"id": "proj-1", "status": "on_hold"},
+    {"id": "proj-2", "project_name": "Renamed", "flagged": true}
+])
+```
 
 ---
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -328,6 +328,31 @@ def create_project(
     }])
 
 
+class ProjectUpdate(BaseModel):
+    """Input model for updating a project."""
+    id: str
+    project_name: Optional[str] = None
+    folder_path: Optional[str] = None
+    note: Optional[str] = None
+    sequential: Optional[bool] = None
+    project_type: Optional[str] = None
+    status: Optional[str] = None
+    review_interval_weeks: Optional[int] = None
+    last_reviewed: Optional[str] = None
+    next_review_date: Optional[str] = None
+    completed_by_children: Optional[bool] = None
+    due_date: Optional[str] = None
+    defer_date: Optional[str] = None
+    planned_date: Optional[str] = None
+    flagged: Optional[bool] = None
+    estimated_minutes: Optional[int] = None
+    tags: Optional[list[str]] = None
+    add_tags: Optional[list[str]] = None
+    remove_tags: Optional[list[str]] = None
+    recurrence: Optional[str] = None
+    repetition_method: Optional[str] = None
+
+
 @mcp.tool()
 def update_project(
     project_id: str,
@@ -352,7 +377,9 @@ def update_project(
     recurrence: Optional[str] = None,
     repetition_method: Optional[str] = None,
 ) -> str:
-    """Update an existing project in OmniFocus.
+    """DEPRECATED: Use update_projects instead. Update a single project in OmniFocus.
+
+    Delegates to update_projects with a single-item list.
 
     Args:
         project_id: The ID of the project to update
@@ -384,148 +411,93 @@ def update_project(
     Returns:
         Success message with project ID and updated fields, or error message
     """
-    client = get_client()
-    try:
-        result = client.update_project(
-            project_id=project_id,
-            project_name=project_name,
-            folder_path=folder_path,
-            note=note,
-            sequential=sequential,
-            project_type=project_type,
-            status=status,
-            review_interval_weeks=review_interval_weeks,
-            last_reviewed=last_reviewed,
-            next_review_date=next_review_date,
-            completed_by_children=completed_by_children,
-            due_date=due_date,
-            defer_date=defer_date,
-            planned_date=planned_date,
-            flagged=flagged,
-            estimated_minutes=estimated_minutes,
-            tags=tags,
-            add_tags=add_tags,
-            remove_tags=remove_tags,
-            recurrence=recurrence,
-            repetition_method=repetition_method,
-        )
-    except ValueError as e:
-        return f"Error: {str(e)}"
-
-    # Handle dict return from client
-    if result["success"]:
-        updated_fields = result["updated_fields"]
-        field_count = len(updated_fields)
-
-        if field_count == 1:
-            response = f"Successfully updated project {project_id}: {updated_fields[0]}"
-        else:
-            response = f"Successfully updated project {project_id}: {field_count} fields ({', '.join(updated_fields)})"
-
-        return response
-    else:
-        error_msg = result.get("error", "Unknown error")
-        return f"Error updating project {project_id}: {error_msg}"
+    # Build project dict from non-None params
+    params = locals()
+    project_dict = {"id": params.pop("project_id")}
+    for k, v in params.items():
+        if v is not None:
+            project_dict[k] = v
+    return update_projects(projects=[project_dict])
 
 
 @mcp.tool()
-def update_projects(
-    project_ids: Union[str, list[str]],
-    folder_path: Optional[str] = None,
-    sequential: Optional[bool] = None,
-    status: Optional[str] = None,
-    review_interval_weeks: Optional[int] = None,
-    last_reviewed: Optional[str] = None,
-    next_review_date: Optional[str] = None,
-    due_date: Optional[str] = None,
-    defer_date: Optional[str] = None,
-    planned_date: Optional[str] = None,
-    flagged: Optional[bool] = None,
-    estimated_minutes: Optional[int] = None,
-    add_tags: Optional[list[str]] = None,
-    remove_tags: Optional[list[str]] = None,
-) -> str:
-    """Update multiple projects with the same properties.
+def update_projects(projects: list[ProjectUpdate]) -> str:
+    """Update one or more projects in OmniFocus.
 
-    This is the BATCH version of update_project(). It updates multiple projects
-    with the same values. This is more efficient than calling update_project()
-    multiple times.
-
-    IMPORTANT: This function does NOT accept project_name or note parameters
-    because those require unique values for each project.
+    Pass a list of project update objects. Each must have an id field.
+    Only the specified fields will be updated — omitted fields are unchanged.
 
     Args:
-        project_ids: Single project ID (str) or list of project IDs to update
-        folder_path: Folder path to move projects to (e.g., "Work > Projects")
-        sequential: Sequential setting (optional)
-        status: Project status - one of: "active", "on_hold", "done", "dropped"
-        review_interval_weeks: Review interval in weeks
-        last_reviewed: Last review date ("now" or ISO format like "2025-01-15")
-        next_review_date: Explicit next review date in ISO format — overrides OmniFocus-calculated date (optional)
-        due_date: Due date in ISO 8601 format, or "" to clear (optional)
-        defer_date: Defer date in ISO 8601 format, or "" to clear (optional)
-        planned_date: Planned date in ISO 8601 format, or "" to clear (optional)
-        flagged: Flag marks projects as a priority — pass True to flag, False to unflag. (optional)
-        estimated_minutes: Estimated time in minutes (optional)
-        add_tags: Add these tags incrementally (optional)
-        remove_tags: Remove these tags (optional)
+        projects: List of project update objects. Each must have:
+            id (required), plus any fields to update: project_name, folder_path,
+            note, sequential, project_type, status, review_interval_weeks,
+            last_reviewed, next_review_date, completed_by_children, due_date,
+            defer_date, planned_date, flagged, estimated_minutes, tags,
+            add_tags, remove_tags, recurrence, repetition_method.
 
     Returns:
-        Success message with updated and failed counts, or error message
+        For single project: success message with updated fields.
+        For multiple projects: summary with per-item results.
 
-    Example:
-        # Drop multiple projects at once
-        update_projects(
-            project_ids=["proj-001", "proj-002", "proj-003"],
-            status="dropped"
-        )
+    Examples:
+        update_projects([{"id": "p1", "status": "on_hold"}])
+        update_projects([
+            {"id": "p1", "status": "on_hold"},
+            {"id": "p2", "project_name": "Renamed", "flagged": true}
+        ])
     """
+    client = get_client()
+
+    # Coerce dicts to ProjectUpdate
     try:
-        client = get_client()
-        result = client.update_projects(
-            project_ids=project_ids,
-            folder_path=folder_path,
-            sequential=sequential,
-            status=status,
-            review_interval_weeks=review_interval_weeks,
-            last_reviewed=last_reviewed,
-            next_review_date=next_review_date,
-            due_date=due_date,
-            defer_date=defer_date,
-            planned_date=planned_date,
-            flagged=flagged,
-            estimated_minutes=estimated_minutes,
-            add_tags=add_tags,
-            remove_tags=remove_tags,
-        )
-
-        # Handle dict return from client
-        updated_count = result["updated_count"]
-        failed_count = result["failed_count"]
-        failures = result["failures"]
-
-        if failed_count == 0:
-            # All succeeded
-            if updated_count == 1:
-                return f"Successfully updated 1 project"
-            else:
-                return f"Successfully updated {updated_count} projects"
-        elif updated_count == 0:
-            # All failed
-            error_details = "; ".join([f"{f['project_id']}: {f['error']}" for f in failures])
-            return f"Error: Failed to update {failed_count} projects. {error_details}"
-        else:
-            # Partial success
-            error_details = "; ".join([f"{f['project_id']}: {f['error']}" for f in failures])
-            return (f"Partially updated: {updated_count} succeeded, {failed_count} failed. "
-                   f"Failures: {error_details}")
-
-    except ValueError as e:
-        # Parameter validation errors
-        return f"Error: {str(e)}"
+        projects = [ProjectUpdate(**p) if isinstance(p, dict) else p for p in projects]
     except Exception as e:
-        # Other errors
-        return f"Error updating projects: {str(e)}"
+        return f"Error: Invalid project input: {e}"
+
+    results = []
+    for project in projects:
+        try:
+            # Build kwargs, excluding None values and the id field
+            kwargs = project.model_dump(exclude_none=True, exclude={"id"})
+            result = client.update_project(project_id=project.id, **kwargs)
+            results.append({
+                "id": project.id,
+                "success": result["success"],
+                "updated_fields": result.get("updated_fields", []),
+                "error": result.get("error"),
+            })
+        except (ValueError, Exception) as e:
+            results.append({
+                "id": project.id,
+                "success": False,
+                "updated_fields": [],
+                "error": str(e),
+            })
+
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    # Single project: match old update_project format
+    if len(projects) == 1:
+        r = results[0]
+        if r["success"]:
+            fields = r["updated_fields"]
+            if len(fields) == 0:
+                return f"Successfully updated project {r['id']} (no changes detected)"
+            elif len(fields) == 1:
+                return f"Successfully updated project {r['id']}: {fields[0]}"
+            else:
+                return f"Successfully updated project {r['id']}: {len(fields)} fields ({', '.join(fields)})"
+        else:
+            return f"Error updating project {r['id']}: {r['error']}"
+
+    # Multiple projects: summary
+    lines = [f"Updated {len(succeeded)} of {len(projects)} projects:"]
+    for r in succeeded:
+        lines.append(f"  - {r['id']}: {', '.join(r['updated_fields'])}")
+    for r in failed:
+        lines.append(f"  - {r['id']}: FAILED — {r['error']}")
+    return "\n".join(lines)
 
 
 

--- a/tests/test_server_coverage.py
+++ b/tests/test_server_coverage.py
@@ -172,26 +172,24 @@ class TestUpdateProjectsEdgeCases:
 
     @mock.patch("omnifocus_mcp.server_fastmcp.get_client")
     def test_all_updates_failed(self, mock_gc):
-        mock_gc.return_value.update_projects.return_value = {
-            "updated_count": 0,
-            "failed_count": 2,
-            "failures": [
-                {"project_id": "p1", "error": "not found"},
-                {"project_id": "p2", "error": "not found"},
-            ],
-        }
-        result = server.update_projects(project_ids=["p1", "p2"], status="active")
-        assert "Failed to update" in result
-        assert "p1: not found" in result
-        mock_gc.return_value.update_projects.assert_called_once()
-        call_kwargs = mock_gc.return_value.update_projects.call_args[1]
-        assert call_kwargs["status"] == "active"
+        mock_gc.return_value.update_project.side_effect = [
+            {"success": False, "project_id": "p1", "updated_fields": [], "error": "not found"},
+            {"success": False, "project_id": "p2", "updated_fields": [], "error": "not found"},
+        ]
+        result = server.update_projects(projects=[
+            {"id": "p1", "status": "active"},
+            {"id": "p2", "status": "active"},
+        ])
+        assert "FAILED" in result
+        assert "not found" in result
+        assert mock_gc.return_value.update_project.call_count == 2
 
     @mock.patch("omnifocus_mcp.server_fastmcp.get_client")
     def test_exception_handler(self, mock_gc):
-        mock_gc.return_value.update_projects.side_effect = RuntimeError("boom")
-        result = server.update_projects(project_ids=["p1"], status="active")
-        assert "Error updating projects:" in result
+        mock_gc.return_value.update_project.side_effect = RuntimeError("boom")
+        result = server.update_projects(projects=[{"id": "p1", "status": "active"}])
+        assert "Error" in result
+        assert "boom" in result
 
 
 class TestGetTasksEdgeCases:

--- a/tests/test_server_redesign_update_project.py
+++ b/tests/test_server_redesign_update_project.py
@@ -2,6 +2,9 @@
 
 This file tests the MCP server layer for update_project().
 Tests are written FIRST (TDD) before implementing server changes.
+
+After the unified update_projects migration (#513), update_project delegates
+to update_projects with a single-item list.
 """
 import pytest
 from unittest import mock
@@ -14,7 +17,10 @@ update_project = server.update_project
 
 
 class TestUpdateProjectServerRedesign:
-    """Tests for update_project() MCP tool (NEW API - Phase 2, Server Layer)."""
+    """Tests for update_project() MCP tool (NEW API - Phase 2, Server Layer).
+
+    After #513, update_project delegates to update_projects.
+    """
 
     # ========================================================================
     # Status Updates
@@ -35,26 +41,7 @@ class TestUpdateProjectServerRedesign:
 
             mock_client.update_project.assert_called_once_with(
                 project_id="proj-001",
-                project_name=None,
-                folder_path=None,
-                note=None,
-                sequential=None,
-                project_type=None,
                 status="active",
-                review_interval_weeks=None,
-                last_reviewed=None,
-                next_review_date=None,
-                completed_by_children=None,
-                due_date=None,
-                defer_date=None,
-                planned_date=None,
-                flagged=None,
-                estimated_minutes=None,
-                tags=None,
-                add_tags=None,
-                remove_tags=None,
-                recurrence=None,
-                repetition_method=None,
             )
 
             assert isinstance(result, str)
@@ -445,3 +432,24 @@ class TestUpdateProjectNewParams:
 
             assert "error" in result.lower()
             assert "tags" in result.lower() or "add_tags" in result.lower()
+
+
+class TestUpdateProjectDelegation:
+    """Tests that update_project delegates to update_projects (#513)."""
+
+    def test_delegation_from_update_project(self):
+        """Old update_project still works by delegating to update_projects."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "proj-1",
+                "updated_fields": ["status"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_project(project_id="proj-1", status="on_hold")
+
+            # Should still call client.update_project (via update_projects delegation)
+            mock_client.update_project.assert_called_once()
+            assert "success" in result.lower() or "updated" in result.lower()

--- a/tests/test_server_redesign_update_projects.py
+++ b/tests/test_server_redesign_update_projects.py
@@ -1,6 +1,7 @@
-"""Tests for update_projects() MCP tool (NEW API - Phase 2, Function 2.2, Server Layer).
+"""Tests for update_projects() MCP tool (unified Pydantic model, #513).
 
-Tests the MCP server layer that wraps the client update_projects() function.
+Tests the new unified update_projects() that accepts list[ProjectUpdate],
+replacing the old batch-same-values version.
 """
 import pytest
 from unittest import mock
@@ -9,279 +10,228 @@ from unittest import mock
 import omnifocus_mcp.server_fastmcp as server
 
 
-class TestUpdateProjectsServerRedesign:
-    """Tests for update_projects() MCP tool (NEW API - Phase 2, Server Layer)."""
+class TestUpdateProjectsUnified:
+    """Tests for unified update_projects() with list[ProjectUpdate] (#513)."""
 
-    def test_update_projects_batch_status(self):
-        """Server: update_projects() MCP tool can set status on multiple projects."""
+    def test_single_item(self):
+        """Single project update returns detailed format."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 3,
-                "failed_count": 0,
-                "updated_ids": ["proj-001", "proj-002", "proj-003"],
-                "failures": []
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "p1",
+                "updated_fields": ["status"]
             }
             mock_get_client.return_value = mock_client
 
-            # Get the actual MCP tool function
-            update_projects = server.update_projects
+            result = server.update_projects(projects=[{"id": "p1", "status": "on_hold"}])
 
-            result = update_projects(
-                project_ids=["proj-001", "proj-002", "proj-003"],
-                status="active"
+            mock_client.update_project.assert_called_once_with(
+                project_id="p1",
+                status="on_hold",
             )
-
-            # Verify client was called correctly
-            mock_client.update_projects.assert_called_once()
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["project_ids"] == ["proj-001", "proj-002", "proj-003"]
-            assert call_kwargs["status"] == "active"
-
-            # Verify human-readable response
             assert isinstance(result, str)
-            assert "3" in result  # Should mention count
+            assert "p1" in result
             assert "success" in result.lower() or "updated" in result.lower()
 
-    def test_update_projects_single_id_string(self):
-        """Server: update_projects() MCP tool accepts single ID as string (Union type)."""
+    def test_multiple_items_different_fields(self):
+        """Multiple projects with different fields each."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 1,
-                "failed_count": 0,
-                "updated_ids": ["proj-001"],
-                "failures": []
-            }
+            mock_client.update_project.side_effect = [
+                {
+                    "success": True,
+                    "project_id": "p1",
+                    "updated_fields": ["status"]
+                },
+                {
+                    "success": True,
+                    "project_id": "p2",
+                    "updated_fields": ["project_name"]
+                },
+            ]
             mock_get_client.return_value = mock_client
 
-            update_projects = server.update_projects
+            result = server.update_projects(projects=[
+                {"id": "p1", "status": "on_hold"},
+                {"id": "p2", "project_name": "Renamed"},
+            ])
 
-            result = update_projects(project_ids="proj-001", status="on_hold")
-
-            # Should pass single string to client
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["project_ids"] == "proj-001"
+            assert mock_client.update_project.call_count == 2
+            # First call: status on p1
+            first_call = mock_client.update_project.call_args_list[0]
+            assert first_call[1]["project_id"] == "p1"
+            assert first_call[1]["status"] == "on_hold"
+            # Second call: project_name on p2
+            second_call = mock_client.update_project.call_args_list[1]
+            assert second_call[1]["project_id"] == "p2"
+            assert second_call[1]["project_name"] == "Renamed"
 
             assert isinstance(result, str)
-            assert "1" in result
-
-    def test_update_projects_multiple_fields(self):
-        """Server: update_projects() MCP tool can update multiple fields."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 2,
-                "failed_count": 0,
-                "updated_ids": ["proj-001", "proj-002"],
-                "failures": []
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["proj-001", "proj-002"],
-                status="active",
-                sequential=True,
-                review_interval_weeks=4
-            )
-
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["status"] == "active"
-            assert call_kwargs["sequential"] is True
-            assert call_kwargs["review_interval_weeks"] == 4
-
-            assert "2" in result
-
-    def test_update_projects_partial_failures(self):
-        """Server: update_projects() MCP tool reports partial failures."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 2,
-                "failed_count": 1,
-                "updated_ids": ["proj-001", "proj-003"],
-                "failures": [{"project_id": "proj-002", "error": "Project not found"}]
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["proj-001", "proj-002", "proj-003"],
-                status="done"
-            )
-
-            assert isinstance(result, str)
-            # Should mention both successes and failures
             assert "2" in result  # Updated count
-            assert "1" in result  # Failed count
-            assert "proj-002" in result  # Failed project ID
+            assert "p1" in result
+            assert "p2" in result
 
-    def test_update_projects_handles_client_exception(self):
-        """Server: update_projects() MCP tool handles client exceptions gracefully."""
+    def test_partial_failure(self):
+        """One succeeds, one fails — reports both."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_projects.side_effect = ValueError("Invalid status")
+            mock_client.update_project.side_effect = [
+                {
+                    "success": True,
+                    "project_id": "p1",
+                    "updated_fields": ["status"]
+                },
+                {
+                    "success": False,
+                    "project_id": "p2",
+                    "updated_fields": [],
+                    "error": "Project not found"
+                },
+            ]
             mock_get_client.return_value = mock_client
 
-            update_projects = server.update_projects
+            result = server.update_projects(projects=[
+                {"id": "p1", "status": "on_hold"},
+                {"id": "p2", "status": "active"},
+            ])
 
-            result = update_projects(
-                project_ids=["proj-001"],
-                status="invalid-status"
-            )
+            assert isinstance(result, str)
+            assert "1" in result  # 1 succeeded
+            assert "p2" in result  # Failed ID mentioned
+            assert "FAILED" in result or "failed" in result.lower()
+
+    def test_all_fields_passthrough(self):
+        """Verify model_dump passes all fields to connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "p1",
+                "updated_fields": ["project_name", "status", "flagged", "due_date",
+                                   "defer_date", "tags", "recurrence"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = server.update_projects(projects=[{
+                "id": "p1",
+                "project_name": "Test",
+                "folder_path": "Work",
+                "note": "A note",
+                "sequential": True,
+                "project_type": "sequential",
+                "status": "active",
+                "review_interval_weeks": 2,
+                "last_reviewed": "2026-03-01",
+                "next_review_date": "2026-03-15",
+                "completed_by_children": True,
+                "due_date": "2026-04-01",
+                "defer_date": "2026-03-20",
+                "planned_date": "2026-03-25",
+                "flagged": True,
+                "estimated_minutes": 60,
+                "tags": ["work"],
+                "recurrence": "FREQ=WEEKLY",
+                "repetition_method": "fixed",
+            }])
+
+            mock_client.update_project.assert_called_once()
+            kwargs = mock_client.update_project.call_args[1]
+            assert kwargs["project_id"] == "p1"
+            assert kwargs["project_name"] == "Test"
+            assert kwargs["folder_path"] == "Work"
+            assert kwargs["note"] == "A note"
+            assert kwargs["sequential"] is True
+            assert kwargs["project_type"] == "sequential"
+            assert kwargs["status"] == "active"
+            assert kwargs["review_interval_weeks"] == 2
+            assert kwargs["last_reviewed"] == "2026-03-01"
+            assert kwargs["next_review_date"] == "2026-03-15"
+            assert kwargs["completed_by_children"] is True
+            assert kwargs["due_date"] == "2026-04-01"
+            assert kwargs["defer_date"] == "2026-03-20"
+            assert kwargs["planned_date"] == "2026-03-25"
+            assert kwargs["flagged"] is True
+            assert kwargs["estimated_minutes"] == 60
+            assert kwargs["tags"] == ["work"]
+            assert kwargs["recurrence"] == "FREQ=WEEKLY"
+            assert kwargs["repetition_method"] == "fixed"
+            # id should NOT be in kwargs (excluded by model_dump)
+            assert "id" not in kwargs
+
+    def test_delegation_from_update_project(self):
+        """Old update_project delegates to update_projects correctly."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "p1",
+                "updated_fields": ["flagged"]
+            }
+            mock_get_client.return_value = mock_client
+
+            # Call the old update_project function
+            result = server.update_project(project_id="p1", flagged=True)
+
+            # Should still call client.update_project via delegation
+            mock_client.update_project.assert_called_once()
+            kwargs = mock_client.update_project.call_args[1]
+            assert kwargs["project_id"] == "p1"
+            assert kwargs["flagged"] is True
+            assert "success" in result.lower() or "updated" in result.lower()
+
+    def test_add_and_remove_tags(self):
+        """update_projects passes add_tags and remove_tags correctly."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "p1",
+                "updated_fields": ["add_tags", "remove_tags"]
+            }
+            mock_get_client.return_value = mock_client
+
+            result = server.update_projects(projects=[{
+                "id": "p1",
+                "add_tags": ["new-tag"],
+                "remove_tags": ["old-tag"],
+            }])
+
+            kwargs = mock_client.update_project.call_args[1]
+            assert kwargs["add_tags"] == ["new-tag"]
+            assert kwargs["remove_tags"] == ["old-tag"]
+
+    def test_exception_during_update(self):
+        """Exception from connector is caught and reported."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_project.side_effect = ValueError("Invalid status")
+            mock_get_client.return_value = mock_client
+
+            result = server.update_projects(projects=[{"id": "p1", "status": "bad"}])
 
             assert isinstance(result, str)
             assert "error" in result.lower()
-            assert "invalid status" in result.lower()
+            assert "Invalid status" in result
 
-    def test_update_projects_sequential_bool_conversion(self):
-        """Server: update_projects() MCP tool converts sequential string to bool."""
+    def test_invalid_input(self):
+        """Invalid project input returns error."""
+        result = server.update_projects(projects=[{"not_a_field": "bad"}])
+        assert isinstance(result, str)
+        assert "error" in result.lower()
+
+    def test_empty_update_no_fields(self):
+        """Project with only id and no fields still calls connector."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
             mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 1,
-                "failed_count": 0,
-                "updated_ids": ["proj-001"],
-                "failures": []
+            mock_client.update_project.return_value = {
+                "success": True,
+                "project_id": "p1",
+                "updated_fields": []
             }
             mock_get_client.return_value = mock_client
 
-            update_projects = server.update_projects
+            result = server.update_projects(projects=[{"id": "p1"}])
 
-            # Test with True
-            result = update_projects(project_ids="proj-001", sequential=True)
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["sequential"] is True
-
-            # Test with False
-            result = update_projects(project_ids="proj-001", sequential=False)
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["sequential"] is False
-
-    def test_update_projects_returns_human_readable_response(self):
-        """Server: update_projects() MCP tool returns human-readable response."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 5,
-                "failed_count": 0,
-                "updated_ids": ["p1", "p2", "p3", "p4", "p5"],
-                "failures": []
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["p1", "p2", "p3", "p4", "p5"],
-                status="active"
-            )
-
+            mock_client.update_project.assert_called_once_with(project_id="p1")
             assert isinstance(result, str)
-            # Should be user-friendly, not raw JSON
-            assert "5" in result
-            assert "project" in result.lower()
-
-
-class TestUpdateProjectsNewParams:
-    """Tests for new parameters: flagged, estimated_minutes, add_tags, remove_tags."""
-
-    def test_update_projects_flagged(self):
-        """Server: update_projects() can set flagged on multiple projects."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 2,
-                "failed_count": 0,
-                "updated_ids": ["proj-1", "proj-2"],
-                "failures": []
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["proj-1", "proj-2"],
-                flagged=True
-            )
-
-            mock_client.update_projects.assert_called_once()
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["flagged"] is True
-            assert "2" in result
-            assert "success" in result.lower() or "updated" in result.lower()
-
-    def test_update_projects_estimated_minutes(self):
-        """Server: update_projects() can set estimated_minutes on multiple projects."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 2,
-                "failed_count": 0,
-                "updated_ids": ["proj-1", "proj-2"],
-                "failures": []
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["proj-1", "proj-2"],
-                estimated_minutes=60
-            )
-
-            mock_client.update_projects.assert_called_once()
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["estimated_minutes"] == 60
-            assert "2" in result
-
-    def test_update_projects_add_tags(self):
-        """Server: update_projects() can add tags to multiple projects."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 2,
-                "failed_count": 0,
-                "updated_ids": ["proj-1", "proj-2"],
-                "failures": []
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["proj-1", "proj-2"],
-                add_tags=["urgent"]
-            )
-
-            mock_client.update_projects.assert_called_once()
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["add_tags"] == ["urgent"]
-            assert "2" in result
-
-    def test_update_projects_remove_tags(self):
-        """Server: update_projects() can remove tags from multiple projects."""
-        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
-            mock_client = mock.Mock()
-            mock_client.update_projects.return_value = {
-                "updated_count": 2,
-                "failed_count": 0,
-                "updated_ids": ["proj-1", "proj-2"],
-                "failures": []
-            }
-            mock_get_client.return_value = mock_client
-
-            update_projects = server.update_projects
-
-            result = update_projects(
-                project_ids=["proj-1", "proj-2"],
-                remove_tags=["old-tag"]
-            )
-
-            mock_client.update_projects.assert_called_once()
-            call_kwargs = mock_client.update_projects.call_args[1]
-            assert call_kwargs["remove_tags"] == ["old-tag"]
-            assert "2" in result


### PR DESCRIPTION
## Summary

Closes #513

New `update_projects(projects: list[ProjectUpdate])` replaces both old functions. Each item has its own id + fields — no more "batch excludes name/note" limitation. Same pattern as update_tasks (#492).

Old `update_project` and `update_projects` (batch) both delegate internally. Net -89 lines.

## Test plan

- [x] 955 tests passing (10 new unified tests, existing tests updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)