### PR TITLE
fix: add effectivelyCompleted/effectivelyDropped to _format_task output

### DIFF
--- a/src/omnifocus_mcp/server_fastmcp.py
+++ b/src/omnifocus_mcp/server_fastmcp.py
@@ -85,6 +85,10 @@ def _format_task(task: dict, truncate_notes: bool = True) -> str:
             result += f"Blocked: Yes\n"
     if task.get('available') is not None:
         result += f"Available: {task['available']}\n"
+    if task.get('effectivelyCompleted'):
+        result += f"Effectively Completed: Yes (parent project/action group is completed)\n"
+    if task.get('effectivelyDropped'):
+        result += f"Effectively Dropped: Yes (parent project/action group is dropped)\n"
     if task.get('next'):
         result += f"Next: Yes\n"
     if task.get('flagged'):

--- a/tests/test_server_formatting.py
+++ b/tests/test_server_formatting.py
@@ -219,6 +219,58 @@ class TestTaskFormatting:
         result = _format_task(task)
         assert "Completed By Children" not in result
 
+    def test_format_task_displays_effectively_completed(self):
+        """Test that _format_task shows Effectively Completed when true."""
+        task = {
+            "id": "task-eff-comp",
+            "name": "Task in Completed Project",
+            "projectName": "Done Project",
+            "completed": False,
+            "effectivelyCompleted": True,
+        }
+
+        result = _format_task(task)
+        assert "Effectively Completed: Yes" in result
+
+    def test_format_task_omits_effectively_completed_when_false(self):
+        """Test that _format_task omits Effectively Completed when false."""
+        task = {
+            "id": "task-active",
+            "name": "Active Task",
+            "projectName": "Active Project",
+            "completed": False,
+            "effectivelyCompleted": False,
+        }
+
+        result = _format_task(task)
+        assert "Effectively Completed" not in result
+
+    def test_format_task_displays_effectively_dropped(self):
+        """Test that _format_task shows Effectively Dropped when true."""
+        task = {
+            "id": "task-eff-drop",
+            "name": "Task in Dropped Project",
+            "projectName": "Dropped Project",
+            "completed": False,
+            "effectivelyDropped": True,
+        }
+
+        result = _format_task(task)
+        assert "Effectively Dropped: Yes" in result
+
+    def test_format_task_omits_effectively_dropped_when_false(self):
+        """Test that _format_task omits Effectively Dropped when false."""
+        task = {
+            "id": "task-active",
+            "name": "Active Task",
+            "projectName": "Active Project",
+            "completed": False,
+            "effectivelyDropped": False,
+        }
+
+        result = _format_task(task)
+        assert "Effectively Dropped" not in result
+
 
 class TestProjectFormatting:
     """Test project formatting function."""


### PR DESCRIPTION
## Summary

- Add `effectivelyCompleted` and `effectivelyDropped` to `_format_task()` output so agents actually see the fields added in #592
- Only displayed when `True` to avoid cluttering output on every task
- 4 new formatter tests (displays when true, omits when false, for each field)

closes #595

## Test plan

- [x] 4 new unit tests for formatter output
- [x] Full suite: 1065 passed, 122 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)