### PR TITLE
security: add missing operations to DESTRUCTIVE_OPERATIONS set

### DIFF
--- a/scripts/check_applescript_safety.sh
+++ b/scripts/check_applescript_safety.sh
@@ -57,6 +57,27 @@ else
 fi
 echo ""
 
+# --- Check 2b: Reverse check — every _verify_database_safety call must use a registered operation ---
+echo "--- Check 2b: Reverse safety coverage (calls → set) ---"
+
+CALLED_OPS=$(grep -oE "_verify_database_safety\('[a-z_]+'\)" "$CONNECTOR" | \
+    grep -oE "'[a-z_]+'" | tr -d "'" | sort -u)
+
+MISSING_REGISTRATION=0
+for op in $CALLED_OPS; do
+    if ! echo "$DESTRUCTIVE_OPS" | grep -qw "$op"; then
+        echo "ERROR: _verify_database_safety('$op') called but '$op' not in DESTRUCTIVE_OPERATIONS set"
+        MISSING_REGISTRATION=$((MISSING_REGISTRATION + 1))
+    fi
+done
+
+if [ "$MISSING_REGISTRATION" -eq 0 ]; then
+    echo "OK: All safety calls use registered operations."
+else
+    ERRORS=$((ERRORS + MISSING_REGISTRATION))
+fi
+echo ""
+
 # --- Check 3: Unescaped string interpolation ---
 # Look for f-string interpolations of common user-input parameters
 # that don't use an _escaped suffix variable.

--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -104,8 +104,10 @@ class OmniFocusConnector:
     DESTRUCTIVE_OPERATIONS = {
         'create_task', 'update_task', 'update_tasks',
         'create_project', 'update_project', 'update_projects',
-        'create_folder', 'create_tag', 'update_tag', 'delete_tasks',
-        'delete_projects', 'delete_tags', 'reorder_task',
+        'create_folder', 'update_folder',
+        'create_tag', 'update_tag',
+        'delete_tasks', 'delete_projects', 'delete_tags',
+        'reorder_task', 'reorder_project',
     }
 
     def __init__(self, enable_safety_checks: bool = True):

--- a/tests/test_safety_guards.py
+++ b/tests/test_safety_guards.py
@@ -148,3 +148,26 @@ class TestSafetyGuardsDisabled:
 
             # All operations work without safety checks - no DatabaseSafetyError raised
             # Test passed - safety checks are disabled, operations succeed
+
+
+class TestDestructiveOperationsCompleteness:
+    """Verify DESTRUCTIVE_OPERATIONS set matches actual _verify_database_safety calls."""
+
+    def test_all_safety_calls_use_registered_operations(self):
+        """Every _verify_database_safety call must use an operation in DESTRUCTIVE_OPERATIONS."""
+        import re
+        from pathlib import Path
+
+        connector_path = Path(__file__).parent.parent / "src" / "omnifocus_mcp" / "omnifocus_connector.py"
+        source = connector_path.read_text()
+
+        # Extract operation names from _verify_database_safety calls
+        called_ops = set(re.findall(r"_verify_database_safety\(['\"](\w+)['\"]\)", source))
+
+        registered_ops = OmniFocusConnector.DESTRUCTIVE_OPERATIONS
+
+        missing = called_ops - registered_ops
+        assert not missing, (
+            f"Operations call _verify_database_safety but are not in DESTRUCTIVE_OPERATIONS: {missing}. "
+            f"Add them to the set or the safety check silently passes (early return at line 153)."
+        )


### PR DESCRIPTION
## Summary

`update_folder` and `reorder_project` called `_verify_database_safety()` but weren't in `DESTRUCTIVE_OPERATIONS`, so the safety check was a no-op.

- Added both to the set
- Meta-test: verifies every safety call uses a registered operation (prevents future drift)
- Audit script: added reverse check (Check 2b: calls → set)

## Test plan

- [x] Meta-test fails before fix, passes after
- [x] Full suite: 1024 passed, 275 skipped
- [x] `check_applescript_safety.sh`: 15 operations, both directions pass

closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)