### PR TITLE
docs: fix README accuracy and add claims validation script

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 An MCP server bridging Claude and OmniFocus via AppleScript on macOS.
 
 **Stack:** Python 3.10+, FastMCP, AppleScript (via `osascript`)
-**Version:** v0.13.1 | **Tests:** 1022 unit, 227 integration/E2E, 47 benchmark/profiling | **Coverage:** 93%
+**Version:** v0.13.1 | **Tests:** 1024 unit, 192 integration/E2E, 47 benchmark/profiling | **Coverage:** 93%
 
 ## Commands
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ complexity:
 audit:
 	@./scripts/check_dependencies.sh
 	@./scripts/check_applescript_safety.sh
+	@./scripts/check_readme_claims.sh
 
 clean:
 	rm -rf __pycache__ .pytest_cache .coverage htmlcov/

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Full profiling data: [PERFORMANCE_PROFILING.md](docs/reference/PERFORMANCE_PROFI
 
 ### Reliable
 
-93% code coverage from 1023 unit tests. 227 integration and E2E tests run against real OmniFocus covering task, project, and tag lifecycles, filtering, hierarchy, dates, recurrence, and review workflows.
+93% code coverage from 1024 unit tests. 192 integration and E2E tests run against real OmniFocus covering task, project, and tag lifecycles, filtering, hierarchy, dates, recurrence, and review workflows.
 
 ### Agent-Friendly
 
-71-scenario blind eval suite with frontier models scoring 100% and popular open-weight models averaging over 90% ([full results](evals/agent_tool_usability/results/scored_results.md)). Agents that have never seen OmniFocus can correctly use every tool from descriptions alone. Scenarios cover tool selection, parameter usage, multi-step workflows, date semantics, recurrence, tag behavior, task movement, text search, and safety-critical operations (drop vs delete, destructive action guardrails). Server instructions teach GTD concepts (task states, project types, sequential dependencies, review cycles) so agents make informed decisions, not just API calls.
+73-scenario blind eval suite with frontier models scoring 100% and popular open-weight models scoring 90-94% ([full results](evals/agent_tool_usability/results/scored_results.md)). Agents that have never seen OmniFocus can correctly use every tool from descriptions alone. Scenarios cover tool selection, parameter usage, multi-step workflows, date semantics, recurrence, tag behavior, task movement, text search, and safety-critical operations (drop vs delete, destructive action guardrails). Server instructions teach GTD concepts (task states, project types, sequential dependencies, review cycles) so agents make informed decisions, not just API calls.
 
-## Tools (23)
+## Tools (21)
 
 ### Projects (6)
 - **get_projects** — filter by ID, query, status; includes dates, review info, task health, stalled detection

--- a/scripts/check_readme_claims.sh
+++ b/scripts/check_readme_claims.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Verify README and CLAUDE.md claims against live data.
+# Catches stale test counts, tool counts, and coverage stats.
+#
+# Usage: ./scripts/check_readme_claims.sh
+
+set -euo pipefail
+
+ERRORS=0
+README="README.md"
+CLAUDE_MD=".claude/CLAUDE.md"
+SERVER="src/omnifocus_mcp/server_fastmcp.py"
+
+echo "Checking README and CLAUDE.md claims..."
+echo ""
+
+# --- Check 1: Tool count ---
+echo "--- Check 1: MCP tool count ---"
+ACTUAL_TOOLS=$(grep -c "@mcp.tool()" "$SERVER")
+README_TOOLS=$(grep -oE 'Tools \([0-9]+\)' "$README" | grep -oE '[0-9]+')
+
+if [ "$ACTUAL_TOOLS" != "$README_TOOLS" ]; then
+    echo "ERROR: README says Tools ($README_TOOLS) but server has $ACTUAL_TOOLS @mcp.tool() decorators"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: Tool count matches ($ACTUAL_TOOLS)"
+fi
+echo ""
+
+# --- Check 2: Unit test count ---
+echo "--- Check 2: Unit test count ---"
+ACTUAL_UNIT=$(uv run pytest tests/ -q 2>/dev/null | tail -1 | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+')
+README_UNIT=$(grep -oE '[0-9]+ unit tests' "$README" | grep -oE '[0-9]+')
+
+if [ "$ACTUAL_UNIT" != "$README_UNIT" ]; then
+    echo "ERROR: README says $README_UNIT unit tests but pytest collects $ACTUAL_UNIT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: Unit test count matches ($ACTUAL_UNIT)"
+fi
+echo ""
+
+# --- Check 3: Coverage badge ---
+echo "--- Check 3: Coverage badge ---"
+BADGE_PCT=$(grep -oE 'coverage-[0-9]+' "$README" | sed 's/coverage-//' || true)
+CLAUDE_PCT=$(grep -oE 'Coverage:.* [0-9]+%' "$CLAUDE_MD" | grep -oE '[0-9]+%' | sed 's/%//' || true)
+
+if [ -n "$BADGE_PCT" ] && [ -n "$CLAUDE_PCT" ]; then
+    if [ "$BADGE_PCT" != "$CLAUDE_PCT" ]; then
+        echo "ERROR: README badge says ${BADGE_PCT}% but CLAUDE.md says ${CLAUDE_PCT}%"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "OK: Coverage claims consistent (${BADGE_PCT}%)"
+    fi
+else
+    echo "WARNING: Could not extract coverage from README or CLAUDE.md"
+fi
+echo ""
+
+# --- Check 4: CLAUDE.md unit test count ---
+echo "--- Check 4: CLAUDE.md test counts ---"
+CLAUDE_UNIT=$(grep -oE '[0-9]+ unit' "$CLAUDE_MD" | head -1 | grep -oE '[0-9]+')
+
+if [ -n "$CLAUDE_UNIT" ] && [ "$ACTUAL_UNIT" != "$CLAUDE_UNIT" ]; then
+    echo "ERROR: CLAUDE.md says $CLAUDE_UNIT unit but pytest collects $ACTUAL_UNIT"
+    ERRORS=$((ERRORS + 1))
+else
+    echo "OK: CLAUDE.md unit test count matches ($CLAUDE_UNIT)"
+fi
+echo ""
+
+# --- Summary ---
+if [ "$ERRORS" -eq 0 ]; then
+    echo "✅ All README/CLAUDE.md claims verified!"
+    exit 0
+else
+    echo "❌ $ERRORS claim(s) out of date. Update README.md and/or .claude/CLAUDE.md."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Fix stale README claims: test counts, tool count (23→21), agent scores, scenario count
- Add `scripts/check_readme_claims.sh` that verifies claims against live data
- Added to `make audit` target

## Test plan

- [x] `./scripts/check_readme_claims.sh` passes all 4 checks
- [x] Manual review of README changes

closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)