### PR TITLE
fix: 7 integration/E2E test failures from v0.12.0 API changes

### DIFF
--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -886,6 +886,8 @@ def create_tasks(tasks: list[TaskCreate]) -> str:
                 result += "\nFlagged: Yes"
             if task.tags:
                 result += f"\nTags: {', '.join(task.tags)}"
+            if task.estimated_minutes:
+                result += f"\nEstimated time: {task.estimated_minutes} minutes"
             return result
         else:
             return f"Error: {r['error']}"

--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -217,8 +217,7 @@ class TestUpdateTasksE2E:
 
         # Call MCP tool
         result = update_tasks(
-            task_ids=task_ids,
-            flagged=True
+            tasks=[{"id": tid, "flagged": True} for tid in task_ids]
         )
 
         assert isinstance(result, str)
@@ -235,14 +234,12 @@ class TestUpdateTasksE2E:
         # Create a single task
         task_id = client.create_task("E2E Single Update Task", project_id=test_project)
 
-        # Call MCP tool with single ID as string
+        # Call MCP tool with single ID wrapped in list
         result = update_tasks(
-            task_ids=task_id,  # Single ID as string
-            flagged=False
+            tasks=[{"id": task_id, "flagged": False}]
         )
 
         assert isinstance(result, str)
-        assert "1" in result  # Should mention 1 task
         assert "updated" in result.lower()
 
         print(f"\n✓ E2E update_tasks single ID: {result}")
@@ -380,8 +377,10 @@ class TestUpdateProjectsE2E:
 
         # Call the MCP tool
         result = server.update_projects(
-            project_ids=[proj_id_1, proj_id_2],
-            status="on_hold"
+            projects=[
+                {"id": proj_id_1, "status": "on_hold"},
+                {"id": proj_id_2, "status": "on_hold"},
+            ]
         )
 
         # Verify MCP tool returns human-readable response
@@ -400,7 +399,7 @@ class TestUpdateProjectsE2E:
         proj_id = client.create_project("E2E Single ID")
 
         # Call MCP tool
-        result = server.update_projects(project_ids=proj_id, sequential=True)
+        result = server.update_projects(projects=[{"id": proj_id, "sequential": True}])
 
         assert isinstance(result, str)
         assert "1" in result  # Should mention 1 project

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -506,7 +506,7 @@ class TestProjectCRUD:
         assert result["success"] is True
 
         # Verify actual status change
-        projects = client.get_projects(project_id=test_project)
+        projects = client.get_projects(project_id=test_project, include_completed=True)
         assert len(projects) == 1
         assert projects[0]['status'] == 'done status'
         print("\n✓ Marked project as done (verified)")
@@ -687,8 +687,8 @@ class TestProjectCRUD:
         Validates the AppleScript patterns: mark dropped, set status to active status,
         mark complete, set status to on hold (#359, #370).
         """
-        def assert_status(expected_status, include_dropped=False):
-            projects = client.get_projects(project_id=test_project, include_dropped=include_dropped)
+        def assert_status(expected_status, include_dropped=False, include_completed=False):
+            projects = client.get_projects(project_id=test_project, include_dropped=include_dropped, include_completed=include_completed)
             assert len(projects) == 1, f"Project not found after setting status to {expected_status}"
             actual = projects[0]['status']
             assert actual == expected_status, \
@@ -721,7 +721,7 @@ class TestProjectCRUD:
         # ACTIVE → DONE
         result = client.update_project(test_project, status="done")
         assert result["success"] is True
-        assert_status('done status')
+        assert_status('done status', include_completed=True)
         print("✓ ACTIVE → DONE")
 
     def test_update_project_set_review_interval_integration(self, client, test_project):


### PR DESCRIPTION
## Summary

Closes #526, closes #525

Pre-release test suite (179 integration + E2E tests) found 7 failures, all from v0.12.0 API changes:

- 4 E2E tests updated from old task_ids/project_ids signature to new Pydantic model format
- 2 integration tests added include_completed=True for done project read-back (#501 effect)
- 1 server fix: estimated_minutes added to create_tasks single-item response
- 1 assertion fix: removed stale count check for single-item update

All 7 previously-failing tests now pass. 978 unit tests pass.

## Test plan

- [x] 978 unit tests passing
- [x] 7/7 previously-failing integration/E2E tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)