### PR TITLE
feat: unified tag CRUD with per-item values (#493)

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -431,6 +431,26 @@ Tags can be nested (e.g., create "High" under parent "Energy" to get "Energy : H
 
 ---
 
+### create_tags
+
+Create one or more tags in OmniFocus (unified batch operation).
+
+Pass a list of TagCreate objects. Each tag must have a `name`; other fields are optional. Prefer this over calling `create_tag` multiple times.
+
+**Parameters:**
+- `tags: list[TagCreate]` (required) — List of tag objects to create. Each supports:
+  - `name: str` (required) — The name of the tag to create
+  - `parent_tag: str` (optional) — Parent tag by NAME for nesting
+  - `children_are_mutually_exclusive: bool` (default: False) — Mutually exclusive children
+
+**Returns:** For single tag: success message with tag ID. For multiple: summary with per-item results.
+
+**Examples:**
+- `create_tags([{"name": "Automation"}])` — Single tag
+- `create_tags([{"name": "High", "parent_tag": "Energy"}, {"name": "Low", "parent_tag": "Energy"}])` — Batch nested tags
+
+---
+
 ### update_tag
 
 Update properties of an existing tag in OmniFocus.
@@ -450,6 +470,28 @@ Tags can be renamed, reparented, or have their status changed. Tags have three s
 - `update_tag("tag-123", parent_tag="People")` — Move tag under "People"
 - `update_tag("tag-123", parent_tag="")` — Move tag to top level
 - `update_tag("tag-123", name="Renamed", parent_tag="Work")` — Rename and reparent in one call
+
+---
+
+### update_tags
+
+Update one or more tags in OmniFocus (unified batch operation).
+
+Each item in the list can update different fields. Prefer this over calling `update_tag` multiple times.
+
+**Parameters:**
+- `tags: list[TagUpdate]` (required) — List of tag update objects. Each must have:
+  - `id: str` (required) — The tag ID to update
+  - `name: str` (optional) — New tag name
+  - `status: str` (optional) — "active", "on_hold", or "dropped"
+  - `children_are_mutually_exclusive: bool` (optional) — Mutually exclusive children
+  - `parent_tag: str` (optional) — Move to parent by NAME, or empty string for top level
+
+**Returns:** For single tag: success message with updated fields. For multiple: summary with per-item results.
+
+**Examples:**
+- `update_tags([{"id": "tag-1", "name": "Renamed"}])` — Single update
+- `update_tags([{"id": "tag-1", "status": "on_hold"}, {"id": "tag-2", "parent_tag": "People"}])` — Batch with different fields
 
 ---
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -1166,47 +1166,102 @@ def get_tags() -> str:
     return result
 
 
+# ============================================================================
+# Pydantic Models for Tag CRUD (v0.12.1)
+# ============================================================================
+
+class TagCreate(BaseModel):
+    """Input model for creating a tag."""
+    name: str
+    parent_tag: Optional[str] = None
+    children_are_mutually_exclusive: bool = False
+
+
+class TagUpdate(BaseModel):
+    """Input model for updating a tag."""
+    id: str
+    name: Optional[str] = None
+    status: Optional[str] = None
+    children_are_mutually_exclusive: Optional[bool] = None
+    parent_tag: Optional[str] = None
+
+
+# ============================================================================
+# Unified Batch Create/Update Tags (v0.12.1)
+# ============================================================================
+
 @mcp.tool()
 def create_tag(
     name: str,
     parent_tag: Optional[str] = None,
     children_are_mutually_exclusive: bool = False
 ) -> str:
-    """Create a new tag in OmniFocus.
+    """DEPRECATED: Use create_tags instead. Creates a single tag (delegates to create_tags)."""
+    return create_tags(tags=[{
+        "name": name,
+        "parent_tag": parent_tag,
+        "children_are_mutually_exclusive": children_are_mutually_exclusive,
+    }])
+
+
+@mcp.tool()
+def create_tags(tags: list[TagCreate]) -> str:
+    """Create one or more tags in OmniFocus.
 
     Tags (formerly 'contexts') represent contexts for doing work — location, tools,
     energy level, people, or workflow states. Tags can be nested (e.g., create "High"
     under parent "Energy" to get "Energy : High").
 
     Args:
-        name: The name of the tag to create
-        parent_tag: Optional parent tag by NAME (not ID) for nesting (e.g., "Energy" to create
-            "Energy : High"). Parent tag must already exist.
-        children_are_mutually_exclusive: If True, child tags of this tag will be
-            mutually exclusive — assigning one child tag to a task silently removes
-            any other child from the same group. Set via OmniAutomation.
+        tags: List of tag objects to create. Each must have:
+            name (required), parent_tag (optional, by NAME not ID),
+            children_are_mutually_exclusive (optional, default False).
 
     Returns:
-        Success message with tag ID and name
+        For single tag: success message with tag ID.
+        For multiple tags: summary with per-item results.
 
-    Raises:
-        ValueError: If a tag with the same name already exists
+    Examples:
+        create_tags([{"name": "Automation"}])
+        create_tags([{"name": "High", "parent_tag": "Energy"}, {"name": "Low", "parent_tag": "Energy"}])
     """
     client = get_client()
+    results = []
+
     try:
-        tag_id = client.create_tag(
-            name=name,
-            parent_tag=parent_tag,
-            children_are_mutually_exclusive=children_are_mutually_exclusive
-        )
-    except ValueError as e:
-        return f"Error: {str(e)}"
+        tags = [TagCreate(**t) if isinstance(t, dict) else t for t in tags]
+    except Exception as e:
+        return f"Error: Invalid tag input: {e}"
 
-    result = f"Successfully created tag '{name}'\nTag ID: {tag_id}"
-    if parent_tag:
-        result += f"\nParent: {parent_tag}"
+    for tag in tags:
+        try:
+            tag_id = client.create_tag(**tag.model_dump())
+            results.append({"name": tag.name, "tag_id": tag_id, "success": True})
+        except (ValueError, Exception) as e:
+            results.append({"name": tag.name, "success": False, "error": str(e)})
 
-    return result
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    # Single tag: detailed format
+    if len(tags) == 1:
+        r = results[0]
+        if r["success"]:
+            tag = tags[0]
+            result = f"Successfully created tag '{tag.name}'\nTag ID: {r['tag_id']}"
+            if tag.parent_tag:
+                result += f"\nParent: {tag.parent_tag}"
+            return result
+        else:
+            return f"Error: {r['error']}"
+
+    # Multiple tags: summary
+    lines = [f"Created {len(succeeded)} of {len(tags)} tags:"]
+    for r in succeeded:
+        lines.append(f"  - {r['name']}: {r['tag_id']}")
+    for r in failed:
+        lines.append(f"  - {r['name']}: FAILED — {r['error']}")
+    return "\n".join(lines)
 
 
 @mcp.tool()
@@ -1217,50 +1272,77 @@ def update_tag(
     children_are_mutually_exclusive: Optional[bool] = None,
     parent_tag: Optional[str] = None
 ) -> str:
-    """Update properties of an existing tag in OmniFocus.
+    """DEPRECATED: Use update_tags instead. Updates a single tag (delegates to update_tags)."""
+    params = locals()
+    tag_dict = {"id": params.pop("tag_id")}
+    for k, v in params.items():
+        if v is not None:
+            tag_dict[k] = v
+    return update_tags(tags=[tag_dict])
 
-    Tags can be renamed, reparented, or have their status changed. Tags have three
-    states: active (tasks are actionable), on_hold (tasks excluded from available
-    queries), and dropped (tag hidden from most views).
+
+@mcp.tool()
+def update_tags(tags: list[TagUpdate]) -> str:
+    """Update one or more tags in OmniFocus.
+
+    Tags can be renamed, reparented, or have their status changed. Each item
+    in the list can update different fields.
 
     Args:
-        tag_id: The ID of the tag to update (from get_tags)
-        name: New tag name (optional)
-        status: Tag status (optional). Values: "active", "on_hold", "dropped".
-            Active = tasks with this tag are actionable. On hold = tag is paused,
-            tasks with this tag become unavailable (excluded from Available perspective)
-            — use for temporary pauses. Dropped = tag is retired/archived, tasks remain
-            available but the tag is hidden from most views — use for permanent retirement.
-        children_are_mutually_exclusive: If True, child tags of this tag will be
-            mutually exclusive — assigning one child tag to a task silently removes
-            any other child from the same group. Set via OmniAutomation. (optional)
-        parent_tag: Move this tag under a different parent tag by NAME (not ID), or empty
-            string to move to top level. Preserves all task associations. Note: get_tags()
-            returns parentTagId by ID, but this parameter accepts the tag's name. (optional)
+        tags: List of tag update objects. Each must have:
+            id (required), name (optional), status (optional: "active", "on_hold",
+            "dropped"), children_are_mutually_exclusive (optional),
+            parent_tag (optional, by NAME or empty string to move to top level).
 
     Returns:
-        Success message with updated fields, or error message
+        For single tag: success message with updated fields.
+        For multiple tags: summary with per-item results.
 
     Examples:
-        update_tag("tag-123", parent_tag="People")  # Move under "People"
-        update_tag("tag-123", parent_tag="")  # Move to top level
+        update_tags([{"id": "tag-123", "name": "Renamed"}])
+        update_tags([{"id": "tag-1", "status": "on_hold"}, {"id": "tag-2", "parent_tag": "People"}])
     """
     client = get_client()
-    try:
-        result = client.update_tag(
-            tag_id=tag_id,
-            name=name,
-            status=status,
-            children_are_mutually_exclusive=children_are_mutually_exclusive,
-            parent_tag=parent_tag
-        )
+    results = []
 
-        fields = ", ".join(result["updated_fields"])
-        return f"Successfully updated tag {tag_id}\nUpdated fields: {fields}"
-    except ValueError as e:
-        return f"Error: {str(e)}"
+    try:
+        tags = [TagUpdate(**t) if isinstance(t, dict) else t for t in tags]
     except Exception as e:
-        return f"Error updating tag: {str(e)}"
+        return f"Error: Invalid tag update input: {e}"
+
+    for tag in tags:
+        try:
+            params = tag.model_dump(exclude_none=True, exclude={"id"})
+            result = client.update_tag(tag_id=tag.id, **params)
+            results.append({
+                "id": tag.id,
+                "success": result.get("success", True),
+                "updated_fields": result.get("updated_fields", []),
+                "error": result.get("error"),
+            })
+        except (ValueError, Exception) as e:
+            results.append({"id": tag.id, "success": False, "updated_fields": [], "error": str(e)})
+
+    succeeded = [r for r in results if r["success"]]
+    failed = [r for r in results if not r["success"]]
+
+    # Single tag: detailed format
+    if len(tags) == 1:
+        r = results[0]
+        if r["success"]:
+            fields = ", ".join(r["updated_fields"])
+            return f"Successfully updated tag {r['id']}\nUpdated fields: {fields}"
+        else:
+            return f"Error updating tag {r['id']}: {r['error']}"
+
+    # Multiple tags: summary
+    lines = [f"Updated {len(succeeded)} of {len(tags)} tags:"]
+    for r in succeeded:
+        fields = ", ".join(r["updated_fields"])
+        lines.append(f"  - {r['id']}: {fields}")
+    for r in failed:
+        lines.append(f"  - {r['id']}: FAILED — {r['error']}")
+    return "\n".join(lines)
 
 
 @mcp.tool()

--- a/tests/test_create_tag.py
+++ b/tests/test_create_tag.py
@@ -1,4 +1,4 @@
-"""Tests for create_tag MCP tool and connector method.
+"""Tests for create_tag and create_tags MCP tools and connector method.
 
 Tests both the server layer (MCP tool) and the connector layer (AppleScript client).
 """
@@ -134,3 +134,93 @@ class TestCreateTagConnector:
             client = OmniFocusConnector()
             with pytest.raises(Exception, match="Parent tag"):
                 client.create_tag("Child", parent_tag="NonExistent")
+
+
+class TestCreateTagsUnified:
+    """Tests for unified create_tags() with Pydantic model input."""
+
+    def test_create_tags_single_item(self):
+        """Single tag returns detailed format matching old create_tag output."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.return_value = "tag-001"
+            mock_get_client.return_value = mock_client
+
+            create_tags = server.create_tags
+            result = create_tags(tags=[{"name": "Automation"}])
+
+            assert "Successfully created tag" in result
+            assert "tag-001" in result
+            assert "Automation" in result
+            mock_client.create_tag.assert_called_once()
+
+    def test_create_tags_batch(self):
+        """Multiple tags return summary with count."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.side_effect = ["tag-001", "tag-002", "tag-003"]
+            mock_get_client.return_value = mock_client
+
+            create_tags = server.create_tags
+            result = create_tags(tags=[
+                {"name": "Tag A"},
+                {"name": "Tag B"},
+                {"name": "Tag C"},
+            ])
+
+            assert "3" in result
+            assert mock_client.create_tag.call_count == 3
+
+    def test_create_tags_partial_failure(self):
+        """One failure in batch returns mixed results."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.side_effect = [
+                "tag-001",
+                ValueError("Tag 'Duplicate' already exists"),
+                "tag-003",
+            ]
+            mock_get_client.return_value = mock_client
+
+            create_tags = server.create_tags
+            result = create_tags(tags=[
+                {"name": "Good Tag"},
+                {"name": "Duplicate"},
+                {"name": "Also Good"},
+            ])
+
+            assert "2" in result
+            assert "FAILED" in result
+            assert "already exists" in result
+
+    def test_create_tags_passes_all_fields(self):
+        """All TagCreate fields are passed through to connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.return_value = "tag-001"
+            mock_get_client.return_value = mock_client
+
+            create_tags = server.create_tags
+            result = create_tags(tags=[{
+                "name": "Priority",
+                "parent_tag": "Energy",
+                "children_are_mutually_exclusive": True,
+            }])
+
+            call_kwargs = mock_client.create_tag.call_args[1]
+            assert call_kwargs["name"] == "Priority"
+            assert call_kwargs["parent_tag"] == "Energy"
+            assert call_kwargs["children_are_mutually_exclusive"] is True
+
+    def test_create_tag_delegates_to_create_tags(self):
+        """Old create_tag should delegate to create_tags."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.create_tag.return_value = "tag-delegated"
+            mock_get_client.return_value = mock_client
+
+            result = create_tag(name="Delegated", parent_tag="Parent")
+
+            assert "tag-delegated" in result
+            assert "Successfully" in result
+            mock_client.create_tag.assert_called_once()

--- a/tests/test_update_tag.py
+++ b/tests/test_update_tag.py
@@ -30,9 +30,7 @@ class TestUpdateTagServer:
             result = update_tag(tag_id="tag-001", name="Renamed")
 
             mock_client.update_tag.assert_called_once_with(
-                tag_id="tag-001", name="Renamed", status=None,
-                children_are_mutually_exclusive=None,
-                parent_tag=None
+                tag_id="tag-001", name="Renamed"
             )
             assert "tag-001" in result
             assert "Successfully" in result
@@ -52,9 +50,7 @@ class TestUpdateTagServer:
             result = update_tag(tag_id="tag-002", status="on_hold")
 
             mock_client.update_tag.assert_called_once_with(
-                tag_id="tag-002", name=None, status="on_hold",
-                children_are_mutually_exclusive=None,
-                parent_tag=None
+                tag_id="tag-002", status="on_hold",
             )
             assert "tag-002" in result
             assert "Successfully" in result
@@ -121,9 +117,7 @@ class TestUpdateTagReparenting:
             result = update_tag(tag_id="tag-001", parent_tag="People")
 
             mock_client.update_tag.assert_called_once_with(
-                tag_id="tag-001", name=None, status=None,
-                children_are_mutually_exclusive=None,
-                parent_tag="People"
+                tag_id="tag-001", parent_tag="People"
             )
             assert "Successfully" in result
 
@@ -325,9 +319,7 @@ class TestUpdateTagStatus:
             result = update_tag(tag_id="tag-001", status="dropped")
 
             mock_client.update_tag.assert_called_once_with(
-                tag_id="tag-001", name=None, status="dropped",
-                children_are_mutually_exclusive=None,
-                parent_tag=None
+                tag_id="tag-001", status="dropped",
             )
             assert "Successfully" in result
 
@@ -410,3 +402,97 @@ class TestTagExclusivity:
 
         assert result == 'tag-new-456'
         assert mock_run.call_count == 1  # Only AppleScript, no OmniAutomation
+
+
+class TestUpdateTagsUnified:
+    """Tests for unified update_tags() with Pydantic model input."""
+
+    def test_update_tags_single_item(self):
+        """Single tag update returns detailed format."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True,
+                "tag_id": "tag-001",
+                "updated_fields": ["name"],
+                "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            update_tags = server.update_tags
+            result = update_tags(tags=[{"id": "tag-001", "name": "Renamed"}])
+
+            assert "Successfully updated tag tag-001" in result
+            assert "name" in result
+            mock_client.update_tag.assert_called_once()
+
+    def test_update_tags_batch_different_fields(self):
+        """Multiple tags with different fields per item."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.side_effect = [
+                {"success": True, "tag_id": "tag-001", "updated_fields": ["name"], "error": None},
+                {"success": True, "tag_id": "tag-002", "updated_fields": ["status"], "error": None},
+            ]
+            mock_get_client.return_value = mock_client
+
+            update_tags = server.update_tags
+            result = update_tags(tags=[
+                {"id": "tag-001", "name": "Renamed"},
+                {"id": "tag-002", "status": "on_hold"},
+            ])
+
+            assert "Updated 2 of 2 tags" in result
+            assert mock_client.update_tag.call_count == 2
+
+    def test_update_tags_partial_failure(self):
+        """One failure in batch returns mixed results."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.side_effect = [
+                {"success": True, "tag_id": "tag-001", "updated_fields": ["name"], "error": None},
+                ValueError("Tag not found"),
+            ]
+            mock_get_client.return_value = mock_client
+
+            update_tags = server.update_tags
+            result = update_tags(tags=[
+                {"id": "tag-001", "name": "Good"},
+                {"id": "tag-bad", "name": "Bad"},
+            ])
+
+            assert "Updated 1 of 2 tags" in result
+            assert "FAILED" in result
+
+    def test_update_tags_excludes_none_fields(self):
+        """Only set fields are passed to connector."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True, "tag_id": "tag-001",
+                "updated_fields": ["status"], "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            update_tags = server.update_tags
+            result = update_tags(tags=[{"id": "tag-001", "status": "on_hold"}])
+
+            call_kwargs = mock_client.update_tag.call_args[1]
+            assert call_kwargs["tag_id"] == "tag-001"
+            assert call_kwargs["status"] == "on_hold"
+            assert "name" not in call_kwargs
+
+    def test_update_tag_delegates_to_update_tags(self):
+        """Old update_tag should delegate to update_tags."""
+        with mock.patch('omnifocus_mcp.server_fastmcp.get_client') as mock_get_client:
+            mock_client = mock.Mock()
+            mock_client.update_tag.return_value = {
+                "success": True, "tag_id": "tag-001",
+                "updated_fields": ["name"], "error": None,
+            }
+            mock_get_client.return_value = mock_client
+
+            result = update_tag(tag_id="tag-001", name="Renamed")
+
+            assert "Successfully updated tag tag-001" in result
+            mock_client.update_tag.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `TagCreate` and `TagUpdate` Pydantic models
- Add `create_tags(tags: list[TagCreate])` and `update_tags(tags: list[TagUpdate])` batch MCP tools
- Deprecate `create_tag`/`update_tag` — now delegate to batch functions
- Update `tool_descriptions.md` with new batch tag documentation

Follows the same pattern as `create_tasks`/`update_tasks` from v0.12.0.

Closes #493

## Test plan

- [x] 10 new unit tests (5 create_tags, 5 update_tags)
- [x] 4 existing tests updated for exclude_none delegation pattern
- [x] Full suite: 1013 passed, 275 skipped
- [x] Client-server parity: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)