### PR TITLE
release: v0.13.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.13.0 | **Tests:** 1023 unit, 227 integration/E2E, 47 benchmark/profiling | **Coverage:** 93%
+**Version:** v0.13.1 | **Tests:** 1022 unit, 227 integration/E2E, 47 benchmark/profiling | **Coverage:** 93%
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to the OmniFocus MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-03-28
+
+Tool description overhaul — trimmed by 67% after blind eval research showed descriptions were 10x the MCP community norm. Adversarial API critic review identified and fixed four description gaps.
+
+### Changed
+
+- **Server instructions and tool docstrings trimmed by 67%** — 29K → 10K chars (#550, #552)
+  - Server instructions: 3,580 → 1,400 chars (cut BATCH OPERATIONS, PLANNING PATTERN, INBOX, REVIEW)
+  - Tool docstrings: avg 900 → 355 chars (let parameter names/types self-document)
+  - Blind eval: trimmed version scores 98.6% vs 100% original on Claude
+
+- **Strengthened effective dates language** to prevent agent hedging (#556, #561)
+  - "include" → "always effective (inherited)", "WILL show", "not a bug"
+
+- **Documented all three tag statuses** with availability effects (#557, #561)
+  - Active (normal), On Hold (excludes from Available), Dropped (hidden, no availability effect)
+
+- **Annotated `stalled_only` parameter** — was the only undescribed boolean filter (#555, #560)
+
+- **Enumerated task `status` valid values** — was bare `status: str` (#558, #561)
+
+- **Added drop+recurrence warning** — dropping without clearing recurrence spawns next occurrence (#550)
+
+- **Added `next` field semantics** to server instructions (#550)
+
+### Fixed
+
+- **Duplicate scenario IDs** 53/54 → 70/71 in blind eval suite (#550)
+- **Stale scenario #5** PASS criteria updated for v0.13.0 API (no single-item wrappers) (#550)
+- **Scenario #13** relaxed from 4 queries to 3+ (removed PLANNING PATTERN dependency) (#550)
+
+### Added
+
+- **5x multi-run eval infrastructure** — `run_eval.py --runs 5` for variance analysis (#544, #559)
+- **Regex + LLM auto-scoring** — `--scorer-model` flag for semantic scoring of explanation scenarios (#544)
+- **macOS Keychain API key storage** for eval runner (#551, #554)
+- **`--descriptions` and `--label` flags** for A/B testing different description versions (#550)
+- **CI wait step** in `/merge-and-status` command — prevents confusing error when CI is pending (#553)
+- **Adversarial API critic** workflow — ranked findings by agent mistake likelihood × severity (#544)
+- **Post-fix eval rerun** confirming Claude at 100% and DeepSeek improved (#562, #563)
+
+### Documentation
+
+- **Blind eval results** — 5x runs across Claude (100%), DeepSeek (93.7%), Llama (89.7%)
+- **Test docstrings** added to all 474 previously undocumented test methods (#547, #549)
+
 ## [0.13.0] - 2026-03-24
 
 Unified batch CRUD for all entity types — tags and folders join tasks and projects with Pydantic model inputs. Deprecated single-item wrappers removed from MCP surface.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 ```bash
 git clone https://github.com/s-morgan-jeffries/omnifocus-mcp.git
 cd omnifocus-mcp
-git checkout v0.13.0  # Latest stable release
+git checkout v0.13.1  # Latest stable release
 
 # Using UV (recommended)
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnifocus-mcp"
-version = "0.13.0"
+version = "0.13.1"
 description = "MCP server for OmniFocus integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/omnifocus_mcp/__init__.py
+++ b/src/omnifocus_mcp/__init__.py
@@ -1,6 +1,6 @@
 """OmniFocus MCP Server - Model Context Protocol server for OmniFocus integration."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 from .omnifocus_connector import OmniFocusConnector, run_applescript
 


### PR DESCRIPTION
## Release v0.13.1

Tool description overhaul — trimmed by 67% after blind eval research showed descriptions were 10x the MCP community norm. Adversarial API critic review identified and fixed four description gaps. First multi-run eval with variance analysis.

### Highlights

- **Descriptions trimmed 67%** — 29K → 10K chars. Claude scores 100% on trimmed descriptions (#550)
- **Adversarial API critic** — 4 findings ranked by impact, all fixed (#544, #555-558)
- **5x eval infrastructure** — `--runs`, regex + LLM auto-scoring, macOS Keychain for API keys (#544, #551)
- **Post-fix eval rerun** confirmed Claude at 100%, DeepSeek improved (#562)

### PRs included

| PR | Description |
|----|-------------|
| #549 | Add docstrings to all tests |
| #552 | Trim server instructions and tool descriptions by 67% |
| #553 | Add CI wait step to merge-and-status command |
| #554 | Use macOS Keychain for eval runner API key |
| #559 | Blind eval 5x run with adversarial API review |
| #560 | Annotate stalled_only parameter |
| #561 | Critic findings — effective dates, tag dropped, task status |
| #563 | Rerun blind evals after critic fixes |

### Validation

- [x] Version sync: all files at 0.13.1
- [x] Client-server parity: 23/23
- [x] Complexity check: pass
- [x] Unit tests: 1022 passed, 275 skipped
- [x] Coverage: 93% (threshold 90%)
- [x] AppleScript safety: pass
- [ ] Dependency audit: 3 low-impact transitive CVEs (#565), false positive on self-package (#564)

### Known issues (not blocking)

- Dependency audit false positive on omnifocus-mcp package (#564)
- 3 transitive dependency CVEs, none affecting our code paths (#565)
- DeepSeek still FAILs #21 (inherited dates) despite fix — model reasoning limitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)