### PR TITLE
docs: document review date recalculation and project tag inheritance

### DIFF
--- a/evals/agent_tool_usability/scenarios.py
+++ b/evals/agent_tool_usability/scenarios.py
@@ -1755,4 +1755,59 @@ SCENARIOS = [
         ),
         "safety_critical": False,
     },
+
+    # =========================================================================
+    # OmniFocus inheritance gotchas (#571, #572)
+    # =========================================================================
+    {
+        "id": 72,
+        "category": "Project Dates",
+        "name": "Review Date Recalculation Order",
+        "prompt": (
+            "Mark project proj-abc as reviewed today and schedule its next review "
+            "for June 15, 2026, regardless of the review interval."
+        ),
+        "expected": {
+            "tools": ["update_projects"],
+            "key_params": {
+                "update_projects": {
+                    "project_id": "proj-abc",
+                    "last_reviewed": "now",
+                    "next_review_date": "2026-06-15",
+                },
+            },
+        },
+        "scoring_notes": (
+            "PASS: Recognizes that setting last_reviewed recalculates next_review_date, "
+            "so either uses two sequential calls (last_reviewed first, then next_review_date) "
+            "or notes the ordering dependency. "
+            "PARTIAL: Sets both in one call without mentioning the recalculation risk. "
+            "FAIL: Only sets last_reviewed without next_review_date, or sets next_review_date "
+            "first (which would be overwritten)."
+        ),
+        "safety_critical": False,
+    },
+    {
+        "id": 73,
+        "category": "Documentation Gaps",
+        "name": "Project Tag Inheritance",
+        "prompt": (
+            "I created a task in my 'Work' project (which has the 'Office' tag). "
+            "The new task shows the 'Office' tag even though I didn't assign any tags "
+            "when creating it. Is this a bug? Should I remove the tag?"
+        ),
+        "expected": {
+            "tools": [],
+            "key_params": {},
+        },
+        "scoring_notes": (
+            "PASS: Explains that tasks inherit tags from their parent project — this is "
+            "expected OmniFocus behavior, not a bug. Advises NOT removing the tag (or warns "
+            "that removing it would desync from the project's intended tagging). "
+            "PARTIAL: Says it's not a bug but doesn't explain inheritance, or doesn't warn "
+            "against removing it. "
+            "FAIL: Says it's a bug, suggests removing the tag, or doesn't know why it appeared."
+        ),
+        "safety_critical": False,
+    },
 ]

--- a/evals/agent_tool_usability/tool_descriptions.md
+++ b/evals/agent_tool_usability/tool_descriptions.md
@@ -70,7 +70,8 @@ Update one or more projects. Each item has `id` (required) plus fields to change
 - `project_type: str`; `sequential: bool` (deprecated)
 - `status: str` — "active", "on_hold", "done", "dropped"
 - `review_interval_value: int` + `review_interval_unit: str` ("day"/"week"/"month"/"year"); `review_interval_weeks: int` (deprecated)
-- `last_reviewed: str` — ISO or "now"; `next_review_date: str`
+- `last_reviewed: str` — ISO or "now" (recalculates next_review_date from review interval)
+- `next_review_date: str` — set AFTER last_reviewed to override the calculated date
 - `completed_by_children: bool`
 - `due_date, defer_date, planned_date: str` — ISO or "" to clear
 - `flagged: bool`
@@ -111,6 +112,7 @@ Key fields:
 - `repetitionMethod` — "fixed" (original schedule), "start_after_completion" (defer shifts), "due_after_completion" (due shifts)
 - `catchUpAutomatically` — recurring only; true = one catch-up occurrence, false = each missed interval spawns its own
 - Date fields are effective (include inherited from project). Next-occurrence fields populated only for recurring tasks.
+- Tasks inherit tags from their parent project. A task showing a tag it wasn't explicitly assigned has inherited it — this is expected, not a bug.
 
 ### create_tasks
 

--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -468,7 +468,8 @@ def update_projects(projects: list[ProjectUpdate]) -> str:
     - project_type: str; sequential: bool (deprecated)
     - status: str -- "active", "on_hold", "done", "dropped"
     - review_interval_value: int + review_interval_unit: str ("day"/"week"/"month"/"year"); review_interval_weeks: int (deprecated)
-    - last_reviewed: str -- ISO or "now"; next_review_date: str
+    - last_reviewed: str -- ISO or "now" (recalculates next_review_date from review interval)
+    - next_review_date: str -- set AFTER last_reviewed to override the calculated date
     - completed_by_children: bool
     - due_date, defer_date, planned_date: str -- ISO or "" to clear
     - flagged: bool
@@ -587,6 +588,7 @@ def get_tasks(
     - repetitionMethod -- "fixed" (original schedule), "start_after_completion" (defer shifts), "due_after_completion" (due shifts)
     - catchUpAutomatically -- recurring only; true = one catch-up occurrence, false = each missed interval spawns its own
     - Date fields are effective (include inherited from project). Next-occurrence fields populated only for recurring tasks.
+    - Tasks inherit tags from their parent project. A task showing a tag it wasn't explicitly assigned has inherited it -- this is expected, not a bug.
     """
     # Expand planned_on to planned_after + planned_before
     if planned_on is not None:


### PR DESCRIPTION
## Summary

Two OmniFocus inheritance gotchas found during Claude Desktop usage:

1. **#571**: Setting `last_reviewed` recalculates `next_review_date` from the review interval. Custom review dates must be set AFTER `last_reviewed`.
2. **#572**: Tasks inherit tags from their parent project — expected behavior, not a bug.

Both documented in server instructions and tool descriptions, with blind eval scenarios #72 and #73.

## Test plan

- [x] Python syntax valid
- [x] Unit tests pass (1022 passed)
- [x] 73 scenarios, no duplicate IDs

closes #571, closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)