### PR TITLE
chore: trim server instructions and tool descriptions by 67%

### DIFF
--- a/evals/agent_tool_usability/run_eval.py
+++ b/evals/agent_tool_usability/run_eval.py
@@ -87,7 +87,7 @@ def run_scenario(client: OpenAI, model: str, scenario: dict, tool_descriptions: 
     }
 
 
-def run_model(client: OpenAI, model: str, scenarios: list, tool_descriptions: str, output_dir: Path) -> dict:
+def run_model(client: OpenAI, model: str, scenarios: list, tool_descriptions: str, output_dir: Path, label: str = "original") -> dict:
     """Run all scenarios for a single model. Returns summary dict."""
     model_short = model.split("/")[-1]
     results = []
@@ -113,7 +113,7 @@ def run_model(client: OpenAI, model: str, scenarios: list, tool_descriptions: st
 
     # Save results
     model_slug = model.replace("/", "_")
-    output_path = output_dir / f"raw_{model_slug}.json"
+    output_path = output_dir / f"raw_{model_slug}_{label}.json"
     with open(output_path, "w") as f:
         json.dump(results, f, indent=2)
 
@@ -136,6 +136,10 @@ def main():
                         help="Comma-separated scenario IDs (default: all)")
     parser.add_argument("--output", default=str(SCRIPT_DIR / "results"),
                         help="Output directory")
+    parser.add_argument("--descriptions", default=str(TOOL_DESCRIPTIONS_PATH),
+                        help="Path to tool descriptions file (default: tool_descriptions.md)")
+    parser.add_argument("--label", default=None,
+                        help="Label for output files (e.g., 'trimmed'). Appended to filenames.")
     args = parser.parse_args()
 
     api_key = get_api_key()
@@ -149,7 +153,9 @@ def main():
         api_key=api_key,
     )
 
-    tool_descriptions = TOOL_DESCRIPTIONS_PATH.read_text()
+    descriptions_path = Path(args.descriptions)
+    tool_descriptions = descriptions_path.read_text()
+    label = args.label or descriptions_path.stem.replace("tool_descriptions", "").strip("_") or "original"
 
     scenarios = SCENARIOS
     if args.scenarios:
@@ -162,20 +168,21 @@ def main():
 
     print(f"Models: {', '.join(models)}")
     print(f"Scenarios: {len(scenarios)}")
+    print(f"Descriptions: {descriptions_path.name} (label: {label})")
     print(f"Output: {args.output}")
     if len(models) > 1:
         print(f"Running {len(models)} models in parallel")
     print()
 
     if len(models) == 1:
-        summary = run_model(client, models[0], scenarios, tool_descriptions, output_dir)
+        summary = run_model(client, models[0], scenarios, tool_descriptions, output_dir, label)
         print(f"\nResults saved to {summary['output_path']}")
         print(f"Total tokens: {summary['total_tokens']}")
     else:
         summaries = []
         with ThreadPoolExecutor(max_workers=len(models)) as executor:
             futures = {
-                executor.submit(run_model, client, model, scenarios, tool_descriptions, output_dir): model
+                executor.submit(run_model, client, model, scenarios, tool_descriptions, output_dir, label): model
                 for model in models
             }
             for future in as_completed(futures):

--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -104,16 +104,16 @@ SCENARIOS = [
     {
         "id": 5,
         "category": "Tool Selection",
-        "name": "Single vs Batch Boundary",
+        "name": "Batch with Mixed Fields",
         "prompt": (
             "Rename task task-123 to 'Buy groceries' and also flag tasks task-456 and task-789."
         ),
         "expected": {
-            "tools": ["update_tasks", "update_tasks"],
+            "tools": ["update_tasks"],
             "key_params": {
-                "update_tasks": {"task_id": "task-123", "task_name": "Buy groceries"},
                 "update_tasks": {
                     "tasks": [
+                        {"id": "task-123", "task_name": "Buy groceries"},
                         {"id": "task-456", "flagged": True},
                         {"id": "task-789", "flagged": True},
                     ],
@@ -121,8 +121,9 @@ SCENARIOS = [
             },
         },
         "scoring_notes": (
-            "PASS: update_task for rename (single), update_tasks for flag (batch). "
-            "PARTIAL: Uses update_task 3x (works but misses batch). "
+            "PASS: Single update_tasks call with all 3 items, each with different fields "
+            "(rename + flags). Per-item values are the API's design. "
+            "PARTIAL: Multiple separate update_tasks calls instead of one batch. "
             "FAIL: Wrong tools or missing flag operation entirely."
         ),
         "safety_critical": False,
@@ -288,9 +289,9 @@ SCENARIOS = [
             },
         },
         "scoring_notes": (
-            "PASS: Follows the PLANNING PATTERN from server instructions — 4 queries "
-            "(overdue, flagged+available, inbox, next). "
-            "PARTIAL: Gets 2-3 of the 4 queries. "
+            "PASS: Makes 3+ targeted queries from: overdue, flagged (ideally +available), "
+            "inbox, next actions. Shows understanding that planning needs multiple views. "
+            "PARTIAL: Makes 1-2 targeted queries (e.g., only overdue + flagged). "
             "FAIL: Single get_tasks() with no filters, or completely wrong approach."
         ),
         "safety_critical": False,
@@ -1317,7 +1318,7 @@ SCENARIOS = [
         "safety_critical": False,
     },
     {
-        "id": 53,
+        "id": 70,
         "category": "Recurrence",
         "name": "Drop Entire Recurring Series",
         "prompt": (
@@ -1344,7 +1345,7 @@ SCENARIOS = [
         "safety_critical": False,
     },
     {
-        "id": 54,
+        "id": 71,
         "category": "Tag Management",
         "name": "Reparent Tag Under New Parent",
         "prompt": (

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -4,444 +4,252 @@ This file contains exactly what an MCP-connected agent sees: the server instruct
 
 ## Server Instructions
 
-OmniFocus is a GTD (Getting Things Done) task manager. Key concepts:
+OmniFocus is a GTD task manager. Hierarchy: Folders > Projects > Tasks > Subtasks.
 
-TASK STATES: Available (can work on now), Blocked (waiting on predecessor in sequential project), Deferred (has future defer date — hidden until then), Flagged (user marked as priority/today), Overdue (past due date), Completed, Dropped. Tasks also have an optional Planned Date — a scheduling signal for when you plan to work on the task, with no availability or overdue constraints (unlike defer/due dates).
+TASK STATES: Available, Blocked, Deferred (future defer date), Flagged, Overdue, Completed, Dropped. Planned Date is a scheduling signal only — no availability/overdue constraints.
 
-PROJECT STATES: Active (tasks are actionable), On Hold (paused — tasks hidden), Dropped (abandoned), Completed.
+PROJECT TYPES: "sequential" (tasks in order; first incomplete = available, rest blocked; position = dependencies), "parallel" (all available), "single_actions" (no completion goal, cannot auto-complete). The `next` field is true for the first available action in a sequential project/action group; in parallel projects, all incomplete tasks have `next: true`.
 
-HIERARCHY: Folders → Projects → Tasks → Subtasks. Folders organize projects. Projects contain tasks. Tasks can have subtasks via parent_task_id.
+ACTION GROUPS: Task with subtasks. Parent shows `blocked: true` while subtasks are active — this is normal, not an error. Do not try to unblock it.
 
-PROJECT TYPES: Three types — "sequential" (tasks completed in order, first incomplete = available, rest = blocked), "parallel" (all tasks available simultaneously), "single_actions" (grab-bag list with no completion goal — cannot auto-complete, used for loose collections like "Someday/Maybe" or catch-all inboxes). Use `projectType` field (not `sequential`) to distinguish all three. Dependencies are positional — reorder tasks to change dependency chains. There are no explicit task-to-task dependency links. The `next` field on a task is true when it is the first available action in a sequential project or action group. In parallel projects, all incomplete tasks have `next: true`.
+INHERITED STATUS: `completed`/`dropped` reflect the task's own state, not its container's. Task in completed project: `completed: false`, `available: false`. Use `available_only=True` for actionable tasks.
 
-ACTION GROUPS: A task with subtasks is an "action group." It can be parallel or sequential, just like a project. The parent task appears as `blocked: true` while its subtasks are active — **this is normal behavior, not an error or a problem to fix.** Check `subtaskCount > 0` to identify action groups. An action group parent cannot be completed until its subtasks are resolved. If you see a task with `blocked: true` and `subtaskCount > 0`, it means "work on the subtasks first" — do not try to unblock it.
+EFFECTIVE DATES: Dates returned by get_tasks include dates inherited from the project. A task with no direct due date shows its project's due date. You cannot clear an inherited date at the task level. Write operations set the task's own date.
 
-INHERITED STATUS: Task-level fields like `completed` and `dropped` reflect the task's own state, NOT its container's state. A task inside a completed project will show `completed: false` (because the task itself wasn't individually completed) but `available: false` (because its container is inactive). This is expected behavior. To find truly actionable tasks, always use `available` or `available_only=True` — do not rely on `completed` alone.
+RECURRING TASKS: `completed=True` uses `mark complete`, which creates the next occurrence. This is guaranteed. WARNING: Dropping a recurring task (status='dropped') without clearing recurrence first (recurrence='') spawns the next occurrence. To stop a series: update_tasks([{"id": "...", "recurrence": "", "status": "dropped"}]).
 
-EFFECTIVE DATES: Date fields (dueDate, deferDate, plannedDate) returned by get_tasks are EFFECTIVE dates — they include dates inherited from the containing project. A task with no direct due date in a project with dueDate=April 15 will return dueDate="2026-04-15T17:00:00" (not empty). Do not assume an empty due date on a task means the project has no due date either. Write operations (update_task) set the task's own date directly.
+TAGS: Represent work contexts. Tags can be Active or On Hold — tasks with On Hold tags are excluded from Available perspective.
 
-BATCH OPERATIONS: When updating multiple items, prefer the unified tools (update_tasks, update_projects) which accept a list of update objects — each item can have different fields. More efficient than multiple individual calls.
-
-RECURRING TASKS: Setting completed=True on a recurring task uses OmniFocus's 'mark complete' command, which automatically creates the next occurrence. This is guaranteed behavior — do not hedge or warn that recurrence might stop.
-
-TAGS: Formerly "contexts." Represent work contexts (location, tools, energy, people, workflow states like Waiting-for or Agenda). Cut across projects. Use for filtering. Tags can be Active or On Hold — tasks with On Hold tags are excluded from OmniFocus's native Available perspective.
-
-PLANNING PATTERN: To plan a day, query: (1) overdue tasks, (2) flagged + available tasks, (3) inbox items, (4) next actions. Prioritize overdue+flagged first.
-
-INBOX: Unprocessed capture bucket. Tasks without a project land here. Non-empty inbox = items need organizing.
-
-REVIEW: Projects have review intervals. Use get_projects() to find projects due for review (check last_reviewed + review_interval_weeks).
-
----
+DEFER vs DUE: Defer = hidden until that date. Due = deadline.
 
 ## Tools
 
 ### get_projects
 
-Retrieve projects from OmniFocus with optional filtering.
+Retrieve projects with optional filtering.
 
 **Parameters:**
-- `project_id: str` (optional) — Filter to specific project by ID
-- `include_full_notes: bool` (default: False) — Return full note content
-- `on_hold_only: bool` (default: False) — If True, only return projects with "on hold" status
-- `query: str` (optional) — Search term to filter by name, note, or folder path (case-insensitive)
-- `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
-- `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
-- `stalled_only: bool` (default: False) — Only return active projects with no available actions (implies include_task_health=True)
-- `flagged_only: bool` (default: False) — Only return flagged projects
-- `include_dropped: bool` (default: False) — Include dropped projects in results (hidden by default)
-- `include_completed: bool` (default: False) — Include completed projects in results (hidden by default)
-- `completed_only: bool` (default: False) — Only return completed projects (implies include_completed)
-- `tag_filter: list[str]` (optional) — Filter projects by tags. Only returns projects with ALL specified tags.
-- `planned_after: str` (optional) — Only return projects with planned date on or after this ISO date
-- `planned_before: str` (optional) — Only return projects with planned date before this ISO date
-- `planned_on: str` (optional) — Only return projects planned for this specific date (e.g., "2026-03-23"). Convenience for planned_after=date + planned_before=next_day. Mutually exclusive with planned_after/planned_before.
-- `has_overdue_tasks: bool` (optional) — Only return projects with overdue tasks (implies include_task_health)
-- `sort_by: str` (optional) — Sort results by field — "name"
-- `sort_order: str` (default: "asc") — Sort direction — "asc" or "desc"
-- `modified_after: str` (optional) — Only return projects modified after this ISO date
-- `modified_before: str` (optional) — Only return projects modified before this ISO date
-- `min_task_count: int` (optional) — Only return projects with at least this many tasks
-- `has_no_due_dates: bool` (optional) — If True, only return projects where no tasks have due dates
+- `project_id: str` — filter to specific project
+- `query: str` — search name/note/folder (case-insensitive)
+- `flagged_only, on_hold_only, stalled_only, completed_only: bool`
+- `include_dropped, include_completed: bool` — include hidden states
+- `include_full_notes: bool`
+- `include_task_health: bool` — adds remainingCount, availableCount, overdueCount, deferredCount, stalled, health
+- `include_last_activity: bool` — adds lastActivityDate
+- `has_overdue_tasks: bool` — implies include_task_health
+- `tag_filter: list[str]` — projects with ALL specified tags
+- `planned_after, planned_before, planned_on: str` — ISO date filters (planned_on is mutually exclusive)
+- `modified_after, modified_before: str`
+- `min_task_count: int`
+- `has_no_due_dates: bool`
+- `sort_by: str` — "name"; `sort_order: str` — "asc"/"desc"
 
-**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, flagged, creationDate, modificationDate, completionDate (null if not completed), droppedDate (null if not dropped), dueDate, deferDate, plannedDate, tags, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalValue, reviewIntervalUnit. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. `dueDate`, `deferDate`, `plannedDate` — project-level dates in ISO format (empty string if not set). Tasks inherit effective dates from their containing project. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status. `stalled` (boolean) — true when availableCount=0 and tasks are not just deferred (project needs attention). With include_last_activity: lastActivityDate.
-
----
+**Returns:** id, name, folderPath, status, projectType, sequential (deprecated), completedByChildren, flagged, creationDate, modificationDate, completionDate, droppedDate, dueDate, deferDate, plannedDate, tags, note, lastReviewDate, nextReviewDate, reviewIntervalValue, reviewIntervalUnit. Optional health/activity fields when requested.
 
 ### create_projects
 
-Create one or more projects in OmniFocus.
+Create one or more projects.
 
-Pass a list of project objects. Each must have a name; all other fields optional.
-
-**Parameters:**
-- `projects: list[ProjectCreate]` (required) — List of project objects. Each supports:
-  - `name: str` (required) — The name of the project
-  - `note: str` (optional) — Note/description (plain text only - rich text not supported via automation APIs)
-  - `folder_path: str` (optional) — Folder path (e.g., "Work > Clients") - folder must exist
-  - `project_type: str` (optional) — Project type: "parallel" (default, all tasks available simultaneously), "sequential" (tasks completed in order, only first available), or "single_actions" (grab-bag list with no completion goal, cannot auto-complete). Overrides `sequential` when provided.
-  - `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
-  - `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
-  - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
-  - `due_date: str` (optional) — Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00"). Tasks inherit this as their effective due date.
-  - `defer_date: str` (optional) — Defer date in ISO 8601 format (when project becomes available)
-  - `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on the project)
-
-**Returns:** For single project: success message with project ID and configuration details. For multiple: summary with per-item results.
-
-**Examples:**
-```
-create_projects([{"name": "Website Redesign"}])
-create_projects([
-    {"name": "Project A", "folder_path": "Work", "project_type": "sequential"},
-    {"name": "Project B", "due_date": "2026-04-01"}
-])
-```
-
----
+**Parameters (per item):**
+- `name: str` (required)
+- `note, folder_path: str`
+- `project_type: str` — "parallel" (default), "sequential", "single_actions"
+- `sequential: bool` (deprecated, use project_type)
+- `review_interval_weeks: int`
+- `completed_by_children: bool`
+- `due_date, defer_date, planned_date: str` — ISO 8601
 
 ### update_projects
 
-Update one or more projects in OmniFocus. Pass a list of project update objects — each must have an `id` field, plus any fields to change. Each project can have different fields updated.
+Update one or more projects. Each item has `id` (required) plus fields to change.
 
-**Parameters:**
-- `projects: list[object]` (required) — List of project update objects. Each object has:
-  - `id: str` (required) — The project ID to update
-  - `project_name: str` (optional) — New project name
-  - `folder_path: str` (optional) — Folder path to move project to (e.g., "Work : Projects")
-  - `note: str` (optional) — New note content. WARNING: Removes rich text formatting.
-  - `project_type: str` (optional) — Change project type: "parallel", "sequential", or "single_actions"
-  - `sequential: bool` (optional, DEPRECATED) — Use project_type instead.
-  - `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
-  - `review_interval_weeks: int` (optional, DEPRECATED) — Use review_interval_value + review_interval_unit instead. Review interval in weeks (0 to clear)
-  - `review_interval_value: int` (optional) — Review interval amount (e.g., 3 for "every 3 months"). Used with review_interval_unit.
-  - `review_interval_unit: str` (optional) — Review interval unit: "day", "week", "month", or "year" (default: "week")
-  - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
-  - `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
-  - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
-  - `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
-  - `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
-  - `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
-  - `flagged: bool` (optional) — Flag marks a project as a priority. Pass True to flag, False to unflag.
-  - `estimated_minutes: int` (optional) — Estimated time in minutes for the project
-  - `tags: list[str]` (optional) — Full replacement — set exact tag list. Conflicts with add_tags/remove_tags.
-  - `add_tags: list[str]` (optional) — Add these tags incrementally. Conflicts with tags.
-  - `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
-  - `recurrence: str` (optional) — iCalendar RRULE string, or empty string to remove recurrence.
-  - `repetition_method: str` (optional) — "fixed", "start_after_completion", or "due_after_completion". Only meaningful when recurrence is set.
-
-**Returns:** For single project: success message with updated fields. For multiple: summary with per-item results.
-
-**Examples:**
-```
-update_projects([{"id": "proj-123", "flagged": true}])
-update_projects([
-    {"id": "proj-1", "status": "on_hold"},
-    {"id": "proj-2", "project_name": "Renamed", "flagged": true}
-])
-```
-
----
+**Parameters (per item):**
+- `id: str` (required)
+- `project_name, note, folder_path: str` — note: replaces rich text
+- `project_type: str`; `sequential: bool` (deprecated)
+- `status: str` — "active", "on_hold", "done", "dropped"
+- `review_interval_value: int` + `review_interval_unit: str` ("day"/"week"/"month"/"year"); `review_interval_weeks: int` (deprecated)
+- `last_reviewed: str` — ISO or "now"; `next_review_date: str`
+- `completed_by_children: bool`
+- `due_date, defer_date, planned_date: str` — ISO or "" to clear
+- `flagged: bool`
+- `estimated_minutes: int`
+- `tags: list[str]` — full replacement (conflicts with add_tags/remove_tags)
+- `add_tags, remove_tags: list[str]`
+- `recurrence: str` — RRULE or "" to clear; `repetition_method: str` — "fixed", "start_after_completion", "due_after_completion"
 
 ### delete_projects
 
-Delete one or more projects from OmniFocus.
+Permanently delete projects and all their tasks. Cannot be undone.
 
-WARNING: This permanently deletes the projects and all their tasks. Cannot be undone.
-
-**Parameters:**
-- `project_ids: str | list[str]` (required) — Single project ID or list of project IDs to delete
-
-**Returns:** Summary of deleted projects with count and any errors encountered
-
----
+- `project_ids: str | list[str]` (required)
 
 ### get_tasks
 
-Get tasks from OmniFocus with optional filtering.
+Get tasks with optional filtering.
 
 **Parameters:**
-- `task_id: str` (optional) — Filter to specific task by ID
-- `parent_task_id: str` (optional) — Filter to subtasks of parent
-- `include_full_notes: bool` (default: False) — Return full note content
-- `project_id: str` (optional) — Project ID to filter tasks (ignored if inbox_only=True)
-- `flagged_only: bool` (default: False) — Only return flagged tasks
-- `include_completed: bool` (default: False) — Include completed tasks
-- `available_only: bool` (default: False) — Only return available tasks (not completed, not dropped, not blocked, not deferred)
-- `overdue: bool` (default: False) — Only return overdue tasks
-- `dropped_only: bool` (default: False) — Only return dropped tasks
-- `blocked_only: bool` (default: False) — Only return blocked tasks
-- `next_only: bool` (default: False) — Only return next tasks
-- `tag_filter: list[str]` (optional) — List of tag names to filter by, e.g., `["Errands", "Weekend"]` (task must have ALL listed tags)
-- `query: str` (optional) — Search term to filter by name or note (case-insensitive)
-- `inbox_only: bool` (default: False) — Only return inbox tasks
-- `planned_after: str` (optional) — Only return tasks with planned date on or after this ISO date
-- `planned_before: str` (optional) — Only return tasks with planned date before this ISO date
-- `sort_by: str` (optional) — Sort results by field — "name", "due_date", or "defer_date"
-- `sort_order: str` (default: "asc") — Sort direction — "asc" or "desc"
-- `modified_after: str` (optional) — Only return tasks modified after this ISO date
-- `modified_before: str` (optional) — Only return tasks modified before this ISO date
-- `created_after: str` (optional) — Only return tasks created after this ISO date
-- `created_before: str` (optional) — Only return tasks created before this ISO date
-- `max_estimated_minutes: int` (optional) — Only return tasks with estimated time <= this value — "quick wins" filter
-- `has_estimate: bool` (optional) — If True, only return tasks with an estimate set; if False, only tasks without
-- `recurring_only: bool` (optional) — If True, only return recurring tasks; if False, only non-recurring
-- `tag_filter_mode: str` (default: "and") — How tag_filter matches — "and" (all tags), "or" (any tag), "not" (none of the tags)
-- `planned_on: str` (optional) — Only return tasks planned for this specific date (e.g., "2026-03-23"). Mutually exclusive with planned_after/planned_before.
+- `task_id, parent_task_id, project_id: str`
+- `query: str` — search name/note
+- `flagged_only, available_only, overdue, dropped_only, blocked_only, next_only, inbox_only: bool`
+- `include_completed: bool`
+- `include_full_notes: bool`
+- `tag_filter: list[str]`; `tag_filter_mode: str` — "and" (default), "or", "not"
+- `planned_after, planned_before, planned_on: str`
+- `modified_after, modified_before, created_after, created_before: str`
+- `max_estimated_minutes: int` — quick wins filter
+- `has_estimate: bool`
+- `recurring_only: bool`
+- `sort_by: str` — "name", "due_date", "defer_date"; `sort_order: str`
 
-**Returns:** Each task includes: id, name, projectName, completed, dropped, blocked, available, next, flagged, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note (truncated unless include_full_notes=True), parentTaskId, subtaskCount, sequential, isRecurring, recurrence, repetitionMethod, repeatSummary, nextDueDate, nextDeferDate, nextPlannedDate, catchUpAutomatically, creationDate, modificationDate, completionDate (null if not completed), droppedDate (null if not dropped).
-`available` is true when the task is actionable — not completed, not dropped, not blocked, not deferred, and not inside a completed or dropped container (project or parent task). This accounts for inherited status: a task in a done project shows `completed: false` but `available: false` because its container is inactive. Use `available_only=True` to get only truly actionable tasks.
+**Returns:** id, name, projectName, completed, dropped, blocked, available, next, flagged, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note, parentTaskId, subtaskCount, sequential, isRecurring, recurrence, repetitionMethod, repeatSummary, nextDueDate, nextDeferDate, nextPlannedDate, catchUpAutomatically, creationDate, modificationDate, completionDate, droppedDate.
 
-Note: Date fields (dueDate, deferDate, plannedDate) reflect effective dates — including dates inherited from the containing project or action group. A task with no direct due date will show its project's due date in dueDate. Example: if project "Q2 Report" has dueDate=April 15, a task in that project with no direct due date will return dueDate="2026-04-15T17:00:00" in get_tasks output (inherited from project, not empty). Write operations (update_task) still set the task's own date directly. Next occurrence fields (nextDueDate, nextDeferDate, nextPlannedDate) are populated only for recurring tasks and show the dates of the next recurrence — empty for non-recurring tasks. `catchUpAutomatically` (boolean, null for non-recurring) controls missed-recurrence behavior: when true, only one catch-up occurrence is created if a task is missed; when false, each missed interval spawns its own occurrence (can flood the inbox).
-
-**Important:** `repeatSummary` is a human-readable version of the recurrence RRULE (e.g., "Every 2 weeks on Mon, Wed, Fri"). **Always use `repeatSummary` for user-facing output — do not manually parse the raw `recurrence` RRULE string.** `repetitionMethod` indicates how the next occurrence is calculated: "fixed" (next occurrence on the original schedule regardless of when completed — e.g., if due every Monday, completing on Wednesday still makes the next occurrence due Monday), "start_after_completion" (next defer date = completion date + interval — e.g., complete Wednesday, next defer = following Wednesday), "due_after_completion" (next due date = completion date + interval — e.g., complete Wednesday, next due = following Wednesday). Use `due_after_completion` when you want the **deadline** to shift based on completion; use `start_after_completion` when you want the **availability window** (defer date) to shift instead. Recurrence rules can be set, modified, or removed via `update_task(recurrence=..., repetition_method=...)`. Use standard iCalendar RRULE format (e.g., `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR`). Pass `recurrence=""` to remove recurrence.
-
----
+Key fields:
+- `available` — true when actionable (accounts for inherited status from containers)
+- `repeatSummary` — human-readable recurrence; always use this for display, don't parse RRULE
+- `repetitionMethod` — "fixed" (original schedule), "start_after_completion" (defer shifts), "due_after_completion" (due shifts)
+- `catchUpAutomatically` — recurring only; true = one catch-up occurrence, false = each missed interval spawns its own
+- Date fields are effective (include inherited from project). Next-occurrence fields populated only for recurring tasks.
 
 ### create_tasks
 
-Create one or more tasks in OmniFocus (unified batch operation).
+Create one or more tasks.
 
-Pass a list of TaskCreate objects. Each task must have a `task_name`; all other fields are optional. For a single task, pass a list with one item. Prefer this over calling `create_task` multiple times.
-
-**Parameters:**
-- `tasks: list[TaskCreate]` (required) — List of task objects to create. Each supports:
-  - `task_name: str` (required) — The name/title of the task
-  - `project_id: str` (optional) — Project ID. Mutually exclusive with parent_task_id.
-  - `parent_task_id: str` (optional) — Parent task ID to create as subtask. Mutually exclusive with project_id.
-  - `note: str` (optional) — Note/description (plain text only)
-  - `due_date: str` (optional) — Due date in ISO 8601 format
-  - `defer_date: str` (optional) — Defer date in ISO 8601 format
-  - `planned_date: str` (optional) — Planned date in ISO 8601 format
-  - `flagged: bool` (default: False) — Flag as priority
-  - `tags: list[str]` (optional) — List of tag names. Tags must already exist.
-  - `estimated_minutes: int` (optional) — Estimated time in minutes
-  - `sequential: bool` (default: False) — If True, subtasks must be completed in order
-  - `completed_by_children: bool` (default: False) — Auto-complete when last subtask completes
-
-**Returns:** For single task: success message with task ID. For multiple: summary with per-item results.
-
-**Examples:**
-- `create_tasks([{"task_name": "Buy groceries"}])` — Single inbox task
-- `create_tasks([{"task_name": "A", "project_id": "p1"}, {"task_name": "B", "project_id": "p1"}])` — Two tasks in a project
-
----
+**Parameters (per item):**
+- `task_name: str` (required)
+- `project_id: str` — mutually exclusive with parent_task_id
+- `parent_task_id: str` — creates subtask
+- `note: str` (plain text only)
+- `due_date, defer_date, planned_date: str` — ISO 8601
+- `flagged: bool`
+- `tags: list[str]` — must already exist
+- `estimated_minutes: int`
+- `sequential: bool` — subtasks completed in order
+- `completed_by_children: bool`
 
 ### update_tasks
 
-Update multiple tasks with per-item values via a list of update objects (unified batch operation).
+Update one or more tasks. Each item has `id` (required) plus fields to change.
 
-Each item in the list is a TaskUpdate object with an `id` field (required) and any fields to change. Different items can have different fields — this is NOT limited to uniform updates.
-
-**Parameters:**
-- `tasks: list[TaskUpdate]` (required) — List of task update objects. Each must have:
-  - `id: str` (required) — The task ID to update
-  - All other fields from update_task are available per item: `task_name`, `project_id`, `parent_task_id`, `note`, `due_date`, `defer_date`, `planned_date`, `flagged`, `tags`, `add_tags`, `remove_tags`, `estimated_minutes`, `completed`, `status`, `recurrence`, `repetition_method`, `sequential`, `completed_by_children`
-
-**Returns:** Summary with counts of successful/failed updates. Continues processing when individual tasks fail.
-
-**Examples:**
-- `update_tasks([{"id": "t1", "flagged": true}, {"id": "t2", "flagged": true}])` — Flag two tasks
-- `update_tasks([{"id": "t1", "task_name": "Renamed"}, {"id": "t2", "completed": true}])` — Different fields per task
-
----
+**Parameters (per item):**
+- `id: str` (required)
+- `task_name, project_id, parent_task_id, note: str`
+- `due_date, defer_date, planned_date: str` — ISO or "" to clear
+- `flagged, completed: bool` — completed=True on recurring task creates next occurrence
+- `status: str`
+- `tags: list[str]` — full replacement (conflicts with add_tags/remove_tags)
+- `add_tags, remove_tags: list[str]`
+- `estimated_minutes: int`
+- `recurrence: str` — RRULE or "" to clear; `repetition_method: str`
+- `sequential: bool`; `completed_by_children: bool`
 
 ### delete_tasks
 
-Delete multiple tasks from OmniFocus.
+Permanently delete tasks. Cannot be undone.
 
-WARNING: This permanently deletes the tasks and cannot be undone.
-
-**Parameters:**
-- `task_ids: str | list[str]` (required) — Single task ID or list of task IDs to delete
-
-**Returns:** Summary of deleted tasks with count and any errors encountered
-
----
+- `task_ids: str | list[str]` (required)
 
 ### reorder_task
 
-Move a task before or after another task to change its position.
+Move a task before or after another task within the same project/level.
 
-Use this to reorder tasks within a project or within a parent task's subtasks. In sequential projects, task order determines dependencies — reordering changes which task is available next (first incomplete = available, rest = blocked).
+- `task_id: str` (required)
+- `before_task_id: str` — place before this task
+- `after_task_id: str` — place after this task
 
-**Parameters:**
-- `task_id: str` (required) — The ID of the task to move
-- `before_task_id: str` (optional) — Place task immediately BEFORE this reference task. Example: reorder_task("C", before_task_id="A") → [..., C, A, ...]
-- `after_task_id: str` (optional) — Place task immediately AFTER this reference task. Example: reorder_task("C", after_task_id="A") → [..., A, C, ...]
-
-**Returns:** Success message confirming the task was reordered
-
-**Note:** Both tasks must be in the same project and at the same level. Exactly one of before_task_id or after_task_id must be provided.
-
----
+Exactly one of before/after required. In sequential projects, order = dependencies.
 
 ### reorder_project
 
-Move a project before or after another project to change its position within a folder.
+Move a project before or after another project within the same folder.
 
-**Parameters:**
-- `project_id: str` (required) — The ID of the project to move
-- `before_project_id: str` (optional) — Place project immediately BEFORE this reference project. Example: reorder_project("C", before_project_id="A") → [..., C, A, ...]
-- `after_project_id: str` (optional) — Place project immediately AFTER this reference project. Example: reorder_project("C", after_project_id="A") → [..., A, C, ...]
+- `project_id: str` (required)
+- `before_project_id: str`
+- `after_project_id: str`
 
-**Returns:** Success message confirming the project was reordered
-
-**Note:** Both projects must be in the same folder. Exactly one of before_project_id or after_project_id must be provided.
-
----
+Exactly one of before/after required.
 
 ### get_folders
 
-Get all folders from OmniFocus with their hierarchy.
+Get all folders with hierarchy.
 
 **Parameters:** None
 
-**Returns:** Each folder includes: id, name, path (hierarchical, e.g. "Work > Clients"), status ("active" or "dropped"). Dropped folders and their contents are hidden from most OmniFocus views.
-
----
+**Returns:** id, name, path (e.g. "Work > Clients"), status ("active"/"dropped").
 
 ### create_folders
 
-Create one or more folders in OmniFocus (unified batch operation).
+Create one or more folders.
 
-**Parameters:**
-- `folders: list[FolderCreate]` (required) — List of folder objects. Each supports:
-  - `name: str` (required) — The name of the folder
-  - `parent_path: str` (optional) — Parent folder path (e.g., "Work" or "Work > Clients")
-
-**Returns:** For single folder: success message with folder ID. For multiple: summary with per-item results.
-
-**Examples:**
-- `create_folders([{"name": "Clients"}])`
-- `create_folders([{"name": "Work"}, {"name": "Personal", "parent_path": "Home"}])`
-
----
+**Parameters (per item):**
+- `name: str` (required)
+- `parent_path: str` — e.g. "Work > Clients"
 
 ### update_folders
 
-Update one or more folders in OmniFocus (unified batch operation).
+Update one or more folders. Each item has `id` (required) plus fields to change.
 
-**Parameters:**
-- `folders: list[FolderUpdate]` (required) — List of folder update objects. Each must have:
-  - `id: str` (required) — The folder ID to update
-  - `name: str` (optional) — New folder name
-  - `status: str` (optional) — "active" or "dropped"
-
-**Returns:** For single folder: success message with updated fields. For multiple: summary with per-item results.
-
-**Examples:**
-- `update_folders([{"id": "f1", "name": "Renamed"}])`
-- `update_folders([{"id": "f1", "status": "dropped"}, {"id": "f2", "name": "New Name"}])`
-
----
+**Parameters (per item):**
+- `id: str` (required)
+- `name: str`
+- `status: str` — "active" or "dropped"
 
 ### get_tags
 
-Retrieve all available tags from OmniFocus.
-
-Tags (formerly 'contexts') represent contexts for doing work — location (Office, Home), tools (Computer, Phone), energy level (High, Low), people, or workflow states (Waiting-for, Agenda). They cut across projects and are used for filtering tasks via get_tasks(tag_filter=[...]).
+Retrieve all tags.
 
 **Parameters:** None
 
-**Returns:** Each tag includes: id, name, status (values: "active", "on hold", "dropped"), parentTagId (empty string if top-level, parent tag's ID if nested — note: create_tag and update_tag accept parent_tag by NAME, not this ID), childrenAreMutuallyExclusive (boolean — when true, child tags are mutually exclusive: assigning one child tag to a task silently removes any other child from the same group).
-
----
+**Returns:** id, name, status ("active"/"on hold"/"dropped"), parentTagId (empty if top-level; create/update accept parent by NAME not ID), childrenAreMutuallyExclusive (assigning one child silently removes siblings).
 
 ### create_tags
 
-Create one or more tags in OmniFocus (unified batch operation).
+Create one or more tags.
 
-Pass a list of TagCreate objects. Each tag must have a `name`; other fields are optional. Prefer this over calling `create_tag` multiple times.
-
-**Parameters:**
-- `tags: list[TagCreate]` (required) — List of tag objects to create. Each supports:
-  - `name: str` (required) — The name of the tag to create
-  - `parent_tag: str` (optional) — Parent tag by NAME for nesting
-  - `children_are_mutually_exclusive: bool` (default: False) — Mutually exclusive children
-
-**Returns:** For single tag: success message with tag ID. For multiple: summary with per-item results.
-
-**Examples:**
-- `create_tags([{"name": "Automation"}])` — Single tag
-- `create_tags([{"name": "High", "parent_tag": "Energy"}, {"name": "Low", "parent_tag": "Energy"}])` — Batch nested tags
-
----
+**Parameters (per item):**
+- `name: str` (required)
+- `parent_tag: str` — parent by name
+- `children_are_mutually_exclusive: bool`
 
 ### update_tags
 
-Update one or more tags in OmniFocus (unified batch operation).
+Update one or more tags. Each item has `id` (required) plus fields to change.
 
-Each item in the list can update different fields. Prefer this over calling `update_tag` multiple times.
-
-**Parameters:**
-- `tags: list[TagUpdate]` (required) — List of tag update objects. Each must have:
-  - `id: str` (required) — The tag ID to update
-  - `name: str` (optional) — New tag name
-  - `status: str` (optional) — "active", "on_hold", or "dropped"
-  - `children_are_mutually_exclusive: bool` (optional) — Mutually exclusive children
-  - `parent_tag: str` (optional) — Move to parent by NAME, or empty string for top level
-
-**Returns:** For single tag: success message with updated fields. For multiple: summary with per-item results.
-
-**Examples:**
-- `update_tags([{"id": "tag-1", "name": "Renamed"}])` — Single update
-- `update_tags([{"id": "tag-1", "status": "on_hold"}, {"id": "tag-2", "parent_tag": "People"}])` — Batch with different fields
-
----
+**Parameters (per item):**
+- `id: str` (required)
+- `name, status: str` — status: "active", "on_hold", "dropped"
+- `children_are_mutually_exclusive: bool`
+- `parent_tag: str` — move to parent by name, "" for top level
 
 ### delete_tags
 
-Delete one or more tags from OmniFocus.
+Delete tags. Tasks lose tag association but are not deleted.
 
-WARNING: This permanently deletes the tags. Tasks that had these tags will lose the tag association but are not themselves deleted.
-
-**Parameters:**
-- `tag_ids: str | list[str]` (required) — Single tag ID or list of tag IDs to delete
-
-**Returns:** Summary of deleted tags with count and any errors encountered
-
----
+- `tag_ids: str | list[str]` (required)
 
 ### get_perspectives
 
-Get all perspectives from OmniFocus with type and ID information.
+Get all perspectives.
 
 **Parameters:** None
 
-**Returns:** Formatted list of perspectives with name, type (built-in/custom), and ID
-
----
+**Returns:** name, type (built-in/custom), id
 
 ### switch_perspective
 
-Switch the front window to a different perspective.
+Switch front window to a perspective.
 
-**Parameters:**
-- `perspective_name: str` (required) — Name of the perspective to switch to
-
-**Returns:** Success message confirming perspective switch
-
----
+- `perspective_name: str` (required)
 
 ### set_focus
 
-Set focus on one or more items, or clear focus.
+Focus on projects/folders, or clear focus. Does not support tasks or tags.
 
-OmniFocus supports focusing on projects and folders only (NOT tasks or tags). To highlight specific tasks, use `update_task(flagged=True)` instead. Call with no arguments (or empty lists) to clear focus.
-
-**Parameters:**
-- `item_ids: str | list[str]` (optional) — Single ID or list of IDs to focus on. Omit or pass empty to clear.
-- `item_types: str | list[str]` (optional) — Matching type(s) - each must be "project" or "folder".
-
-**Returns:** Success message confirming focus set or cleared
-
----
+- `item_ids: str | list[str]` — omit or empty to clear
+- `item_types: str | list[str]` — "project" or "folder"
 
 ### get_focus
 
-Get the currently focused items in OmniFocus.
+Get currently focused items.
 
 **Parameters:** None
-
-**Returns:** Formatted list of currently focused items, or a message if no focus is set

--- a/evals/agent_tool_usability/tool_descriptions_v_original.md
+++ b/evals/agent_tool_usability/tool_descriptions_v_original.md
@@ -1,0 +1,447 @@
+# OmniFocus MCP Tool Descriptions
+
+This file contains exactly what an MCP-connected agent sees: the server instructions and all tool schemas with docstrings. Used as input for blind agent eval.
+
+## Server Instructions
+
+OmniFocus is a GTD (Getting Things Done) task manager. Key concepts:
+
+TASK STATES: Available (can work on now), Blocked (waiting on predecessor in sequential project), Deferred (has future defer date — hidden until then), Flagged (user marked as priority/today), Overdue (past due date), Completed, Dropped. Tasks also have an optional Planned Date — a scheduling signal for when you plan to work on the task, with no availability or overdue constraints (unlike defer/due dates).
+
+PROJECT STATES: Active (tasks are actionable), On Hold (paused — tasks hidden), Dropped (abandoned), Completed.
+
+HIERARCHY: Folders → Projects → Tasks → Subtasks. Folders organize projects. Projects contain tasks. Tasks can have subtasks via parent_task_id.
+
+PROJECT TYPES: Three types — "sequential" (tasks completed in order, first incomplete = available, rest = blocked), "parallel" (all tasks available simultaneously), "single_actions" (grab-bag list with no completion goal — cannot auto-complete, used for loose collections like "Someday/Maybe" or catch-all inboxes). Use `projectType` field (not `sequential`) to distinguish all three. Dependencies are positional — reorder tasks to change dependency chains. There are no explicit task-to-task dependency links. The `next` field on a task is true when it is the first available action in a sequential project or action group. In parallel projects, all incomplete tasks have `next: true`.
+
+ACTION GROUPS: A task with subtasks is an "action group." It can be parallel or sequential, just like a project. The parent task appears as `blocked: true` while its subtasks are active — **this is normal behavior, not an error or a problem to fix.** Check `subtaskCount > 0` to identify action groups. An action group parent cannot be completed until its subtasks are resolved. If you see a task with `blocked: true` and `subtaskCount > 0`, it means "work on the subtasks first" — do not try to unblock it.
+
+INHERITED STATUS: Task-level fields like `completed` and `dropped` reflect the task's own state, NOT its container's state. A task inside a completed project will show `completed: false` (because the task itself wasn't individually completed) but `available: false` (because its container is inactive). This is expected behavior. To find truly actionable tasks, always use `available` or `available_only=True` — do not rely on `completed` alone.
+
+EFFECTIVE DATES: Date fields (dueDate, deferDate, plannedDate) returned by get_tasks are EFFECTIVE dates — they include dates inherited from the containing project. A task with no direct due date in a project with dueDate=April 15 will return dueDate="2026-04-15T17:00:00" (not empty). Do not assume an empty due date on a task means the project has no due date either. Write operations (update_task) set the task's own date directly.
+
+BATCH OPERATIONS: When updating multiple items, prefer the unified tools (update_tasks, update_projects) which accept a list of update objects — each item can have different fields. More efficient than multiple individual calls.
+
+RECURRING TASKS: Setting completed=True on a recurring task uses OmniFocus's 'mark complete' command, which automatically creates the next occurrence. This is guaranteed behavior — do not hedge or warn that recurrence might stop. WARNING: Dropping a recurring task (status='dropped') WITHOUT first clearing recurrence (recurrence='') will spawn the next occurrence. To permanently stop a recurring series, clear recurrence and drop in a single update_tasks call: update_tasks([{"id": "...", "recurrence": "", "status": "dropped"}]).
+
+TAGS: Formerly "contexts." Represent work contexts (location, tools, energy, people, workflow states like Waiting-for or Agenda). Cut across projects. Use for filtering. Tags can be Active or On Hold — tasks with On Hold tags are excluded from OmniFocus's native Available perspective.
+
+PLANNING PATTERN: To plan a day, query: (1) overdue tasks, (2) flagged + available tasks, (3) inbox items, (4) next actions. Prioritize overdue+flagged first.
+
+INBOX: Unprocessed capture bucket. Tasks without a project land here. Non-empty inbox = items need organizing.
+
+REVIEW: Projects have review intervals. Use get_projects() to find projects due for review (check last_reviewed + review_interval_weeks).
+
+---
+
+## Tools
+
+### get_projects
+
+Retrieve projects from OmniFocus with optional filtering.
+
+**Parameters:**
+- `project_id: str` (optional) — Filter to specific project by ID
+- `include_full_notes: bool` (default: False) — Return full note content
+- `on_hold_only: bool` (default: False) — If True, only return projects with "on hold" status
+- `query: str` (optional) — Search term to filter by name, note, or folder path (case-insensitive)
+- `include_task_health: bool` (default: False) — Include per-project task health counts (remaining, available, overdue, deferred)
+- `include_last_activity: bool` (default: False) — Compute lastActivityDate (most recent task creation/completion)
+- `stalled_only: bool` (default: False) — Only return active projects with no available actions (implies include_task_health=True)
+- `flagged_only: bool` (default: False) — Only return flagged projects
+- `include_dropped: bool` (default: False) — Include dropped projects in results (hidden by default)
+- `include_completed: bool` (default: False) — Include completed projects in results (hidden by default)
+- `completed_only: bool` (default: False) — Only return completed projects (implies include_completed)
+- `tag_filter: list[str]` (optional) — Filter projects by tags. Only returns projects with ALL specified tags.
+- `planned_after: str` (optional) — Only return projects with planned date on or after this ISO date
+- `planned_before: str` (optional) — Only return projects with planned date before this ISO date
+- `planned_on: str` (optional) — Only return projects planned for this specific date (e.g., "2026-03-23"). Convenience for planned_after=date + planned_before=next_day. Mutually exclusive with planned_after/planned_before.
+- `has_overdue_tasks: bool` (optional) — Only return projects with overdue tasks (implies include_task_health)
+- `sort_by: str` (optional) — Sort results by field — "name"
+- `sort_order: str` (default: "asc") — Sort direction — "asc" or "desc"
+- `modified_after: str` (optional) — Only return projects modified after this ISO date
+- `modified_before: str` (optional) — Only return projects modified before this ISO date
+- `min_task_count: int` (optional) — Only return projects with at least this many tasks
+- `has_no_due_dates: bool` (optional) — If True, only return projects where no tasks have due dates
+
+**Returns:** Each project includes: id, name, folderPath, status, projectType, sequential, completedByChildren, flagged, creationDate, modificationDate, completionDate (null if not completed), droppedDate (null if not dropped), dueDate, deferDate, plannedDate, tags, note (truncated unless include_full_notes=True), lastReviewDate, nextReviewDate, reviewIntervalValue, reviewIntervalUnit. `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List — grab-bag list with no completion goal, cannot auto-complete). `sequential` (boolean) is retained for backwards compatibility. `completedByChildren` (boolean) — true if the project auto-completes when its last remaining action is completed. `dueDate`, `deferDate`, `plannedDate` — project-level dates in ISO format (empty string if not set). Tasks inherit effective dates from their containing project. With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status. `stalled` (boolean) — true when availableCount=0 and tasks are not just deferred (project needs attention). With include_last_activity: lastActivityDate.
+
+---
+
+### create_projects
+
+Create one or more projects in OmniFocus.
+
+Pass a list of project objects. Each must have a name; all other fields optional.
+
+**Parameters:**
+- `projects: list[ProjectCreate]` (required) — List of project objects. Each supports:
+  - `name: str` (required) — The name of the project
+  - `note: str` (optional) — Note/description (plain text only - rich text not supported via automation APIs)
+  - `folder_path: str` (optional) — Folder path (e.g., "Work > Clients") - folder must exist
+  - `project_type: str` (optional) — Project type: "parallel" (default, all tasks available simultaneously), "sequential" (tasks completed in order, only first available), or "single_actions" (grab-bag list with no completion goal, cannot auto-complete). Overrides `sequential` when provided.
+  - `sequential: bool` (default: False, DEPRECATED) — Use project_type instead. If True, creates a sequential project.
+  - `review_interval_weeks: int` (optional) — Review interval in weeks for GTD review cycle
+  - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
+  - `due_date: str` (optional) — Due date in ISO 8601 format (e.g., "2025-10-15" or "2025-10-15T17:00:00"). Tasks inherit this as their effective due date.
+  - `defer_date: str` (optional) — Defer date in ISO 8601 format (when project becomes available)
+  - `planned_date: str` (optional) — Planned date in ISO 8601 format (when you plan to work on the project)
+
+**Returns:** For single project: success message with project ID and configuration details. For multiple: summary with per-item results.
+
+**Examples:**
+```
+create_projects([{"name": "Website Redesign"}])
+create_projects([
+    {"name": "Project A", "folder_path": "Work", "project_type": "sequential"},
+    {"name": "Project B", "due_date": "2026-04-01"}
+])
+```
+
+---
+
+### update_projects
+
+Update one or more projects in OmniFocus. Pass a list of project update objects — each must have an `id` field, plus any fields to change. Each project can have different fields updated.
+
+**Parameters:**
+- `projects: list[object]` (required) — List of project update objects. Each object has:
+  - `id: str` (required) — The project ID to update
+  - `project_name: str` (optional) — New project name
+  - `folder_path: str` (optional) — Folder path to move project to (e.g., "Work : Projects")
+  - `note: str` (optional) — New note content. WARNING: Removes rich text formatting.
+  - `project_type: str` (optional) — Change project type: "parallel", "sequential", or "single_actions"
+  - `sequential: bool` (optional, DEPRECATED) — Use project_type instead.
+  - `status: str` (optional) — Project status - "active", "on_hold", "done", or "dropped"
+  - `review_interval_weeks: int` (optional, DEPRECATED) — Use review_interval_value + review_interval_unit instead. Review interval in weeks (0 to clear)
+  - `review_interval_value: int` (optional) — Review interval amount (e.g., 3 for "every 3 months"). Used with review_interval_unit.
+  - `review_interval_unit: str` (optional) — Review interval unit: "day", "week", "month", or "year" (default: "week")
+  - `last_reviewed: str` (optional) — Last reviewed date in ISO format or "now"
+  - `next_review_date: str` (optional) — Explicit next review date in ISO format — overrides the date OmniFocus calculates from last_reviewed + review_interval
+  - `completed_by_children: bool` (optional) — Auto-complete the project when its last remaining action is completed
+  - `due_date: str` (optional) — Due date in ISO 8601 format, or "" to clear
+  - `defer_date: str` (optional) — Defer date in ISO 8601 format, or "" to clear
+  - `planned_date: str` (optional) — Planned date in ISO 8601 format, or "" to clear
+  - `flagged: bool` (optional) — Flag marks a project as a priority. Pass True to flag, False to unflag.
+  - `estimated_minutes: int` (optional) — Estimated time in minutes for the project
+  - `tags: list[str]` (optional) — Full replacement — set exact tag list. Conflicts with add_tags/remove_tags.
+  - `add_tags: list[str]` (optional) — Add these tags incrementally. Conflicts with tags.
+  - `remove_tags: list[str]` (optional) — Remove these tags. Conflicts with tags.
+  - `recurrence: str` (optional) — iCalendar RRULE string, or empty string to remove recurrence.
+  - `repetition_method: str` (optional) — "fixed", "start_after_completion", or "due_after_completion". Only meaningful when recurrence is set.
+
+**Returns:** For single project: success message with updated fields. For multiple: summary with per-item results.
+
+**Examples:**
+```
+update_projects([{"id": "proj-123", "flagged": true}])
+update_projects([
+    {"id": "proj-1", "status": "on_hold"},
+    {"id": "proj-2", "project_name": "Renamed", "flagged": true}
+])
+```
+
+---
+
+### delete_projects
+
+Delete one or more projects from OmniFocus.
+
+WARNING: This permanently deletes the projects and all their tasks. Cannot be undone.
+
+**Parameters:**
+- `project_ids: str | list[str]` (required) — Single project ID or list of project IDs to delete
+
+**Returns:** Summary of deleted projects with count and any errors encountered
+
+---
+
+### get_tasks
+
+Get tasks from OmniFocus with optional filtering.
+
+**Parameters:**
+- `task_id: str` (optional) — Filter to specific task by ID
+- `parent_task_id: str` (optional) — Filter to subtasks of parent
+- `include_full_notes: bool` (default: False) — Return full note content
+- `project_id: str` (optional) — Project ID to filter tasks (ignored if inbox_only=True)
+- `flagged_only: bool` (default: False) — Only return flagged tasks
+- `include_completed: bool` (default: False) — Include completed tasks
+- `available_only: bool` (default: False) — Only return available tasks (not completed, not dropped, not blocked, not deferred)
+- `overdue: bool` (default: False) — Only return overdue tasks
+- `dropped_only: bool` (default: False) — Only return dropped tasks
+- `blocked_only: bool` (default: False) — Only return blocked tasks
+- `next_only: bool` (default: False) — Only return next tasks
+- `tag_filter: list[str]` (optional) — List of tag names to filter by, e.g., `["Errands", "Weekend"]` (task must have ALL listed tags)
+- `query: str` (optional) — Search term to filter by name or note (case-insensitive)
+- `inbox_only: bool` (default: False) — Only return inbox tasks
+- `planned_after: str` (optional) — Only return tasks with planned date on or after this ISO date
+- `planned_before: str` (optional) — Only return tasks with planned date before this ISO date
+- `sort_by: str` (optional) — Sort results by field — "name", "due_date", or "defer_date"
+- `sort_order: str` (default: "asc") — Sort direction — "asc" or "desc"
+- `modified_after: str` (optional) — Only return tasks modified after this ISO date
+- `modified_before: str` (optional) — Only return tasks modified before this ISO date
+- `created_after: str` (optional) — Only return tasks created after this ISO date
+- `created_before: str` (optional) — Only return tasks created before this ISO date
+- `max_estimated_minutes: int` (optional) — Only return tasks with estimated time <= this value — "quick wins" filter
+- `has_estimate: bool` (optional) — If True, only return tasks with an estimate set; if False, only tasks without
+- `recurring_only: bool` (optional) — If True, only return recurring tasks; if False, only non-recurring
+- `tag_filter_mode: str` (default: "and") — How tag_filter matches — "and" (all tags), "or" (any tag), "not" (none of the tags)
+- `planned_on: str` (optional) — Only return tasks planned for this specific date (e.g., "2026-03-23"). Mutually exclusive with planned_after/planned_before.
+
+**Returns:** Each task includes: id, name, projectName, completed, dropped, blocked, available, next, flagged, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note (truncated unless include_full_notes=True), parentTaskId, subtaskCount, sequential, isRecurring, recurrence, repetitionMethod, repeatSummary, nextDueDate, nextDeferDate, nextPlannedDate, catchUpAutomatically, creationDate, modificationDate, completionDate (null if not completed), droppedDate (null if not dropped).
+`available` is true when the task is actionable — not completed, not dropped, not blocked, not deferred, and not inside a completed or dropped container (project or parent task). This accounts for inherited status: a task in a done project shows `completed: false` but `available: false` because its container is inactive. Use `available_only=True` to get only truly actionable tasks.
+
+Note: Date fields (dueDate, deferDate, plannedDate) reflect effective dates — including dates inherited from the containing project or action group. A task with no direct due date will show its project's due date in dueDate. Example: if project "Q2 Report" has dueDate=April 15, a task in that project with no direct due date will return dueDate="2026-04-15T17:00:00" in get_tasks output (inherited from project, not empty). Write operations (update_task) still set the task's own date directly. Next occurrence fields (nextDueDate, nextDeferDate, nextPlannedDate) are populated only for recurring tasks and show the dates of the next recurrence — empty for non-recurring tasks. `catchUpAutomatically` (boolean, null for non-recurring) controls missed-recurrence behavior: when true, only one catch-up occurrence is created if a task is missed; when false, each missed interval spawns its own occurrence (can flood the inbox).
+
+**Important:** `repeatSummary` is a human-readable version of the recurrence RRULE (e.g., "Every 2 weeks on Mon, Wed, Fri"). **Always use `repeatSummary` for user-facing output — do not manually parse the raw `recurrence` RRULE string.** `repetitionMethod` indicates how the next occurrence is calculated: "fixed" (next occurrence on the original schedule regardless of when completed — e.g., if due every Monday, completing on Wednesday still makes the next occurrence due Monday), "start_after_completion" (next defer date = completion date + interval — e.g., complete Wednesday, next defer = following Wednesday), "due_after_completion" (next due date = completion date + interval — e.g., complete Wednesday, next due = following Wednesday). Use `due_after_completion` when you want the **deadline** to shift based on completion; use `start_after_completion` when you want the **availability window** (defer date) to shift instead. Recurrence rules can be set, modified, or removed via `update_task(recurrence=..., repetition_method=...)`. Use standard iCalendar RRULE format (e.g., `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR`). Pass `recurrence=""` to remove recurrence.
+
+---
+
+### create_tasks
+
+Create one or more tasks in OmniFocus (unified batch operation).
+
+Pass a list of TaskCreate objects. Each task must have a `task_name`; all other fields are optional. For a single task, pass a list with one item. Prefer this over calling `create_task` multiple times.
+
+**Parameters:**
+- `tasks: list[TaskCreate]` (required) — List of task objects to create. Each supports:
+  - `task_name: str` (required) — The name/title of the task
+  - `project_id: str` (optional) — Project ID. Mutually exclusive with parent_task_id.
+  - `parent_task_id: str` (optional) — Parent task ID to create as subtask. Mutually exclusive with project_id.
+  - `note: str` (optional) — Note/description (plain text only)
+  - `due_date: str` (optional) — Due date in ISO 8601 format
+  - `defer_date: str` (optional) — Defer date in ISO 8601 format
+  - `planned_date: str` (optional) — Planned date in ISO 8601 format
+  - `flagged: bool` (default: False) — Flag as priority
+  - `tags: list[str]` (optional) — List of tag names. Tags must already exist.
+  - `estimated_minutes: int` (optional) — Estimated time in minutes
+  - `sequential: bool` (default: False) — If True, subtasks must be completed in order
+  - `completed_by_children: bool` (default: False) — Auto-complete when last subtask completes
+
+**Returns:** For single task: success message with task ID. For multiple: summary with per-item results.
+
+**Examples:**
+- `create_tasks([{"task_name": "Buy groceries"}])` — Single inbox task
+- `create_tasks([{"task_name": "A", "project_id": "p1"}, {"task_name": "B", "project_id": "p1"}])` — Two tasks in a project
+
+---
+
+### update_tasks
+
+Update multiple tasks with per-item values via a list of update objects (unified batch operation).
+
+Each item in the list is a TaskUpdate object with an `id` field (required) and any fields to change. Different items can have different fields — this is NOT limited to uniform updates.
+
+**Parameters:**
+- `tasks: list[TaskUpdate]` (required) — List of task update objects. Each must have:
+  - `id: str` (required) — The task ID to update
+  - All other fields from update_task are available per item: `task_name`, `project_id`, `parent_task_id`, `note`, `due_date`, `defer_date`, `planned_date`, `flagged`, `tags`, `add_tags`, `remove_tags`, `estimated_minutes`, `completed`, `status`, `recurrence`, `repetition_method`, `sequential`, `completed_by_children`
+
+**Returns:** Summary with counts of successful/failed updates. Continues processing when individual tasks fail.
+
+**Examples:**
+- `update_tasks([{"id": "t1", "flagged": true}, {"id": "t2", "flagged": true}])` — Flag two tasks
+- `update_tasks([{"id": "t1", "task_name": "Renamed"}, {"id": "t2", "completed": true}])` — Different fields per task
+
+---
+
+### delete_tasks
+
+Delete multiple tasks from OmniFocus.
+
+WARNING: This permanently deletes the tasks and cannot be undone.
+
+**Parameters:**
+- `task_ids: str | list[str]` (required) — Single task ID or list of task IDs to delete
+
+**Returns:** Summary of deleted tasks with count and any errors encountered
+
+---
+
+### reorder_task
+
+Move a task before or after another task to change its position.
+
+Use this to reorder tasks within a project or within a parent task's subtasks. In sequential projects, task order determines dependencies — reordering changes which task is available next (first incomplete = available, rest = blocked).
+
+**Parameters:**
+- `task_id: str` (required) — The ID of the task to move
+- `before_task_id: str` (optional) — Place task immediately BEFORE this reference task. Example: reorder_task("C", before_task_id="A") → [..., C, A, ...]
+- `after_task_id: str` (optional) — Place task immediately AFTER this reference task. Example: reorder_task("C", after_task_id="A") → [..., A, C, ...]
+
+**Returns:** Success message confirming the task was reordered
+
+**Note:** Both tasks must be in the same project and at the same level. Exactly one of before_task_id or after_task_id must be provided.
+
+---
+
+### reorder_project
+
+Move a project before or after another project to change its position within a folder.
+
+**Parameters:**
+- `project_id: str` (required) — The ID of the project to move
+- `before_project_id: str` (optional) — Place project immediately BEFORE this reference project. Example: reorder_project("C", before_project_id="A") → [..., C, A, ...]
+- `after_project_id: str` (optional) — Place project immediately AFTER this reference project. Example: reorder_project("C", after_project_id="A") → [..., A, C, ...]
+
+**Returns:** Success message confirming the project was reordered
+
+**Note:** Both projects must be in the same folder. Exactly one of before_project_id or after_project_id must be provided.
+
+---
+
+### get_folders
+
+Get all folders from OmniFocus with their hierarchy.
+
+**Parameters:** None
+
+**Returns:** Each folder includes: id, name, path (hierarchical, e.g. "Work > Clients"), status ("active" or "dropped"). Dropped folders and their contents are hidden from most OmniFocus views.
+
+---
+
+### create_folders
+
+Create one or more folders in OmniFocus (unified batch operation).
+
+**Parameters:**
+- `folders: list[FolderCreate]` (required) — List of folder objects. Each supports:
+  - `name: str` (required) — The name of the folder
+  - `parent_path: str` (optional) — Parent folder path (e.g., "Work" or "Work > Clients")
+
+**Returns:** For single folder: success message with folder ID. For multiple: summary with per-item results.
+
+**Examples:**
+- `create_folders([{"name": "Clients"}])`
+- `create_folders([{"name": "Work"}, {"name": "Personal", "parent_path": "Home"}])`
+
+---
+
+### update_folders
+
+Update one or more folders in OmniFocus (unified batch operation).
+
+**Parameters:**
+- `folders: list[FolderUpdate]` (required) — List of folder update objects. Each must have:
+  - `id: str` (required) — The folder ID to update
+  - `name: str` (optional) — New folder name
+  - `status: str` (optional) — "active" or "dropped"
+
+**Returns:** For single folder: success message with updated fields. For multiple: summary with per-item results.
+
+**Examples:**
+- `update_folders([{"id": "f1", "name": "Renamed"}])`
+- `update_folders([{"id": "f1", "status": "dropped"}, {"id": "f2", "name": "New Name"}])`
+
+---
+
+### get_tags
+
+Retrieve all available tags from OmniFocus.
+
+Tags (formerly 'contexts') represent contexts for doing work — location (Office, Home), tools (Computer, Phone), energy level (High, Low), people, or workflow states (Waiting-for, Agenda). They cut across projects and are used for filtering tasks via get_tasks(tag_filter=[...]).
+
+**Parameters:** None
+
+**Returns:** Each tag includes: id, name, status (values: "active", "on hold", "dropped"), parentTagId (empty string if top-level, parent tag's ID if nested — note: create_tag and update_tag accept parent_tag by NAME, not this ID), childrenAreMutuallyExclusive (boolean — when true, child tags are mutually exclusive: assigning one child tag to a task silently removes any other child from the same group).
+
+---
+
+### create_tags
+
+Create one or more tags in OmniFocus (unified batch operation).
+
+Pass a list of TagCreate objects. Each tag must have a `name`; other fields are optional. Prefer this over calling `create_tag` multiple times.
+
+**Parameters:**
+- `tags: list[TagCreate]` (required) — List of tag objects to create. Each supports:
+  - `name: str` (required) — The name of the tag to create
+  - `parent_tag: str` (optional) — Parent tag by NAME for nesting
+  - `children_are_mutually_exclusive: bool` (default: False) — Mutually exclusive children
+
+**Returns:** For single tag: success message with tag ID. For multiple: summary with per-item results.
+
+**Examples:**
+- `create_tags([{"name": "Automation"}])` — Single tag
+- `create_tags([{"name": "High", "parent_tag": "Energy"}, {"name": "Low", "parent_tag": "Energy"}])` — Batch nested tags
+
+---
+
+### update_tags
+
+Update one or more tags in OmniFocus (unified batch operation).
+
+Each item in the list can update different fields. Prefer this over calling `update_tag` multiple times.
+
+**Parameters:**
+- `tags: list[TagUpdate]` (required) — List of tag update objects. Each must have:
+  - `id: str` (required) — The tag ID to update
+  - `name: str` (optional) — New tag name
+  - `status: str` (optional) — "active", "on_hold", or "dropped"
+  - `children_are_mutually_exclusive: bool` (optional) — Mutually exclusive children
+  - `parent_tag: str` (optional) — Move to parent by NAME, or empty string for top level
+
+**Returns:** For single tag: success message with updated fields. For multiple: summary with per-item results.
+
+**Examples:**
+- `update_tags([{"id": "tag-1", "name": "Renamed"}])` — Single update
+- `update_tags([{"id": "tag-1", "status": "on_hold"}, {"id": "tag-2", "parent_tag": "People"}])` — Batch with different fields
+
+---
+
+### delete_tags
+
+Delete one or more tags from OmniFocus.
+
+WARNING: This permanently deletes the tags. Tasks that had these tags will lose the tag association but are not themselves deleted.
+
+**Parameters:**
+- `tag_ids: str | list[str]` (required) — Single tag ID or list of tag IDs to delete
+
+**Returns:** Summary of deleted tags with count and any errors encountered
+
+---
+
+### get_perspectives
+
+Get all perspectives from OmniFocus with type and ID information.
+
+**Parameters:** None
+
+**Returns:** Formatted list of perspectives with name, type (built-in/custom), and ID
+
+---
+
+### switch_perspective
+
+Switch the front window to a different perspective.
+
+**Parameters:**
+- `perspective_name: str` (required) — Name of the perspective to switch to
+
+**Returns:** Success message confirming perspective switch
+
+---
+
+### set_focus
+
+Set focus on one or more items, or clear focus.
+
+OmniFocus supports focusing on projects and folders only (NOT tasks or tags). To highlight specific tasks, use `update_task(flagged=True)` instead. Call with no arguments (or empty lists) to clear focus.
+
+**Parameters:**
+- `item_ids: str | list[str]` (optional) — Single ID or list of IDs to focus on. Omit or pass empty to clear.
+- `item_types: str | list[str]` (optional) — Matching type(s) - each must be "project" or "folder".
+
+**Returns:** Success message confirming focus set or cleared
+
+---
+
+### get_focus
+
+Get the currently focused items in OmniFocus.
+
+**Parameters:** None
+
+**Returns:** Formatted list of currently focused items, or a message if no focus is set

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -9,33 +9,23 @@ from pydantic import BaseModel
 from .omnifocus_connector import OmniFocusConnector
 
 # Create FastMCP server
-mcp = FastMCP("omnifocus-mcp", instructions="""OmniFocus is a GTD (Getting Things Done) task manager. Key concepts:
+mcp = FastMCP("omnifocus-mcp", instructions="""OmniFocus is a GTD task manager. Hierarchy: Folders > Projects > Tasks > Subtasks.
 
-TASK STATES: Available (can work on now), Blocked (waiting on predecessor in sequential project), Deferred (has future defer date — hidden until then), Flagged (user marked as priority/today), Overdue (past due date), Completed, Dropped.
+TASK STATES: Available, Blocked, Deferred (future defer date), Flagged, Overdue, Completed, Dropped. Planned Date is a scheduling signal only — no availability/overdue constraints.
 
-PROJECT STATES: Active (tasks are actionable), On Hold (paused — tasks hidden), Dropped (abandoned), Completed.
+PROJECT TYPES: "sequential" (tasks in order; first incomplete = available, rest blocked; position = dependencies), "parallel" (all available), "single_actions" (no completion goal, cannot auto-complete). The `next` field is true for the first available action in a sequential project/action group; in parallel projects, all incomplete tasks have `next: true`.
 
-HIERARCHY: Folders → Projects → Tasks → Subtasks. Folders organize projects. Projects contain tasks. Tasks can have subtasks via parent_task_id.
+ACTION GROUPS: Task with subtasks. Parent shows `blocked: true` while subtasks are active — this is normal, not an error. Do not try to unblock it.
 
-SEQUENTIAL VS PARALLEL: Sequential projects release one task at a time (first incomplete = available, rest = blocked). Parallel projects make all tasks available. Dependencies are positional — reorder tasks to change dependency chains. There are no explicit task-to-task dependency links. The `next` field on a task is true when it is the first available action in a sequential project or action group. In parallel projects, all incomplete tasks have `next: true`.
+INHERITED STATUS: `completed`/`dropped` reflect the task's own state, not its container's. Task in completed project: `completed: false`, `available: false`. Use `available_only=True` for actionable tasks.
 
-ACTION GROUPS: A task with subtasks is an "action group." It can be parallel or sequential, just like a project. The parent task appears as `blocked: true` while its subtasks are active — this is normal behavior, not an error or a problem to fix. Check `subtaskCount > 0` to identify action groups. An action group parent cannot be completed until its subtasks are resolved. If you see a task with `blocked: true` and `subtaskCount > 0`, it means "work on the subtasks first" — do not try to unblock it.
+EFFECTIVE DATES: Dates returned by get_tasks include dates inherited from the project. A task with no direct due date shows its project's due date. You cannot clear an inherited date at the task level. Write operations set the task's own date.
 
-INHERITED STATUS: Task-level fields like `completed` and `dropped` reflect the task's own state, NOT its container's state. A task inside a completed project will show `completed: false` (because the task itself wasn't individually completed) but `available: false` (because its container is inactive). This is expected behavior. To find truly actionable tasks, always use `available` or `available_only=True` — do not rely on `completed` alone.
+RECURRING TASKS: `completed=True` uses `mark complete`, which creates the next occurrence. This is guaranteed. WARNING: Dropping a recurring task (status='dropped') without clearing recurrence first (recurrence='') spawns the next occurrence. To stop a series: update_tasks([{"id": "...", "recurrence": "", "status": "dropped"}]).
 
-EFFECTIVE DATES: Date fields (dueDate, deferDate, plannedDate) returned by get_tasks are EFFECTIVE dates — they include dates inherited from the containing project. A task with no direct due date in a project with dueDate=April 15 will return dueDate="2026-04-15T17:00:00" (not empty). Do not assume an empty due date on a task means the project has no due date either. Write operations (update_task) set the task's own date directly.
+TAGS: Represent work contexts. Tags can be Active or On Hold — tasks with On Hold tags are excluded from Available perspective.
 
-BATCH OPERATIONS: When applying the same change to multiple items, prefer the batch tools (update_tasks, update_projects) over multiple individual calls. Batch tools accept a list of IDs and are more efficient.
-
-RECURRING TASKS: Setting completed=True on a recurring task uses OmniFocus's 'mark complete' command, which automatically creates the next occurrence. This is guaranteed behavior — do not hedge or warn that recurrence might stop.
-
-TAGS: Formerly "contexts." Represent work contexts (location, tools, energy, people, workflow states like Waiting-for or Agenda). Cut across projects. Use for filtering. Tags can be Active or On Hold — tasks with On Hold tags are excluded from OmniFocus's native Available perspective.
-
-PLANNING PATTERN: To plan a day, query: (1) overdue tasks, (2) flagged + available tasks, (3) inbox items, (4) next actions. Prioritize overdue+flagged first.
-
-INBOX: Unprocessed capture bucket. Tasks without a project land here. Non-empty inbox = items need organizing.
-
-REVIEW: Projects have review intervals. Use get_projects() to find projects due for review (check lastReviewDate + reviewIntervalValue/reviewIntervalUnit).
+DEFER vs DUE: Defer = hidden until that date. Due = deadline.
 """)
 
 # Configuration
@@ -244,44 +234,25 @@ def get_projects(
     min_task_count: Optional[int] = None,
     has_no_due_dates: Optional[bool] = None,
 ) -> str:
-    """Retrieve projects from OmniFocus with optional filtering.
+    """Retrieve projects with optional filtering.
 
-    Args:
-        project_id: Filter to specific project by ID (optional)
-        include_full_notes: Return full note content (default: False)
-        on_hold_only: If True, only return projects with "on hold" status
-        query: Optional search term to filter by name, note, or folder path (case-insensitive)
-        include_task_health: If True, include per-project task health counts (remaining, available, overdue, deferred)
-        include_last_activity: If True, compute lastActivityDate (most recent task creation/completion)
-        stalled_only: If True, only return active projects with no available actions — projects that need attention (implies include_task_health=True)
-        flagged_only: If True, only return flagged projects
-        include_dropped: If True, include dropped projects in results (default: False — dropped projects are hidden)
-        include_completed: If True, include completed projects (hidden by default)
-        completed_only: If True, only return completed projects (implies include_completed)
-        tag_filter: Only return projects with ALL specified tags (case-insensitive)
-        planned_after: Only return projects with planned date on or after this ISO date (optional)
-        planned_before: Only return projects with planned date before this ISO date (optional)
-        planned_on: Only return projects planned for this specific date, e.g., "2026-03-23" (optional).
-            Convenience for planned_after=date + planned_before=next_day. Mutually exclusive
-            with planned_after/planned_before.
-        has_overdue_tasks: If True, only return projects with overdue tasks (implies include_task_health=True). (optional)
-        sort_by: Sort results by field — "name" (optional)
-        sort_order: Sort direction — "asc" (default) or "desc"
-        modified_after: Only return projects modified after this ISO date (optional)
-        modified_before: Only return projects modified before this ISO date (optional)
-        min_task_count: Only return projects with at least this many tasks (optional)
-        has_no_due_dates: If True, only return projects where no tasks have due dates (optional)
+    Parameters:
+    - project_id: str -- filter to specific project
+    - query: str -- search name/note/folder (case-insensitive)
+    - flagged_only, on_hold_only, stalled_only, completed_only: bool
+    - include_dropped, include_completed: bool -- include hidden states
+    - include_full_notes: bool
+    - include_task_health: bool -- adds remainingCount, availableCount, overdueCount, deferredCount, stalled, health
+    - include_last_activity: bool -- adds lastActivityDate
+    - has_overdue_tasks: bool -- implies include_task_health
+    - tag_filter: list[str] -- projects with ALL specified tags
+    - planned_after, planned_before, planned_on: str -- ISO date filters (planned_on is mutually exclusive)
+    - modified_after, modified_before: str
+    - min_task_count: int
+    - has_no_due_dates: bool
+    - sort_by: str -- "name"; sort_order: str -- "asc"/"desc"
 
-    Returns:
-        Each project includes: id, name, folderPath, status, projectType, sequential,
-        completedByChildren, flagged, creationDate, tags, note (truncated unless include_full_notes=True).
-        `projectType` is "sequential", "parallel", or "single_actions" (Single Actions List —
-        a grab-bag list with no completion goal). `sequential` (boolean) is retained for
-        backwards compatibility. `completedByChildren` (boolean) indicates whether the project
-        auto-completes when its last remaining action is completed.
-        With include_task_health: remainingCount, availableCount, overdueCount, deferredCount, stalled, health status.
-        `stalled` (boolean) — true when availableCount=0 and not all tasks are deferred (project needs attention).
-        With include_last_activity: lastActivityDate.
+    Returns: id, name, folderPath, status, projectType, sequential (deprecated), completedByChildren, flagged, creationDate, modificationDate, completionDate, droppedDate, dueDate, deferDate, plannedDate, tags, note, lastReviewDate, nextReviewDate, reviewIntervalValue, reviewIntervalUnit. Optional health/activity fields when requested.
     """
     # Expand planned_on to planned_after + planned_before
     if planned_on is not None:
@@ -488,30 +459,22 @@ def update_project(
 
 @mcp.tool()
 def update_projects(projects: list[ProjectUpdate]) -> str:
-    """Update one or more projects in OmniFocus.
+    """Update one or more projects. Each item has id (required) plus fields to change.
 
-    Pass a list of project update objects. Each must have an id field.
-    Only the specified fields will be updated — omitted fields are unchanged.
-
-    Args:
-        projects: List of project update objects. Each must have:
-            id (required), plus any fields to update: project_name, folder_path,
-            note, sequential, project_type, status, review_interval_weeks,
-            review_interval_value, review_interval_unit,
-            last_reviewed, next_review_date, completed_by_children, due_date,
-            defer_date, planned_date, flagged, estimated_minutes, tags,
-            add_tags, remove_tags, recurrence, repetition_method.
-
-    Returns:
-        For single project: success message with updated fields.
-        For multiple projects: summary with per-item results.
-
-    Examples:
-        update_projects([{"id": "p1", "status": "on_hold"}])
-        update_projects([
-            {"id": "p1", "status": "on_hold"},
-            {"id": "p2", "project_name": "Renamed", "flagged": true}
-        ])
+    Parameters (per item):
+    - id: str (required)
+    - project_name, note, folder_path: str -- note: replaces rich text
+    - project_type: str; sequential: bool (deprecated)
+    - status: str -- "active", "on_hold", "done", "dropped"
+    - review_interval_value: int + review_interval_unit: str ("day"/"week"/"month"/"year"); review_interval_weeks: int (deprecated)
+    - last_reviewed: str -- ISO or "now"; next_review_date: str
+    - completed_by_children: bool
+    - due_date, defer_date, planned_date: str -- ISO or "" to clear
+    - flagged: bool
+    - estimated_minutes: int
+    - tags: list[str] -- full replacement (conflicts with add_tags/remove_tags)
+    - add_tags, remove_tags: list[str]
+    - recurrence: str -- RRULE or "" to clear; repetition_method: str -- "fixed", "start_after_completion", "due_after_completion"
     """
     client = get_client()
 
@@ -599,58 +562,30 @@ def get_tasks(
     planned_before: Optional[str] = None,
     planned_on: Optional[str] = None,
 ) -> str:
-    """Get tasks from OmniFocus with optional filtering.
+    """Get tasks with optional filtering.
 
-    Args:
-        task_id: Filter to specific task by ID (optional)
-        parent_task_id: Filter to subtasks of this parent task (optional)
-        include_full_notes: Return full note content (default: False)
-        project_id: Optional project ID to filter tasks (ignored if inbox_only=True)
-        flagged_only: If True, only return flagged tasks
-        include_completed: If True, include completed tasks (default: False)
-        available_only: If True, only return available tasks (not completed, not dropped, not blocked, not deferred)
-        overdue: If True, only return overdue tasks
-        dropped_only: If True, only return dropped tasks
-        blocked_only: If True, only return blocked tasks
-        next_only: If True, only return next tasks
-        tag_filter: List of tag names to filter by, e.g., ["Errands", "Weekend"] (task must have ALL listed tags)
-        query: Optional search term to filter by name or note (case-insensitive)
-        inbox_only: If True, only return inbox tasks
-        sort_by: Sort results by field — "name", "due_date", or "defer_date" (optional)
-        sort_order: Sort direction — "asc" (default) or "desc"
-        modified_after: Only return tasks modified after this ISO date (optional)
-        modified_before: Only return tasks modified before this ISO date (optional)
-        created_after: Only return tasks created after this ISO date (optional)
-        created_before: Only return tasks created before this ISO date (optional)
-        max_estimated_minutes: Only return tasks with estimated time ≤ this value — "quick wins" filter (optional)
-        has_estimate: If True, only return tasks with an estimate set; if False, only tasks without (optional)
-        recurring_only: If True, only return recurring tasks; if False, only non-recurring (optional)
-        tag_filter_mode: How tag_filter matches — "and" (default: all tags), "or" (any tag), "not" (none of the tags)
-        planned_after: Only return tasks with planned date on or after this ISO date (optional)
-        planned_before: Only return tasks with planned date before this ISO date (optional)
-        planned_on: Only return tasks planned for this specific date, e.g., "2026-03-23" (optional).
-            Convenience for planned_after=date + planned_before=next_day. Mutually exclusive
-            with planned_after/planned_before.
+    Parameters:
+    - task_id, parent_task_id, project_id: str
+    - query: str -- search name/note
+    - flagged_only, available_only, overdue, dropped_only, blocked_only, next_only, inbox_only: bool
+    - include_completed: bool
+    - include_full_notes: bool
+    - tag_filter: list[str]; tag_filter_mode: str -- "and" (default), "or", "not"
+    - planned_after, planned_before, planned_on: str
+    - modified_after, modified_before, created_after, created_before: str
+    - max_estimated_minutes: int -- quick wins filter
+    - has_estimate: bool
+    - recurring_only: bool
+    - sort_by: str -- "name", "due_date", "defer_date"; sort_order: str
 
-    Returns:
-        Each task includes: id, name, projectName, completed, dropped, blocked, available, next,
-        flagged, inInbox, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note (truncated
-        unless include_full_notes=True), parentTaskId, subtaskCount, sequential, nextDueDate,
-        nextDeferDate, nextPlannedDate, catchUpAutomatically.
-        `available` is true when the task is not completed, not dropped, not blocked, and not
-        deferred (defer date is in the past or unset). Equivalent to OmniFocus's native Available
-        filter.
+    Returns: id, name, projectName, completed, dropped, blocked, available, next, flagged, dueDate, deferDate, plannedDate, estimatedMinutes, tags, note, parentTaskId, subtaskCount, sequential, isRecurring, recurrence, repetitionMethod, repeatSummary, nextDueDate, nextDeferDate, nextPlannedDate, catchUpAutomatically, creationDate, modificationDate, completionDate, droppedDate.
 
-    Note: Date fields (dueDate, deferDate, plannedDate) reflect effective dates — including
-    dates inherited from the containing project or action group. A task with no direct due
-    date will show its project's due date in dueDate. Example: if project "Q2 Report" has
-    dueDate=April 15, a task with no direct due date returns dueDate="2026-04-15T17:00:00"
-    (inherited, not empty). Write operations (update_task) still set the task's own date
-    directly. Next occurrence fields (nextDueDate, nextDeferDate,
-    nextPlannedDate) are populated only for recurring tasks and show the dates of the next
-    recurrence — empty for non-recurring tasks. `catchUpAutomatically` (boolean, null for
-    non-recurring) controls missed-recurrence behavior: when true, only one catch-up
-    occurrence is created; when false, each missed interval spawns its own occurrence.
+    Key fields:
+    - available -- true when actionable (accounts for inherited status from containers)
+    - repeatSummary -- human-readable recurrence; always use this for display, don't parse RRULE
+    - repetitionMethod -- "fixed" (original schedule), "start_after_completion" (defer shifts), "due_after_completion" (due shifts)
+    - catchUpAutomatically -- recurring only; true = one catch-up occurrence, false = each missed interval spawns its own
+    - Date fields are effective (include inherited from project). Next-occurrence fields populated only for recurring tasks.
     """
     # Expand planned_on to planned_after + planned_before
     if planned_on is not None:
@@ -818,27 +753,19 @@ class TaskUpdate(BaseModel):
 
 @mcp.tool()
 def create_tasks(tasks: list[TaskCreate]) -> str:
-    """Create one or more tasks in OmniFocus.
+    """Create one or more tasks.
 
-    Pass a list of task objects. Each task must have a task_name; all other
-    fields are optional. For a single task, pass a list with one item.
-
-    Args:
-        tasks: List of task objects to create. Each object supports:
-            task_name (required), project_id, parent_task_id, note, due_date,
-            defer_date, planned_date, flagged, tags, estimated_minutes,
-            sequential, completed_by_children.
-
-    Returns:
-        For single task: success message with task ID.
-        For multiple tasks: summary with per-item results.
-
-    Examples:
-        create_tasks([{"task_name": "Buy groceries"}])
-        create_tasks([
-            {"task_name": "Task A", "project_id": "proj-1", "flagged": true},
-            {"task_name": "Task B", "tags": ["work"], "due_date": "2026-04-01"}
-        ])
+    Parameters (per item):
+    - task_name: str (required)
+    - project_id: str -- mutually exclusive with parent_task_id
+    - parent_task_id: str -- creates subtask
+    - note: str (plain text only)
+    - due_date, defer_date, planned_date: str -- ISO 8601
+    - flagged: bool
+    - tags: list[str] -- must already exist
+    - estimated_minutes: int
+    - sequential: bool -- subtasks completed in order
+    - completed_by_children: bool
     """
     client = get_client()
     results = []
@@ -905,26 +832,16 @@ def create_tasks(tasks: list[TaskCreate]) -> str:
 
 @mcp.tool()
 def create_projects(projects: list[ProjectCreate]) -> str:
-    """Create one or more projects in OmniFocus.
+    """Create one or more projects.
 
-    Pass a list of project objects. Each must have a name; all other fields optional.
-
-    Args:
-        projects: List of project objects to create. Each object supports:
-            name (required), note, folder_path, project_type, sequential,
-            review_interval_weeks, completed_by_children, due_date,
-            defer_date, planned_date.
-
-    Returns:
-        For single project: success message with project ID.
-        For multiple projects: summary with per-item results.
-
-    Examples:
-        create_projects([{"name": "Website Redesign"}])
-        create_projects([
-            {"name": "Project A", "folder_path": "Work", "project_type": "sequential"},
-            {"name": "Project B", "due_date": "2026-04-01"}
-        ])
+    Parameters (per item):
+    - name: str (required)
+    - note, folder_path: str
+    - project_type: str -- "parallel" (default), "sequential", "single_actions"
+    - sequential: bool (deprecated, use project_type)
+    - review_interval_weeks: int
+    - completed_by_children: bool
+    - due_date, defer_date, planned_date: str -- ISO 8601
     """
     client = get_client()
 
@@ -1047,28 +964,19 @@ def update_task(
 
 @mcp.tool()
 def update_tasks(tasks: list[TaskUpdate]) -> str:
-    """Update one or more tasks in OmniFocus.
+    """Update one or more tasks. Each item has id (required) plus fields to change.
 
-    Pass a list of task update objects. Each must have an id field.
-    Only the specified fields will be updated — omitted fields are unchanged.
-
-    Args:
-        tasks: List of task update objects. Each must have:
-            id (required), plus any fields to update: task_name, project_id,
-            parent_task_id, note, due_date, defer_date, planned_date, flagged,
-            tags, add_tags, remove_tags, estimated_minutes, completed, status,
-            recurrence, repetition_method, sequential, completed_by_children.
-
-    Returns:
-        For single task: success message with updated fields.
-        For multiple tasks: summary with per-item results.
-
-    Examples:
-        update_tasks([{"id": "t1", "flagged": true}])
-        update_tasks([
-            {"id": "t1", "flagged": true},
-            {"id": "t2", "task_name": "Renamed", "due_date": "2026-04-01"}
-        ])
+    Parameters (per item):
+    - id: str (required)
+    - task_name, project_id, parent_task_id, note: str
+    - due_date, defer_date, planned_date: str -- ISO or "" to clear
+    - flagged, completed: bool -- completed=True on recurring task creates next occurrence
+    - status: str
+    - tags: list[str] -- full replacement (conflicts with add_tags/remove_tags)
+    - add_tags, remove_tags: list[str]
+    - estimated_minutes: int
+    - recurrence: str -- RRULE or "" to clear; repetition_method: str
+    - sequential: bool; completed_by_children: bool
     """
     client = get_client()
 
@@ -1129,20 +1037,9 @@ def update_tasks(tasks: list[TaskUpdate]) -> str:
 
 @mcp.tool()
 def get_tags() -> str:
-    """Retrieve all available tags from OmniFocus.
+    """Retrieve all tags.
 
-    Tags (formerly 'contexts') represent contexts for doing work — location (Office, Home),
-    tools (Computer, Phone), energy level (High, Low), people, or workflow states
-    (Waiting-for, Agenda). They cut across projects and are used for filtering tasks
-    via get_tasks(tag_filter=[...]).
-
-    Returns:
-        Each tag includes: id, name, status, parentTagId, childrenAreMutuallyExclusive.
-        `parentTagId` is the parent tag's ID (empty string if top-level). Note: create_tag()
-        and update_tag() accept parent_tag by NAME, not by this ID.
-        `childrenAreMutuallyExclusive` (boolean) — when true, child tags are mutually
-        exclusive: assigning one child tag to a task silently removes any other child
-        from the same group. Read via OmniAutomation (defaults to false if unavailable).
+    Returns: id, name, status ("active"/"on hold"/"dropped"), parentTagId (empty if top-level; create/update accept parent by NAME not ID), childrenAreMutuallyExclusive (assigning one child silently removes siblings).
     """
     client = get_client()
     tags = client.get_tags()
@@ -1201,24 +1098,12 @@ def create_tag(
 
 @mcp.tool()
 def create_tags(tags: list[TagCreate]) -> str:
-    """Create one or more tags in OmniFocus.
+    """Create one or more tags.
 
-    Tags (formerly 'contexts') represent contexts for doing work — location, tools,
-    energy level, people, or workflow states. Tags can be nested (e.g., create "High"
-    under parent "Energy" to get "Energy : High").
-
-    Args:
-        tags: List of tag objects to create. Each must have:
-            name (required), parent_tag (optional, by NAME not ID),
-            children_are_mutually_exclusive (optional, default False).
-
-    Returns:
-        For single tag: success message with tag ID.
-        For multiple tags: summary with per-item results.
-
-    Examples:
-        create_tags([{"name": "Automation"}])
-        create_tags([{"name": "High", "parent_tag": "Energy"}, {"name": "Low", "parent_tag": "Energy"}])
+    Parameters (per item):
+    - name: str (required)
+    - parent_tag: str -- parent by name
+    - children_are_mutually_exclusive: bool
     """
     client = get_client()
     results = []
@@ -1277,24 +1162,13 @@ def update_tag(
 
 @mcp.tool()
 def update_tags(tags: list[TagUpdate]) -> str:
-    """Update one or more tags in OmniFocus.
+    """Update one or more tags. Each item has id (required) plus fields to change.
 
-    Tags can be renamed, reparented, or have their status changed. Each item
-    in the list can update different fields.
-
-    Args:
-        tags: List of tag update objects. Each must have:
-            id (required), name (optional), status (optional: "active", "on_hold",
-            "dropped"), children_are_mutually_exclusive (optional),
-            parent_tag (optional, by NAME or empty string to move to top level).
-
-    Returns:
-        For single tag: success message with updated fields.
-        For multiple tags: summary with per-item results.
-
-    Examples:
-        update_tags([{"id": "tag-123", "name": "Renamed"}])
-        update_tags([{"id": "tag-1", "status": "on_hold"}, {"id": "tag-2", "parent_tag": "People"}])
+    Parameters (per item):
+    - id: str (required)
+    - name, status: str -- status: "active", "on_hold", "dropped"
+    - children_are_mutually_exclusive: bool
+    - parent_tag: str -- move to parent by name, "" for top level
     """
     client = get_client()
     results = []
@@ -1341,20 +1215,9 @@ def update_tags(tags: list[TagUpdate]) -> str:
 
 @mcp.tool()
 def delete_tags(tag_ids: Union[str, list[str]]) -> str:
-    """Delete one or more tags from OmniFocus.
+    """Delete tags. Tasks lose tag association but are not deleted.
 
-    WARNING: This permanently deletes the tags. Tasks that had these tags will
-    lose the tag association but are not themselves deleted.
-
-    Args:
-        tag_ids: Single tag ID (str) or list of tag IDs to delete
-
-    Returns:
-        Summary of deleted tags with count and any errors encountered
-
-    Examples:
-        delete_tags("tag-123")  # Delete single tag
-        delete_tags(["tag-001", "tag-002"])  # Delete multiple
+    - tag_ids: str | list[str] (required)
     """
     client = get_client()
     try:
@@ -1383,19 +1246,9 @@ def delete_tags(tag_ids: Union[str, list[str]]) -> str:
 
 @mcp.tool()
 def delete_tasks(task_ids: Union[str, list[str]]) -> str:
-    """Delete one or more tasks from OmniFocus.
+    """Permanently delete tasks. Cannot be undone.
 
-    WARNING: This permanently deletes the tasks and cannot be undone.
-
-    Args:
-        task_ids: Single task ID (str) or list of task IDs to delete
-
-    Returns:
-        Summary of deleted tasks with count and any errors encountered
-
-    Examples:
-        delete_tasks("task-123")  # Delete single task
-        delete_tasks(["task-001", "task-002", "task-003"])  # Delete multiple
+    - task_ids: str | list[str] (required)
     """
     client = get_client()
     try:
@@ -1429,15 +1282,9 @@ def delete_tasks(task_ids: Union[str, list[str]]) -> str:
 
 @mcp.tool()
 def delete_projects(project_ids: Union[str, list[str]]) -> str:
-    """Delete one or more projects from OmniFocus.
+    """Permanently delete projects and all their tasks. Cannot be undone.
 
-    WARNING: This permanently deletes the projects and all their tasks. Cannot be undone.
-
-    Args:
-        project_ids: Single project ID (str) or list of project IDs to delete
-
-    Returns:
-        Summary of deleted projects with count and any errors encountered
+    - project_ids: str | list[str] (required)
     """
     client = get_client()
     try:
@@ -1474,12 +1321,9 @@ def delete_projects(project_ids: Union[str, list[str]]) -> str:
 
 @mcp.tool()
 def get_folders() -> str:
-    """Get all folders from OmniFocus with their hierarchy.
+    """Get all folders with hierarchy.
 
-    Returns:
-        Each folder includes: id, name, path (hierarchical, e.g. "Work > Clients"),
-        status ("active" or "dropped"). Dropped folders and their contents are hidden
-        from most OmniFocus views.
+    Returns: id, name, path (e.g. "Work > Clients"), status ("active"/"dropped").
     """
     client = get_client()
     folders = client.get_folders()
@@ -1527,19 +1371,11 @@ def create_folder(name: str, parent_path: Optional[str] = None) -> str:
 
 @mcp.tool()
 def create_folders(folders: list[FolderCreate]) -> str:
-    """Create one or more folders in OmniFocus.
+    """Create one or more folders.
 
-    Args:
-        folders: List of folder objects to create. Each must have:
-            name (required), parent_path (optional, e.g., "Work" or "Work > Clients").
-
-    Returns:
-        For single folder: success message with folder ID.
-        For multiple folders: summary with per-item results.
-
-    Examples:
-        create_folders([{"name": "Clients"}])
-        create_folders([{"name": "Work"}, {"name": "Personal"}])
+    Parameters (per item):
+    - name: str (required)
+    - parent_path: str -- e.g. "Work > Clients"
     """
     client = get_client()
     results = []
@@ -1596,19 +1432,12 @@ def update_folder(
 
 @mcp.tool()
 def update_folders(folders: list[FolderUpdate]) -> str:
-    """Update one or more folders in OmniFocus.
+    """Update one or more folders. Each item has id (required) plus fields to change.
 
-    Args:
-        folders: List of folder update objects. Each must have:
-            id (required), name (optional), status (optional: "active" or "dropped").
-
-    Returns:
-        For single folder: success message with updated fields.
-        For multiple folders: summary with per-item results.
-
-    Examples:
-        update_folders([{"id": "folder-123", "name": "Renamed"}])
-        update_folders([{"id": "f1", "status": "dropped"}, {"id": "f2", "name": "New"}])
+    Parameters (per item):
+    - id: str (required)
+    - name: str
+    - status: str -- "active" or "dropped"
     """
     client = get_client()
     results = []
@@ -1659,25 +1488,13 @@ def update_folders(folders: list[FolderUpdate]) -> str:
 
 @mcp.tool()
 def reorder_task(task_id: str, before_task_id: Optional[str] = None, after_task_id: Optional[str] = None) -> str:
-    """Move a task before or after another task to change its position.
+    """Move a task before or after another task within the same project/level.
 
-    Use this to reorder tasks within a project or within a parent task's subtasks.
-    In sequential projects, task order determines dependencies — reordering changes
-    which task is available next (first incomplete = available, rest = blocked).
+    - task_id: str (required)
+    - before_task_id: str -- place before this task
+    - after_task_id: str -- place after this task
 
-    Args:
-        task_id: The ID of the task to move
-        before_task_id: Place task immediately BEFORE this reference task (provide either this OR after_task_id).
-            Example: reorder_task("C", before_task_id="A") results in [..., C, A, ...]
-        after_task_id: Place task immediately AFTER this reference task (provide either this OR before_task_id).
-            Example: reorder_task("C", after_task_id="A") results in [..., A, C, ...]
-
-    Returns:
-        Success message confirming the task was reordered
-
-    Note:
-        Both tasks must be in the same project and at the same level (both root-level or both subtasks of the same parent).
-        Exactly one of before_task_id or after_task_id must be provided.
+    Exactly one of before/after required. In sequential projects, order = dependencies.
     """
     client = get_client()
     try:
@@ -1697,23 +1514,13 @@ def reorder_task(task_id: str, before_task_id: Optional[str] = None, after_task_
 
 @mcp.tool()
 def reorder_project(project_id: str, before_project_id: Optional[str] = None, after_project_id: Optional[str] = None) -> str:
-    """Move a project before or after another project to change its position within a folder.
+    """Move a project before or after another project within the same folder.
 
-    Use this to reorder projects within a folder. Both projects must be in the same folder.
+    - project_id: str (required)
+    - before_project_id: str
+    - after_project_id: str
 
-    Args:
-        project_id: The ID of the project to move
-        before_project_id: Place project immediately BEFORE this reference project (provide either this OR after_project_id).
-            Example: reorder_project("C", before_project_id="A") results in [..., C, A, ...]
-        after_project_id: Place project immediately AFTER this reference project (provide either this OR before_project_id).
-            Example: reorder_project("C", after_project_id="A") results in [..., A, C, ...]
-
-    Returns:
-        Success message confirming the project was reordered
-
-    Note:
-        Both projects must be in the same folder.
-        Exactly one of before_project_id or after_project_id must be provided.
+    Exactly one of before/after required.
     """
     client = get_client()
     try:
@@ -1735,10 +1542,9 @@ def reorder_project(project_id: str, before_project_id: Optional[str] = None, af
 
 @mcp.tool()
 def get_perspectives() -> str:
-    """Get all perspectives from OmniFocus with type and ID information.
+    """Get all perspectives.
 
-    Returns:
-        Formatted list of perspectives with name, type (built-in/custom), and ID
+    Returns: name, type (built-in/custom), id
     """
     client = get_client()
     perspectives = client.get_perspectives()
@@ -1760,13 +1566,9 @@ def get_perspectives() -> str:
 
 @mcp.tool()
 def switch_perspective(perspective_name: str) -> str:
-    """Switch the front window to a different perspective.
+    """Switch front window to a perspective.
 
-    Args:
-        perspective_name: Name of the perspective to switch to
-
-    Returns:
-        Success message confirming perspective switch
+    - perspective_name: str (required)
     """
     client = get_client()
     try:
@@ -1781,17 +1583,10 @@ def set_focus(
     item_ids: str | list[str] = None,
     item_types: str | list[str] = None,
 ) -> str:
-    """Set focus on one or more items, or clear focus.
+    """Focus on projects/folders, or clear focus. Does not support tasks or tags.
 
-    OmniFocus supports focusing on projects and folders only (NOT tasks or tags). To highlight specific tasks, use update_task(flagged=True) instead.
-    Call with no arguments (or empty lists) to clear focus.
-
-    Args:
-        item_ids: Single ID or list of IDs to focus on. Omit or pass empty to clear.
-        item_types: Matching type(s) - each must be "project" or "folder".
-
-    Returns:
-        Success message confirming focus set or cleared
+    - item_ids: str | list[str] -- omit or empty to clear
+    - item_types: str | list[str] -- "project" or "folder"
     """
     client = get_client()
     try:
@@ -1812,10 +1607,7 @@ def set_focus(
 
 @mcp.tool()
 def get_focus() -> str:
-    """Get the currently focused items in OmniFocus.
-
-    Returns:
-        Formatted list of currently focused items, or a message if no focus is set
+    """Get currently focused items.
     """
     client = get_client()
     try:


### PR DESCRIPTION
## Summary

- Adopt aggressively compressed server instructions and tool docstrings after blind eval comparison (3 versions × 71 scenarios × independent scoring)
- Server instructions: 3,580 → 1,400 chars; tool docstrings: avg 900 → 355 chars
- Community research showed our descriptions were 10x the MCP server norm (Playwright ~35 chars avg, Filesystem ~300 chars avg, us ~900 chars avg)
- Blind eval: trimmed version scores 140/142 (98.6%) vs 142/142 original — one regression on inherited dates confidence

Also fixes:
- Add undocumented drop+recurrence gotcha (dropping recurring task without clearing recurrence spawns next occurrence)
- Add `next` field semantics to server instructions
- Fix duplicate scenario IDs 53/54 → 70/71
- Update scenario #5 for v0.13.0 API (no single-item wrappers)
- Update scenario #13 to remove PLANNING PATTERN dependency
- Add `--descriptions` and `--label` flags to `run_eval.py`

## Test plan

- [x] Unit tests pass (1022 passed, 275 skipped)
- [ ] Blind eval scores stable with new descriptions
- [ ] Claude Desktop context pressure reduced (user to verify)

closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)