### PR TITLE
chore: add CI wait step to merge-and-status command

### DIFF
--- a/.claude/commands/merge-and-status.md
+++ b/.claude/commands/merge-and-status.md
@@ -7,24 +7,29 @@ Merge the current PR, pull main, and show open milestone issues.
    gh pr list --head "$(git branch --show-current)" --state open --json number --jq '.[0].number'
    ```
 
-2. **Squash merge** the PR and delete the branch:
+2. **Wait for CI checks to pass:**
+   ```bash
+   gh pr checks <number> --watch
+   ```
+
+3. **Squash merge** the PR and delete the branch:
    ```bash
    gh pr merge <number> --squash --delete-branch
    ```
 
-3. **Switch to main and pull:**
+4. **Switch to main and pull:**
    ```bash
    git checkout main && git pull
    ```
 
-4. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
+5. **Determine the current milestone.** Look at the most recent closed PR's milestone, or find the earliest open milestone:
    ```bash
    gh api repos/:owner/:repo/milestones --jq 'sort_by(.due_on // .title) | map(select(.state == "open")) | .[0].title'
    ```
 
-5. **List open issues** on that milestone:
+6. **List open issues** on that milestone:
    ```bash
    gh issue list --milestone "<milestone>" --state open
    ```
 
-6. **Display results** as a formatted table with issue number, title, and labels.
+7. **Display results** as a formatted table with issue number, title, and labels.


### PR DESCRIPTION
## Summary

- Add `gh pr checks --watch` step before merge attempt in `/merge-and-status`
- Prevents confusing "base branch policy prohibits the merge" error when CI is still running

## Test plan

- [x] Next `/merge-and-status` invocation should wait for CI then merge cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)