### PR TITLE
chore: refactor _post_process_projects to reduce complexity (#521)

### DIFF
--- a/scripts/check_complexity.sh
+++ b/scripts/check_complexity.sh
@@ -64,7 +64,7 @@ echo ""
 #   - _post_process_tasks: CC ≤ 29 (28 current - normalization + 6 filter steps)
 #   - _filter_projects_by_conditions: CC ≤ 25 (24 current - 3 conditions × pos/neg matching)
 #   - _filter_by_date_range: CC ≤ 6 (5 current - delegates to _item_passes_date_check)
-#   - _post_process_projects: CC ≤ 29 (28 current - projectType + 9 filter steps incl. tags, planned dates, flagged, completed)
+#   - _post_process_projects: CC ≤ 19 (18 current - delegates to _compute_project_types, _filter_projects_by_query, _compute_stalled_status)
 #
 # Original functions not yet refactored:
 #   - update_projects: CC ≤ 60 (59 current — #417 added flagged/estimated/tags, #506 added review_interval_value/unit)
@@ -95,7 +95,7 @@ try:
                     continue
                 elif name == '_filter_by_date_range' and cc <= 6:
                     continue
-                elif name == '_post_process_projects' and cc <= 29:
+                elif name == '_post_process_projects' and cc <= 19:
                     continue
                 # Original functions
                 elif name == 'update_projects' and cc <= 60:

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -814,6 +814,40 @@ class OmniFocusConnector:
         if sort_order not in valid_sort_order:
             raise ValueError(f"Invalid sort_order value: {sort_order}. Must be one of: {valid_sort_order}")
 
+    @staticmethod
+    def _compute_project_types(projects: list[dict[str, Any]]) -> None:
+        """Set projectType from singleton and sequential flags (mutates in place)."""
+        for p in projects:
+            if p.get("singletonActionHolder"):
+                p["projectType"] = "single_actions"
+            elif p.get("sequential"):
+                p["projectType"] = "sequential"
+            else:
+                p["projectType"] = "parallel"
+
+    @staticmethod
+    def _filter_projects_by_query(
+        projects: list[dict[str, Any]], query: str
+    ) -> list[dict[str, Any]]:
+        """Filter projects by case-insensitive text match on name, note, or folderPath."""
+        query_lower = query.lower()
+        return [
+            p for p in projects
+            if query_lower in p.get('name', '').lower()
+            or query_lower in p.get('note', '').lower()
+            or query_lower in p.get('folderPath', '').lower()
+        ]
+
+    @staticmethod
+    def _compute_stalled_status(projects: list[dict[str, Any]]) -> None:
+        """Compute stalled field from task health data (mutates in place)."""
+        for p in projects:
+            p["stalled"] = (
+                p.get("status") == "active status"
+                and p.get("availableCount", 1) == 0
+                and not p.get("hasDeferredOnly", False)
+            )
+
     def _post_process_projects(
         self,
         projects: list[dict[str, Any]],
@@ -834,60 +868,34 @@ class OmniFocusConnector:
         planned_before: Optional[str] = None,
     ) -> list[dict[str, Any]]:
         """Post-process projects: compute types, apply filters, sort."""
-        # Compute projectType from singleton and sequential flags
-        for p in projects:
-            if p.get("singletonActionHolder"):
-                p["projectType"] = "single_actions"
-            elif p.get("sequential"):
-                p["projectType"] = "sequential"
-            else:
-                p["projectType"] = "parallel"
+        self._compute_project_types(projects)
 
-        # Apply date range filtering
         if modified_after or modified_before or planned_after or planned_before:
             projects = self._filter_by_date_range(
                 projects, None, None, modified_after, modified_before,
                 planned_after, planned_before
             )
 
-        # Apply conditional filters
         if min_task_count is not None or has_overdue_tasks is not None or has_no_due_dates is not None:
             projects = self._filter_projects_by_conditions(
                 projects, min_task_count, has_overdue_tasks, has_no_due_dates
             )
 
-        # Apply query filter
         if query:
-            query_lower = query.lower()
-            projects = [
-                p for p in projects
-                if query_lower in p.get('name', '').lower()
-                or query_lower in p.get('note', '').lower()
-                or query_lower in p.get('folderPath', '').lower()
-            ]
+            projects = self._filter_projects_by_query(projects, query)
 
-        # Apply tag filter
         if tag_filter:
             projects = self._filter_tasks_by_tags(projects, tag_filter, "and")
 
-        # Compute stalled field when task health is available
         if include_task_health:
-            for p in projects:
-                p["stalled"] = (
-                    p.get("status") == "active status"
-                    and p.get("availableCount", 1) == 0
-                    and not p.get("hasDeferredOnly", False)
-                )
+            self._compute_stalled_status(projects)
 
-        # Filter to stalled projects only
         if stalled_only:
             projects = [p for p in projects if p.get("stalled", False)]
 
-        # Filter to flagged projects only
         if flagged_only:
             projects = [p for p in projects if p.get("flagged", False)]
 
-        # Apply sorting
         if sort_by:
             reverse = (sort_order == "desc")
             projects = sorted(projects, key=lambda p: p.get("name", "").lower(), reverse=reverse)

--- a/tests/test_get_projects_helpers.py
+++ b/tests/test_get_projects_helpers.py
@@ -193,3 +193,81 @@ class TestPostProcessProjects:
         projects = [self._sample_project()]
         result = client._post_process_projects(projects, **self._default_params())
         assert len(result) == 1
+
+
+# ── Extracted helpers ─────────────────────────────────────────────────────
+
+
+class TestComputeProjectTypes:
+
+    def test_parallel_default(self):
+        projects = [{"singletonActionHolder": False, "sequential": False}]
+        OmniFocusConnector._compute_project_types(projects)
+        assert projects[0]["projectType"] == "parallel"
+
+    def test_sequential(self):
+        projects = [{"singletonActionHolder": False, "sequential": True}]
+        OmniFocusConnector._compute_project_types(projects)
+        assert projects[0]["projectType"] == "sequential"
+
+    def test_single_actions(self):
+        projects = [{"singletonActionHolder": True, "sequential": False}]
+        OmniFocusConnector._compute_project_types(projects)
+        assert projects[0]["projectType"] == "single_actions"
+
+    def test_singleton_takes_precedence(self):
+        """singletonActionHolder checked first, even if sequential is also True."""
+        projects = [{"singletonActionHolder": True, "sequential": True}]
+        OmniFocusConnector._compute_project_types(projects)
+        assert projects[0]["projectType"] == "single_actions"
+
+
+class TestFilterProjectsByQuery:
+
+    def test_matches_name(self):
+        projects = [{"name": "Marketing Plan", "note": "", "folderPath": ""}]
+        result = OmniFocusConnector._filter_projects_by_query(projects, "marketing")
+        assert len(result) == 1
+
+    def test_matches_note(self):
+        projects = [{"name": "P1", "note": "Review marketing budget", "folderPath": ""}]
+        result = OmniFocusConnector._filter_projects_by_query(projects, "marketing")
+        assert len(result) == 1
+
+    def test_matches_folder_path(self):
+        projects = [{"name": "P1", "note": "", "folderPath": "Work/Marketing"}]
+        result = OmniFocusConnector._filter_projects_by_query(projects, "marketing")
+        assert len(result) == 1
+
+    def test_no_match(self):
+        projects = [{"name": "Engineering", "note": "Code review", "folderPath": "Work"}]
+        result = OmniFocusConnector._filter_projects_by_query(projects, "marketing")
+        assert len(result) == 0
+
+    def test_case_insensitive(self):
+        projects = [{"name": "MARKETING", "note": "", "folderPath": ""}]
+        result = OmniFocusConnector._filter_projects_by_query(projects, "marketing")
+        assert len(result) == 1
+
+
+class TestComputeStalledStatus:
+
+    def test_stalled_when_active_no_available(self):
+        projects = [{"status": "active status", "availableCount": 0, "hasDeferredOnly": False}]
+        OmniFocusConnector._compute_stalled_status(projects)
+        assert projects[0]["stalled"] is True
+
+    def test_not_stalled_when_has_available(self):
+        projects = [{"status": "active status", "availableCount": 3, "hasDeferredOnly": False}]
+        OmniFocusConnector._compute_stalled_status(projects)
+        assert projects[0]["stalled"] is False
+
+    def test_not_stalled_when_on_hold(self):
+        projects = [{"status": "on hold status", "availableCount": 0, "hasDeferredOnly": False}]
+        OmniFocusConnector._compute_stalled_status(projects)
+        assert projects[0]["stalled"] is False
+
+    def test_not_stalled_when_deferred_only(self):
+        projects = [{"status": "active status", "availableCount": 0, "hasDeferredOnly": True}]
+        OmniFocusConnector._compute_stalled_status(projects)
+        assert projects[0]["stalled"] is False


### PR DESCRIPTION
## Summary

- Extract `_compute_project_types` (CC 4), `_filter_projects_by_query` (CC 5), `_compute_stalled_status` (CC 4)
- `_post_process_projects` CC reduced from 28 → 18
- Complexity threshold lowered from 29 to 19

Closes #521

## Test plan

- [x] 13 new unit tests for 3 extracted helpers
- [x] All 33 project helper tests pass
- [x] Full test suite: 1000 passed, 268 skipped
- [x] Complexity check passes with lowered threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)