### PR TITLE
fix: auto-retry transient AppleScript errors on read operations

### DIFF
--- a/src/omnifocus_mcp/omnifocus_connector.py
+++ b/src/omnifocus_mcp/omnifocus_connector.py
@@ -1,9 +1,15 @@
 """Client for interacting with OmniFocus app."""
 import subprocess
 import json
+import logging
 import os
+import re
+import time
 from enum import Enum
 from typing import Any, Optional, Union
+
+
+logger = logging.getLogger(__name__)
 
 
 class TaskStatus(Enum):
@@ -45,6 +51,71 @@ def run_applescript(script: str, timeout: int = 60) -> str:
         timeout=timeout
     )
     return result.stdout.strip()
+
+
+# Apple Event Manager error codes that indicate a transient connection failure,
+# typically caused by OmniFocus crashing and auto-restarting.
+#   -609 connectionInvalid:  target app crashed or connection handle is stale
+#   -600 procNotFound:       target app is not running (e.g., mid-restart)
+#   -1712 errAETimeout:      Apple Event timed out
+_TRANSIENT_APPLESCRIPT_ERROR_CODES = frozenset({-609, -600, -1712})
+_APPLESCRIPT_ERROR_CODE_RE = re.compile(r'\((-?\d+)\)')
+
+
+def _is_transient_applescript_error(stderr: str) -> bool:
+    """True if osascript stderr contains a transient connection/timeout error code."""
+    if not stderr:
+        return False
+    for match in _APPLESCRIPT_ERROR_CODE_RE.finditer(stderr):
+        if int(match.group(1)) in _TRANSIENT_APPLESCRIPT_ERROR_CODES:
+            return True
+    return False
+
+
+def run_applescript_read(
+    script: str,
+    timeout: int = 60,
+    max_retries: int = 1,
+    retry_delay: float = 3.0,
+) -> str:
+    """Execute AppleScript with auto-retry on transient connection errors.
+
+    Wraps run_applescript() with a single retry for transient errors (e.g.,
+    -609 "Connection is invalid" when OmniFocus crashes and auto-restarts).
+    USE ONLY for read-only operations: a write that crashed mid-call may have
+    already been applied, and retrying could create duplicates.
+    """
+    last_exc = None
+    for attempt in range(max_retries + 1):
+        try:
+            return run_applescript(script, timeout=timeout)
+        except subprocess.CalledProcessError as e:
+            if not _is_transient_applescript_error(e.stderr):
+                raise
+            last_exc = e
+            if attempt < max_retries:
+                logger.warning(
+                    "OmniFocus transient AppleScript error (attempt %d/%d); "
+                    "retrying in %.1fs. stderr: %s",
+                    attempt + 1, max_retries + 1, retry_delay,
+                    (e.stderr or '').strip(),
+                )
+                time.sleep(retry_delay)
+            else:
+                logger.error(
+                    "OmniFocus transient AppleScript error after %d attempts; "
+                    "giving up. stderr: %s",
+                    max_retries + 1, (e.stderr or '').strip(),
+                )
+    hinted = (
+        "OmniFocus connection invalid or unavailable after retry. "
+        "OmniFocus may have crashed; if it auto-recovers, the call will "
+        f"succeed on the next attempt. Original error: {last_exc.stderr}"
+    )
+    raise subprocess.CalledProcessError(
+        last_exc.returncode, last_exc.cmd,
+        output=last_exc.output, stderr=hinted,
+    )
 
 
 # AppleScript helper functions for JSON escaping
@@ -1318,7 +1389,7 @@ class OmniFocusConnector:
         )
 
         try:
-            result = run_applescript(script, timeout=timeout)
+            result = run_applescript_read(script, timeout=timeout)
             if result:
                 projects = json.loads(result)
 
@@ -3475,7 +3546,7 @@ class OmniFocusConnector:
         )
 
         try:
-            result = run_applescript(script, timeout=timeout)
+            result = run_applescript_read(script, timeout=timeout)
             if result:
                 tasks = json.loads(result)
 
@@ -4405,7 +4476,7 @@ class OmniFocusConnector:
         ''' + APPLESCRIPT_JSON_HELPERS
 
         try:
-            result = run_applescript(script)
+            result = run_applescript_read(script)
             if result:
                 tags = json.loads(result)
             else:
@@ -4963,7 +5034,7 @@ class OmniFocusConnector:
         '''
 
         try:
-            result = run_applescript(script)
+            result = run_applescript_read(script)
             folders = json.loads(result)
             for folder in folders:
                 folder["status"] = "dropped" if folder.get("hidden") else "active"
@@ -5330,7 +5401,7 @@ class OmniFocusConnector:
         '''
 
         try:
-            result = run_applescript(script)
+            result = run_applescript_read(script)
             return json.loads(result)
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error retrieving perspectives: {e.stderr}")
@@ -5550,7 +5621,7 @@ class OmniFocusConnector:
         '''
 
         try:
-            result = run_applescript(script)
+            result = run_applescript_read(script)
             return json.loads(result)
         except subprocess.CalledProcessError as e:
             raise Exception(f"Error getting focus: {e.stderr}")

--- a/tests/test_omnifocus_client.py
+++ b/tests/test_omnifocus_client.py
@@ -2817,3 +2817,156 @@ class TestGetProjectsCompletedFilter:
             client.get_projects(completed_only=True)
             script = mock_run.call_args[0][0]
             assert 'projStatus is not "done status"' in script
+
+
+class TestTransientAppleScriptErrorDetection:
+    """Tests for _is_transient_applescript_error helper."""
+
+    def test_recognizes_609_connection_invalid(self):
+        """The exact stderr from the bug report should be recognized as transient."""
+        from omnifocus_mcp.omnifocus_connector import _is_transient_applescript_error
+        stderr = "375:377: execution error: OmniFocus got an error: Connection is invalid. (-609)"
+        assert _is_transient_applescript_error(stderr) is True
+
+    def test_recognizes_600_proc_not_found(self):
+        """OmniFocus not running mid-restart (-600) is transient."""
+        from omnifocus_mcp.omnifocus_connector import _is_transient_applescript_error
+        stderr = "execution error: Application isn't running. (-600)"
+        assert _is_transient_applescript_error(stderr) is True
+
+    def test_recognizes_1712_apple_event_timeout(self):
+        """Apple Event timeout (-1712) is transient."""
+        from omnifocus_mcp.omnifocus_connector import _is_transient_applescript_error
+        stderr = "execution error: AppleEvent timed out. (-1712)"
+        assert _is_transient_applescript_error(stderr) is True
+
+    def test_ignores_unrelated_error_code(self):
+        """Non-transient error codes (e.g., -10000) must not be retried."""
+        from omnifocus_mcp.omnifocus_connector import _is_transient_applescript_error
+        stderr = "execution error: Some permanent failure. (-10000)"
+        assert _is_transient_applescript_error(stderr) is False
+
+    def test_ignores_empty_stderr(self):
+        """Empty or None stderr returns False (no error info to act on)."""
+        from omnifocus_mcp.omnifocus_connector import _is_transient_applescript_error
+        assert _is_transient_applescript_error("") is False
+        assert _is_transient_applescript_error(None) is False
+
+
+class TestRunAppleScriptRead:
+    """Tests for run_applescript_read — the retry wrapper for read-only ops."""
+
+    def test_retries_once_on_609_and_succeeds(self):
+        """First call raises -609, second succeeds — wrapper returns second result."""
+        from omnifocus_mcp.omnifocus_connector import run_applescript_read
+        transient_err = subprocess.CalledProcessError(
+            1, 'osascript',
+            stderr="execution error: OmniFocus got an error: Connection is invalid. (-609)",
+        )
+        with mock.patch('subprocess.run') as mock_run, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.time.sleep') as mock_sleep:
+            mock_run.side_effect = [transient_err, mock.Mock(stdout="recovered\n")]
+            result = run_applescript_read("tell application \"OmniFocus\" to return name")
+            assert result == "recovered"
+            assert mock_run.call_count == 2
+            mock_sleep.assert_called_once()
+
+    def test_no_retry_on_non_transient_error(self):
+        """Non-transient errors (e.g., -1728 object not found) propagate immediately."""
+        from omnifocus_mcp.omnifocus_connector import run_applescript_read
+        permanent_err = subprocess.CalledProcessError(
+            1, 'osascript',
+            stderr="execution error: Can't get object. (-1728)",
+        )
+        with mock.patch('subprocess.run') as mock_run, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.time.sleep') as mock_sleep:
+            mock_run.side_effect = permanent_err
+            with pytest.raises(subprocess.CalledProcessError) as exc_info:
+                run_applescript_read("some script")
+            assert "(-1728)" in exc_info.value.stderr
+            assert mock_run.call_count == 1
+            mock_sleep.assert_not_called()
+
+    def test_exhausted_retries_raise_with_recovery_hint(self):
+        """When all retries fail, raise with a helpful hint and original error preserved."""
+        from omnifocus_mcp.omnifocus_connector import run_applescript_read
+        transient_err = subprocess.CalledProcessError(
+            1, 'osascript',
+            stderr="execution error: Connection is invalid. (-609)",
+        )
+        with mock.patch('subprocess.run') as mock_run, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.time.sleep'):
+            mock_run.side_effect = [transient_err, transient_err]
+            with pytest.raises(subprocess.CalledProcessError) as exc_info:
+                run_applescript_read("some script")
+            assert "may have crashed" in exc_info.value.stderr
+            assert "(-609)" in exc_info.value.stderr  # original preserved
+            assert mock_run.call_count == 2
+
+    def test_timeout_propagates_without_retry(self):
+        """subprocess.TimeoutExpired is not a CalledProcessError — must NOT be retried."""
+        from omnifocus_mcp.omnifocus_connector import run_applescript_read
+        with mock.patch('subprocess.run') as mock_run, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.time.sleep') as mock_sleep:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd='osascript', timeout=60)
+            with pytest.raises(subprocess.TimeoutExpired):
+                run_applescript_read("some script")
+            assert mock_run.call_count == 1
+            mock_sleep.assert_not_called()
+
+
+class TestReadMethodsUseRetryWrapper:
+    """Verify each public read method routes through run_applescript_read (not run_applescript)."""
+
+    @pytest.fixture
+    def client(self):
+        return OmniFocusConnector(enable_safety_checks=False)
+
+    def test_get_tasks_uses_run_applescript_read(self, client):
+        """get_tasks must call run_applescript_read so transient errors auto-retry."""
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript_read') as mock_read, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_plain:
+            mock_read.return_value = "[]"
+            mock_plain.return_value = "[]"
+            client.get_tasks()
+            assert mock_read.called, "get_tasks must use run_applescript_read for auto-retry on -609"
+
+    def test_get_projects_uses_run_applescript_read(self, client):
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript_read') as mock_read, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_plain:
+            mock_read.return_value = "[]"
+            mock_plain.return_value = "[]"
+            client.get_projects()
+            assert mock_read.called, "get_projects must use run_applescript_read"
+
+    def test_get_tags_uses_run_applescript_read(self, client):
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript_read') as mock_read, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_plain:
+            mock_read.return_value = "[]"
+            mock_plain.return_value = "[]"
+            client.get_tags()
+            assert mock_read.called, "get_tags must use run_applescript_read"
+
+    def test_get_folders_uses_run_applescript_read(self, client):
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript_read') as mock_read, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_plain:
+            mock_read.return_value = "[]"
+            mock_plain.return_value = "[]"
+            client.get_folders()
+            assert mock_read.called, "get_folders must use run_applescript_read"
+
+    def test_get_perspectives_uses_run_applescript_read(self, client):
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript_read') as mock_read, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_plain:
+            mock_read.return_value = "[]"
+            mock_plain.return_value = "[]"
+            client.get_perspectives()
+            assert mock_read.called, "get_perspectives must use run_applescript_read"
+
+    def test_get_focus_uses_run_applescript_read(self, client):
+        with mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript_read') as mock_read, \
+             mock.patch('omnifocus_mcp.omnifocus_connector.run_applescript') as mock_plain:
+            mock_read.return_value = "[]"
+            mock_plain.return_value = "[]"
+            client.get_focus()
+            assert mock_read.called, "get_focus must use run_applescript_read"


### PR DESCRIPTION
## Summary

- Adds `run_applescript_read()` wrapper that detects transient Apple Event errors (`-609` connection invalid, `-600` proc not found, `-1712` AE timeout) and retries once after a 3s delay — the typical OmniFocus crash/restart window
- Wires the 6 public read methods (`get_tasks`, `get_projects`, `get_tags`, `get_folders`, `get_perspectives`, `get_focus`) to use the new wrapper
- Writes are intentionally NOT retried: a write that crashed mid-call may have already been applied, so retry could create duplicates
- Introduces a module-level logger; warnings on retry attempts go to stderr (visible in MCP client logs) so `-609` frequency can be tracked over time

Closes #597

## Test plan

- [x] Unit tests: 15 new tests covering transient-error detection, retry behavior, no-retry on permanent errors, retry exhaustion with hint, timeout passthrough, and wiring for all 6 read methods (`make test` → 1080 passed)
- [x] Integration tests: full happy-path suite on test DB (`make test-integration` → 155 passed) — verifies the wrapper doesn't break normal flow
- [x] Client/server parity check (`./scripts/check_client_server_parity.sh`)
- [x] AppleScript safety audit (`./scripts/check_applescript_safety.sh`)
- [ ] Real-world: confirm the next time -609 happens that retry kicks in transparently and the warning lands in `~/Library/Logs/Claude/mcp-server-omnifocus.log`

## Out of scope

- Auto-retry for write operations (would need an idempotency-key model)
- Pinging OmniFocus before retry (the 3s sleep covers the typical restart window)
- Configurable retry count/delay via env vars (defaults conservative; can revisit if patterns emerge)