### PR TITLE
release: v0.13.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.12.1 | **Tests:** 1004 unit, 227 integration/E2E, 47 benchmark/profiling | **Coverage:** 93%
+**Version:** v0.13.0 | **Tests:** 1023 unit, 227 integration/E2E, 47 benchmark/profiling | **Coverage:** 93%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-03-24
+
+Unified batch CRUD for all entity types — tags and folders join tasks and projects with Pydantic model inputs. Deprecated single-item wrappers removed from MCP surface.
+
+### Added
+
+- **Unified `create_tags()` and `update_tags()`** with `TagCreate`/`TagUpdate` Pydantic models (#493, #541)
+  - Batch tag creation and updates with per-item values
+  - `create_tag`/`update_tag` deprecated to delegate
+
+- **Unified `create_folders()` and `update_folders()`** with `FolderCreate`/`FolderUpdate` Pydantic models (#494, #542)
+  - Batch folder creation and updates with per-item values
+  - `create_folder`/`update_folder` deprecated to delegate
+
+### Removed
+
+- **8 deprecated single-item MCP tools** removed from agent-visible surface (#495, #543)
+  - `create_task`, `update_task`, `create_project`, `update_project`, `create_tag`, `update_tag`, `create_folder`, `update_folder`
+  - Functions remain as internal Python helpers; agents now use batch versions exclusively
+  - MCP tool count: 29 → 21
+
+### Changed
+
+- **Eval scenarios updated** to use batch tool names throughout (71 scenarios)
+- **tool_descriptions.md** cleaned up — removed 8 deprecated sections
+
 ## [0.12.1] - 2026-03-23
 
 Test quality and eval accuracy release — driven by adversarial test quality review (#518). Refactored high-complexity helpers, fixed stale eval scenarios, and added missing test coverage.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A comprehensive, fast, reliable, and agent-friendly MCP server for OmniFocus on 
 
 ### Comprehensive
 
-25 tools covering projects, tasks, folders, tags, perspectives, and focus. Full CRUD on projects and tasks with unified batch operations (Pydantic model inputs), 20+ filter types on task and project queries, and date management including recurrence (RRULE read/write).
+21 tools covering projects, tasks, folders, tags, perspectives, and focus. Full CRUD with unified batch operations (Pydantic model inputs), 20+ filter types on task and project queries, and date management including recurrence (RRULE read/write).
 
 ### Fast
 
@@ -32,7 +32,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 
 ### Reliable
 
-93% code coverage from 1004 unit tests. 227 integration and E2E tests run against real OmniFocus covering task, project, and tag lifecycles, filtering, hierarchy, dates, recurrence, and review workflows.
+93% code coverage from 1023 unit tests. 227 integration and E2E tests run against real OmniFocus covering task, project, and tag lifecycles, filtering, hierarchy, dates, recurrence, and review workflows.
 
 ### Agent-Friendly
 
@@ -86,7 +86,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 ```bash
 git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
-git checkout v0.12.1  # Latest stable release
+git checkout v0.13.0  # Latest stable release
 
 # Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.12.1"
+version = "0.13.0"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Summary

Unified batch CRUD for all entity types. Deprecated single-item wrappers removed from MCP surface.

### PRs included (3)
- #541 feat: unified tag CRUD (create_tags, update_tags)
- #542 feat: unified folder CRUD (create_folders, update_folders)
- #543 chore: remove 8 deprecated single-item MCP tools (29 → 21 tools)

### Validation
- [x] Version sync
- [x] Client-server parity
- [x] Complexity check
- [x] Unit tests (1022 passed)
- [x] Integration tests (152 passed — pre-release run)
- [x] E2E tests (40 passed — pre-release run)
- [x] Dependency audit
- [x] AppleScript safety
- [x] Coverage: 93% (threshold 90%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)