### PR TITLE
fix: annotate stalled_only parameter in tool descriptions

### DIFF
--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -31,7 +31,8 @@ Retrieve projects with optional filtering.
 **Parameters:**
 - `project_id: str` — filter to specific project
 - `query: str` — search name/note/folder (case-insensitive)
-- `flagged_only, on_hold_only, stalled_only, completed_only: bool`
+- `flagged_only, on_hold_only, completed_only: bool`
+- `stalled_only: bool` — active projects with no available next actions
 - `include_dropped, include_completed: bool` — include hidden states
 - `include_full_notes: bool`
 - `include_task_health: bool` — adds remainingCount, availableCount, overdueCount, deferredCount, stalled, health

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -239,7 +239,8 @@ def get_projects(
     Parameters:
     - project_id: str -- filter to specific project
     - query: str -- search name/note/folder (case-insensitive)
-    - flagged_only, on_hold_only, stalled_only, completed_only: bool
+    - flagged_only, on_hold_only, completed_only: bool
+    - stalled_only: bool -- active projects with no available next actions
     - include_dropped, include_completed: bool -- include hidden states
     - include_full_notes: bool
     - include_task_health: bool -- adds remainingCount, availableCount, overdueCount, deferredCount, stalled, health


### PR DESCRIPTION
## Summary

- Separate `stalled_only` from the comma-grouped boolean filters and add description: "active projects with no available next actions"
- Critic Finding #1 (HIGH impact) from #544 blind eval

## Test plan

- [x] Python syntax valid
- [ ] Unit tests pass

closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)