### PR TITLE
fix: resolve dependency audit false positive and ignored CVE

### DIFF
--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -23,8 +23,11 @@ else
     exit 1
 fi
 
-# Run pip-audit on installed packages
-if $PIP_AUDIT 2>&1; then
+# Run pip-audit:
+#   --skip-editable: skip omnifocus-mcp (not on PyPI, causes false positive)
+#   --ignore-vuln: suppress CVEs with no fix available (dev-only deps)
+#     CVE-2026-4539: pygments ReDoS in ADL lexer, no fix released
+if $PIP_AUDIT --skip-editable --ignore-vuln CVE-2026-4539 2>&1; then
     echo ""
     echo "✅ Dependency audit PASSED — no known vulnerabilities found."
     exit 0


### PR DESCRIPTION
## Summary

- `--skip-editable`: skips omnifocus-mcp package (not on PyPI)
- `--ignore-vuln CVE-2026-4539`: pygments ReDoS, dev-only, no fix available

Script now passes clean.

## Test plan

- [x] `./scripts/check_dependencies.sh` exits 0

closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)