### PR TITLE
fix: remove brittle assertion in update_projects E2E test

### DIFF
--- a/tests/test_e2e_real.py
+++ b/tests/test_e2e_real.py
@@ -404,7 +404,6 @@ class TestUpdateProjectsE2E:
         result = server.update_projects(projects=[{"id": proj_id, "sequential": True}])
 
         assert isinstance(result, str)
-        assert "1" in result  # Should mention 1 project
         assert "success" in result.lower() or "updated" in result.lower()
 
         print(f"\n✓ E2E update_projects single ID: {result}")


### PR DESCRIPTION
## Summary

Single-item `update_projects` returns `"Successfully updated project X: fields"` — no count digit. The `assert "1" in result` assertion failed. Removed it; success check is sufficient.

Found during pre-release integration test run.

## Test plan

- [x] Unit tests: 1003 passed
- [x] E2E: 40 passed (verified locally against test DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)