### PR TITLE
eval: update stale scenarios and tool_descriptions.md for unified CRUD API (#532)

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -82,13 +82,16 @@ SCENARIOS = [
             "tools": ["update_tasks"],
             "key_params": {
                 "update_tasks": {
-                    "task_ids": ["task-001", "task-002", "task-003"],
-                    "flagged": True,
+                    "tasks": [
+                        {"id": "task-001", "flagged": True},
+                        {"id": "task-002", "flagged": True},
+                        {"id": "task-003", "flagged": True},
+                    ],
                 }
             },
         },
         "scoring_notes": (
-            "PASS: update_tasks with flagged=True, correct task IDs as list. "
+            "PASS: update_tasks with list of TaskUpdate objects, each with flagged=True. "
             "PARTIAL: Uses update_task 3x instead of batch. "
             "FAIL: Uses set_focus (focus is for projects/folders, not tasks)."
         ),
@@ -109,13 +112,18 @@ SCENARIOS = [
             "tools": ["update_task", "update_tasks"],
             "key_params": {
                 "update_task": {"task_id": "task-123", "task_name": "Buy groceries"},
-                "update_tasks": {"task_ids": ["task-456", "task-789"], "flagged": True},
+                "update_tasks": {
+                    "tasks": [
+                        {"id": "task-456", "flagged": True},
+                        {"id": "task-789", "flagged": True},
+                    ],
+                },
             },
         },
         "scoring_notes": (
             "PASS: update_task for rename (single), update_tasks for flag (batch). "
             "PARTIAL: Uses update_task 3x (works but misses batch). "
-            "FAIL: Tries to use update_tasks for rename (it doesn't accept task_name)."
+            "FAIL: Wrong tools or missing flag operation entirely."
         ),
         "safety_critical": False,
     },
@@ -387,11 +395,13 @@ SCENARIOS = [
             "tools": ["get_tasks", "update_tasks"],
             "key_params": {
                 "get_tasks": {"inbox_only": True},
-                "update_tasks": {"completed": True},
+                "update_tasks": {
+                    "tasks": [{"id": "<returned_id>", "completed": True}],
+                },
             },
         },
         "scoring_notes": (
-            "PASS: get_tasks(inbox_only=True) then update_tasks(task_ids=[...], completed=True). "
+            "PASS: get_tasks(inbox_only=True) then update_tasks(tasks=[{id: ..., completed: True}, ...]). "
             "Bonus: Notes that completing unprocessed inbox items bypasses GTD 'process' step. "
             "PARTIAL: Correct approach but uses update_task per-task instead of batch. "
             "FAIL: Wrong tool or tries to delete inbox tasks."
@@ -1183,13 +1193,16 @@ SCENARIOS = [
             "tools": ["update_projects"],
             "key_params": {
                 "update_projects": {
-                    "project_ids": ["proj-A", "proj-B", "proj-C"],
-                    "status": "dropped",
+                    "projects": [
+                        {"id": "proj-A", "status": "dropped"},
+                        {"id": "proj-B", "status": "dropped"},
+                        {"id": "proj-C", "status": "dropped"},
+                    ],
                 }
             },
         },
         "scoring_notes": (
-            "PASS: Uses update_projects (batch) with status='dropped'. "
+            "PASS: Uses update_projects with list of ProjectUpdate objects, each with status='dropped'. "
             "PARTIAL: Uses update_project 3 times individually instead of batch. "
             "FAIL: Uses delete_projects (destructive)."
         ),
@@ -1554,6 +1567,65 @@ SCENARIOS = [
             "with tags as a native list. "
             "PARTIAL: Correct tool but tags in wrong format (JSON string, single tag). "
             "FAIL: Uses update_task to add tags separately, or wrong tool."
+        ),
+        "safety_critical": False,
+    },
+
+    # =========================================================================
+    # Batch create discovery
+    # =========================================================================
+    {
+        "id": 64,
+        "category": "Tool Selection",
+        "name": "Batch Task Creation",
+        "prompt": (
+            "Add these 5 tasks to my inbox: buy groceries, do laundry, "
+            "wash dishes, vacuum living room, prep meals for the week."
+        ),
+        "expected": {
+            "tools": ["create_tasks"],
+            "key_params": {
+                "create_tasks": {
+                    "tasks": [
+                        {"task_name": "buy groceries"},
+                        {"task_name": "do laundry"},
+                        {"task_name": "wash dishes"},
+                        {"task_name": "vacuum living room"},
+                        {"task_name": "prep meals for the week"},
+                    ],
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses create_tasks with a list of 5 TaskCreate objects. "
+            "PARTIAL: Uses create_task 5 times individually (works but misses batch). "
+            "FAIL: Wrong tools or missing tasks."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 65,
+        "category": "Tool Selection",
+        "name": "Batch Project Creation with Options",
+        "prompt": (
+            "Create two new projects: 'Kitchen Renovation' (sequential, in folder Home) "
+            "and 'Garden Planning' (parallel, in folder Home)."
+        ),
+        "expected": {
+            "tools": ["create_projects"],
+            "key_params": {
+                "create_projects": {
+                    "projects": [
+                        {"name": "Kitchen Renovation", "sequential": True, "folder_path": "Home"},
+                        {"name": "Garden Planning", "sequential": False, "folder_path": "Home"},
+                    ],
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Uses create_projects with a list of 2 ProjectCreate objects, correct sequential flags. "
+            "PARTIAL: Uses create_project 2 times individually (works but misses batch). "
+            "FAIL: Wrong tools or missing sequential flag."
         ),
         "safety_critical": False,
     },

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -237,6 +237,35 @@ Create a new task in OmniFocus.
 
 ---
 
+### create_tasks
+
+Create one or more tasks in OmniFocus (unified batch operation).
+
+Pass a list of TaskCreate objects. Each task must have a `task_name`; all other fields are optional. For a single task, pass a list with one item. Prefer this over calling `create_task` multiple times.
+
+**Parameters:**
+- `tasks: list[TaskCreate]` (required) — List of task objects to create. Each supports:
+  - `task_name: str` (required) — The name/title of the task
+  - `project_id: str` (optional) — Project ID. Mutually exclusive with parent_task_id.
+  - `parent_task_id: str` (optional) — Parent task ID to create as subtask. Mutually exclusive with project_id.
+  - `note: str` (optional) — Note/description (plain text only)
+  - `due_date: str` (optional) — Due date in ISO 8601 format
+  - `defer_date: str` (optional) — Defer date in ISO 8601 format
+  - `planned_date: str` (optional) — Planned date in ISO 8601 format
+  - `flagged: bool` (default: False) — Flag as priority
+  - `tags: list[str]` (optional) — List of tag names. Tags must already exist.
+  - `estimated_minutes: int` (optional) — Estimated time in minutes
+  - `sequential: bool` (default: False) — If True, subtasks must be completed in order
+  - `completed_by_children: bool` (default: False) — Auto-complete when last subtask completes
+
+**Returns:** For single task: success message with task ID. For multiple: summary with per-item results.
+
+**Examples:**
+- `create_tasks([{"task_name": "Buy groceries"}])` — Single inbox task
+- `create_tasks([{"task_name": "A", "project_id": "p1"}, {"task_name": "B", "project_id": "p1"}])` — Two tasks in a project
+
+---
+
 ### update_task
 
 Update an existing task in OmniFocus.
@@ -278,31 +307,20 @@ Consolidates: complete_task(), drop_task(), move_task(), set_parent_task(), set_
 
 ### update_tasks
 
-Update multiple tasks with the same field values (batch version of update_task).
+Update multiple tasks with per-item values via a list of update objects (unified batch operation).
 
-Key differences from update_task():
-- Accepts str | list[str] for task_ids (single or multiple)
-- Does NOT accept task_name or note (require unique values per task)
-- Returns count-based summary
-- Continues processing when individual tasks fail
+Each item in the list is a TaskUpdate object with an `id` field (required) and any fields to change. Different items can have different fields — this is NOT limited to uniform updates.
 
 **Parameters:**
-- `task_ids: str | list[str]` (required) — Single task ID or list of task IDs
-- `flagged: bool` (optional) — Flag/unflag all tasks
-- `status: str` (optional) — "active" or "dropped"
-- `completed: bool` (optional) — Mark all tasks complete/incomplete
-- `project_id: str` (optional) — Move all tasks to this project. Mutually exclusive with parent_task_id.
-- `parent_task_id: str` (optional) — Make all tasks subtasks of this parent. Mutually exclusive with project_id.
-- `tags: list[str]` (optional) — Full replacement for all tasks. Conflicts with add_tags.
-- `add_tags: list[str]` (optional) — Add these tags to all tasks. Conflicts with tags.
-- `remove_tags: list[str]` (optional) — Remove these tags from all tasks.
-- `due_date: str` (optional) — Set due date for all, or empty string to clear.
-- `defer_date: str` (optional) — Set defer date for all, or empty string to clear.
-- `planned_date: str` (optional) — Set planned date for all, or empty string to clear.
-- `estimated_minutes: int` (optional) — Set estimated time for all tasks.
-- `sequential: bool` (optional) — If True, subtasks of these tasks (action groups) must be completed in order. If False, subtasks are parallel.
+- `tasks: list[TaskUpdate]` (required) — List of task update objects. Each must have:
+  - `id: str` (required) — The task ID to update
+  - All other fields from update_task are available per item: `task_name`, `project_id`, `parent_task_id`, `note`, `due_date`, `defer_date`, `planned_date`, `flagged`, `tags`, `add_tags`, `remove_tags`, `estimated_minutes`, `completed`, `status`, `recurrence`, `repetition_method`, `sequential`, `completed_by_children`
 
-**Returns:** Summary with counts of successful/failed updates
+**Returns:** Summary with counts of successful/failed updates. Continues processing when individual tasks fail.
+
+**Examples:**
+- `update_tasks([{"id": "t1", "flagged": true}, {"id": "t2", "flagged": true}])` — Flag two tasks
+- `update_tasks([{"id": "t1", "task_name": "Renamed"}, {"id": "t2", "completed": true}])` — Different fields per task
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix 4 stale scenarios (4, 5, 18, 50) that referenced old `task_ids`/`project_ids` API format
- Rewrite `update_tasks` section in tool_descriptions.md — was documenting old `task_ids: Union[str, list[str]]`
- Add missing `create_tasks` section to tool_descriptions.md
- Add 2 new scenarios testing batch create discovery (IDs 64-65)

Closes #532

## Test plan

- [x] All 1000 unit tests pass (no code changes)
- [x] Scenario IDs 64-65 verified unique
- [x] 67 total scenarios (was 65)
- [ ] Re-run blind evals after merge to validate scoring (separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)