### PR TITLE
test: add Pydantic conflict validation tests and write benchmark assertions (#534)

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -263,6 +263,17 @@ class TestReadBenchmarks:
         br = _benchmark("get_perspectives", lambda: client.get_perspectives())
         assert br.mean < 5.0, f"get_perspectives() regression: {br.mean:.2f}s (baseline: 0.96s, threshold: 5.0s)"
 
+    def test_get_projects_compound_filters(self, client):
+        """get_projects() with multiple filters stacked."""
+        br = _benchmark(
+            "get_projects (compound filters)",
+            lambda: client.get_projects(
+                flagged_only=True, include_task_health=True,
+                planned_after="2026-01-01"
+            ),
+        )
+        assert br.mean < 5.0, f"get_projects compound filter regression: {br.mean:.2f}s (threshold: 5.0s)"
+
 
 class TestWriteBenchmarks:
     """Benchmark write operations (creates and cleans up test data)."""
@@ -282,7 +293,8 @@ class TestWriteBenchmarks:
             task_ids.append(tid)
             return tid
 
-        _benchmark("create_task", create, iterations=WRITE_ITERATIONS)
+        br = _benchmark("create_task", create, iterations=WRITE_ITERATIONS)
+        assert br.mean < 5.0, f"create_task regression: {br.mean:.2f}s (baseline: ~0.9s, threshold: 5.0s)"
         for tid in task_ids:
             try:
                 client.delete_tasks(tid)
@@ -303,7 +315,8 @@ class TestWriteBenchmarks:
                 client.update_task(task_id, flagged=toggle[idx % len(toggle)])
                 idx += 1
 
-            _benchmark("update_task", update, iterations=WRITE_ITERATIONS)
+            br = _benchmark("update_task", update, iterations=WRITE_ITERATIONS)
+            assert br.mean < 5.0, f"update_task regression: {br.mean:.2f}s (baseline: ~0.9s, threshold: 5.0s)"
         finally:
             try:
                 client.delete_tasks(task_id)
@@ -320,7 +333,9 @@ class TestWriteBenchmarks:
             start = time.perf_counter()
             client.delete_tasks(task_id)
             times.append(time.perf_counter() - start)
-        BenchmarkResult("delete_tasks", times).report()
+        br = BenchmarkResult("delete_tasks", times)
+        br.report()
+        assert br.mean < 5.0, f"delete_tasks regression: {br.mean:.2f}s (threshold: 5.0s)"
 
     def test_create_project(self, client):
         """create_project() — single project creation."""
@@ -331,7 +346,8 @@ class TestWriteBenchmarks:
             project_ids.append(pid)
             return pid
 
-        _benchmark("create_project", create, iterations=WRITE_ITERATIONS)
+        br = _benchmark("create_project", create, iterations=WRITE_ITERATIONS)
+        assert br.mean < 5.0, f"create_project regression: {br.mean:.2f}s (baseline: ~0.9s, threshold: 5.0s)"
         for pid in project_ids:
             try:
                 client.delete_projects(pid)
@@ -348,7 +364,8 @@ class TestWriteBenchmarks:
             client.update_project(test_project, sequential=toggle[idx % len(toggle)])
             idx += 1
 
-        _benchmark("update_project", update, iterations=WRITE_ITERATIONS)
+        br = _benchmark("update_project", update, iterations=WRITE_ITERATIONS)
+        assert br.mean < 5.0, f"update_project regression: {br.mean:.2f}s (baseline: ~0.9s, threshold: 5.0s)"
 
     def test_delete_project(self, client):
         """delete_projects() — single project deletion."""
@@ -358,7 +375,9 @@ class TestWriteBenchmarks:
             start = time.perf_counter()
             client.delete_projects(pid)
             times.append(time.perf_counter() - start)
-        BenchmarkResult("delete_projects", times).report()
+        br = BenchmarkResult("delete_projects", times)
+        br.report()
+        assert br.mean < 5.0, f"delete_projects regression: {br.mean:.2f}s (threshold: 5.0s)"
 
     def test_reorder_project(self, client):
         """reorder_project() — move project before another."""
@@ -377,7 +396,8 @@ class TestWriteBenchmarks:
                     client.reorder_project(p1, after_project_id=p2)
                 idx += 1
 
-            _benchmark("reorder_project", reorder, iterations=WRITE_ITERATIONS)
+            br = _benchmark("reorder_project", reorder, iterations=WRITE_ITERATIONS)
+            assert br.mean < 5.0, f"reorder_project regression: {br.mean:.2f}s (threshold: 5.0s)"
         finally:
             try:
                 client.delete_projects([p1, p2])
@@ -403,11 +423,12 @@ class TestWriteBenchmarks:
                 client.update_tasks(task_ids, flagged=toggle[idx % len(toggle)])
                 idx += 1
 
-            _benchmark(
+            br = _benchmark(
                 f"update_tasks ({batch_size} tasks)",
                 batch_update,
                 iterations=WRITE_ITERATIONS,
             )
+            assert br.mean < 15.0, f"update_tasks batch regression: {br.mean:.2f}s (threshold: 15.0s)"
         finally:
             try:
                 client.delete_tasks(task_ids)
@@ -433,11 +454,12 @@ class TestWriteBenchmarks:
                 )
                 idx += 1
 
-            _benchmark(
+            br = _benchmark(
                 f"update_projects ({batch_size} projects)",
                 batch_update,
                 iterations=WRITE_ITERATIONS,
             )
+            assert br.mean < 15.0, f"update_projects batch regression: {br.mean:.2f}s (threshold: 15.0s)"
         finally:
             try:
                 client.delete_projects(project_ids)
@@ -458,7 +480,9 @@ class TestWriteBenchmarks:
                 client.delete_tasks(tid)
             except Exception:
                 pass
-        BenchmarkResult("mark_complete (single)", times).report()
+        br = BenchmarkResult("mark_complete (single)", times)
+        br.report()
+        assert br.mean < 5.0, f"mark_complete regression: {br.mean:.2f}s (threshold: 5.0s)"
 
     def test_mark_complete_batch(self, client, test_project):
         """update_tasks(completed=True) — batch mark complete."""
@@ -474,7 +498,9 @@ class TestWriteBenchmarks:
         start = time.perf_counter()
         client.update_tasks(task_ids, completed=True)
         elapsed = time.perf_counter() - start
-        BenchmarkResult(f"mark_complete (batch {batch_size})", [elapsed]).report()
+        br = BenchmarkResult(f"mark_complete (batch {batch_size})", [elapsed])
+        br.report()
+        assert br.mean < 15.0, f"mark_complete batch regression: {br.mean:.2f}s (threshold: 15.0s)"
 
         try:
             client.delete_tasks(task_ids)

--- a/tests/test_server_redesign_create.py
+++ b/tests/test_server_redesign_create.py
@@ -266,6 +266,25 @@ class TestCreateTasksUnified:
             assert "1" in result  # 1 failed
             assert "Bad Task" in result or "failed" in result.lower()
 
+    def test_create_tasks_rejects_project_id_and_parent_task_id(self):
+        """create_tasks: single item with both project_id and parent_task_id returns error."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_task.side_effect = ValueError(
+                "Cannot specify both project_id and parent_task_id"
+            )
+            mock_get_client.return_value = mock_client
+
+            create_tasks = server.create_tasks
+            result = create_tasks(tasks=[{
+                "task_name": "Conflicting Task",
+                "project_id": "proj-1",
+                "parent_task_id": "task-parent",
+            }])
+
+            assert "error" in result.lower()
+            assert "project_id" in result.lower() or "parent_task_id" in result.lower()
+
     def test_create_tasks_with_all_fields(self):
         """create_tasks passes all fields through to connector."""
         with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:

--- a/tests/test_server_redesign_update.py
+++ b/tests/test_server_redesign_update.py
@@ -789,3 +789,35 @@ class TestUpdateTasksUnified:
             assert call_kwargs["task_id"] == "task-001"
             assert call_kwargs["flagged"] is True
             assert "Successfully updated task task-001" in result
+
+    # ========================================================================
+    # Conflict Validation (#534)
+    # ========================================================================
+
+    def test_update_tasks_rejects_tags_with_add_tags(self):
+        """tags + add_tags conflict detected at connector level, error returned."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.side_effect = ValueError(
+                "Cannot specify both tags and add_tags"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = update_tasks([{"id": "t1", "tags": ["x"], "add_tags": ["y"]}])
+
+            assert "error" in result.lower() or "FAILED" in result
+            mock_client.update_task.assert_called_once()
+
+    def test_update_task_rejects_tags_with_add_tags(self):
+        """tags + add_tags conflict via single update_task path."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_task.side_effect = ValueError(
+                "Cannot specify both tags and add_tags"
+            )
+            mock_get_client.return_value = mock_client
+
+            result = update_task("t1", tags=["x"], add_tags=["y"])
+
+            assert "error" in result.lower() or "FAILED" in result
+            mock_client.update_task.assert_called_once()


### PR DESCRIPTION
## Summary

- **3 conflict validation tests**: `tags`+`add_tags` on `update_tasks`/`update_task`, `project_id`+`parent_task_id` on `create_tasks`
- **11 write benchmark assertions**: all write operations now have regression thresholds (5.0s single, 15.0s batch) matching the read benchmark pattern
- **1 compound filter benchmark**: `get_projects` with `flagged_only` + `include_task_health` + `planned_after`

Closes #534

## Test plan

- [x] Unit tests: 1003 passed, 275 skipped
- [x] Benchmark assertions will fire on real OmniFocus runs (skipped in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)