### PR TITLE
chore: refactor _filter_by_date_range to reduce complexity (#512)

### DIFF
--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -63,7 +63,7 @@ echo ""
 #   - _build_update_task_commands: CC ≤ 30 (29 current - 17 updatable fields)
 #   - _post_process_tasks: CC ≤ 29 (28 current - normalization + 6 filter steps)
 #   - _filter_projects_by_conditions: CC ≤ 25 (24 current - 3 conditions × pos/neg matching)
-#   - _filter_by_date_range: CC ≤ 27 (26 current - 3 date range checks: created, modified, planned)
+#   - _filter_by_date_range: CC ≤ 6 (5 current - delegates to _item_passes_date_check)
 #   - _post_process_projects: CC ≤ 29 (28 current - projectType + 9 filter steps incl. tags, planned dates, flagged, completed)
 #
 # Original functions not yet refactored:
@@ -93,7 +93,7 @@ try:
                     continue
                 elif name == '_filter_projects_by_conditions' and cc <= 25:
                     continue
-                elif name == '_filter_by_date_range' and cc <= 27:
+                elif name == '_filter_by_date_range' and cc <= 6:
                     continue
                 elif name == '_post_process_projects' and cc <= 29:
                     continue

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -403,6 +403,29 @@ class OmniFocusConnector:
 
         return filtered
 
+    @staticmethod
+    def _item_passes_date_check(
+        item: dict[str, Any],
+        field_key: str,
+        after_date: Optional[str],
+        before_date: Optional[str],
+    ) -> bool:
+        """Check if an item's date field passes after/before filters.
+
+        Returns True if no filters are active, or if the item's date is within bounds.
+        Returns False if the date is missing/empty when filters are active, or out of bounds.
+        """
+        if not after_date and not before_date:
+            return True
+        date_value = item.get(field_key, '')
+        if not date_value:
+            return False
+        if after_date and date_value < after_date:
+            return False
+        if before_date and date_value > before_date:
+            return False
+        return True
+
     def _filter_by_date_range(
         self,
         items: list[dict[str, Any]],
@@ -413,65 +436,13 @@ class OmniFocusConnector:
         planned_after: Optional[str] = None,
         planned_before: Optional[str] = None,
     ) -> list[dict[str, Any]]:
-        """Filter items by date ranges.
-
-        Args:
-            items: List of task or project dictionaries to filter
-            created_after: Only include items created after this date
-            created_before: Only include items created before this date
-            modified_after: Only include items modified after this date
-            modified_before: Only include items modified before this date
-            planned_after: Only include items with planned date on or after this date
-            planned_before: Only include items with planned date before this date
-
-        Returns:
-            Filtered list of items
-        """
-        filtered = []
-
-        for item in items:
-            include = True
-
-            # Check creation date filters
-            if created_after or created_before:
-                creation_date = item.get('creationDate', '')
-                if creation_date:
-                    if created_after and creation_date < created_after:
-                        include = False
-                    if created_before and creation_date > created_before:
-                        include = False
-                else:
-                    # No creation date - exclude if filtering by creation date
-                    include = False
-
-            # Check modification date filters
-            if include and (modified_after or modified_before):
-                mod_date = item.get('modificationDate', '')
-                if mod_date:
-                    if modified_after and mod_date < modified_after:
-                        include = False
-                    if modified_before and mod_date > modified_before:
-                        include = False
-                else:
-                    # No modification date - exclude if filtering by modification date
-                    include = False
-
-            # Check planned date filters
-            if include and (planned_after or planned_before):
-                planned_date = item.get('plannedDate', '')
-                if planned_date:
-                    if planned_after and planned_date < planned_after:
-                        include = False
-                    if planned_before and planned_date > planned_before:
-                        include = False
-                else:
-                    # No planned date - exclude if filtering by planned date
-                    include = False
-
-            if include:
-                filtered.append(item)
-
-        return filtered
+        """Filter items by date ranges (created, modified, planned)."""
+        return [
+            item for item in items
+            if (self._item_passes_date_check(item, 'creationDate', created_after, created_before)
+                and self._item_passes_date_check(item, 'modificationDate', modified_after, modified_before)
+                and self._item_passes_date_check(item, 'plannedDate', planned_after, planned_before))
+        ]
 
     def _filter_tasks_by_tags(self, tasks: list[dict[str, Any]], tag_filter: list[str], mode: str) -> list[dict[str, Any]]:
         """Filter tasks by tags using boolean logic.

--- a/tests/test_date_range_filtering.py
+++ b/tests/test_date_range_filtering.py
@@ -130,3 +130,63 @@ class TestProjectDateRangeFiltering:
 
             assert len(projects) == 1
             assert projects[0]['id'] == "p1"
+
+
+class TestItemPassesDateCheck:
+    """Tests for _item_passes_date_check helper."""
+
+    def test_no_filters_returns_true(self):
+        """No after/before filters means item always passes."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"creationDate": "2025-01-15T10:00:00Z"}, "creationDate", None, None
+        ) is True
+
+    def test_after_filter_passes(self):
+        """Item date after the threshold passes."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"creationDate": "2025-01-20T10:00:00Z"}, "creationDate", "2025-01-15T00:00:00Z", None
+        ) is True
+
+    def test_after_filter_fails(self):
+        """Item date before the threshold fails."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"creationDate": "2025-01-10T10:00:00Z"}, "creationDate", "2025-01-15T00:00:00Z", None
+        ) is False
+
+    def test_before_filter_passes(self):
+        """Item date before the threshold passes."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"creationDate": "2025-01-10T10:00:00Z"}, "creationDate", None, "2025-01-15T00:00:00Z"
+        ) is True
+
+    def test_before_filter_fails(self):
+        """Item date after the threshold fails."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"creationDate": "2025-01-20T10:00:00Z"}, "creationDate", None, "2025-01-15T00:00:00Z"
+        ) is False
+
+    def test_missing_date_field_excluded(self):
+        """Item without the date field is excluded when filter is active."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"id": "t1"}, "creationDate", "2025-01-15T00:00:00Z", None
+        ) is False
+
+    def test_empty_date_field_excluded(self):
+        """Item with empty string date is excluded when filter is active."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"creationDate": ""}, "creationDate", "2025-01-15T00:00:00Z", None
+        ) is False
+
+    def test_range_filter_both_bounds(self):
+        """Item within both bounds passes."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"modificationDate": "2025-01-15T10:00:00Z"}, "modificationDate",
+            "2025-01-10T00:00:00Z", "2025-01-20T00:00:00Z"
+        ) is True
+
+    def test_range_filter_outside_bounds(self):
+        """Item outside both bounds fails."""
+        assert OmniFocusConnector._item_passes_date_check(
+            {"modificationDate": "2025-01-25T10:00:00Z"}, "modificationDate",
+            "2025-01-10T00:00:00Z", "2025-01-20T00:00:00Z"
+        ) is False


### PR DESCRIPTION
## Summary

- Extract `_item_passes_date_check` static helper from `_filter_by_date_range`
- Eliminates 3 identical date check blocks (created, modified, planned)
- CC reduced from 26 → 5 (helper is CC 8)
- Complexity threshold lowered from 27 to 6

Closes #512

## Test plan

- [x] 9 new unit tests for `_item_passes_date_check` helper
- [x] All 18 date range tests pass
- [x] Full test suite: 987 passed, 268 skipped
- [x] Complexity check passes with lowered threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)